### PR TITLE
fix(core): DwFeature.scanMounted skips subtrees that are mounted 

### DIFF
--- a/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
+++ b/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
@@ -31,14 +31,24 @@ class DwFeatureSpec {
 abstract interface class DwFeature {
   DwFeatureSpec get dwFeature;
 
-  /// The [DwFeatureSpec]s of every mounted [DwFeature] widget, keyed by id (a
-  /// feature declared by several instances appears once).
+  /// The [DwFeatureSpec]s of every [DwFeature] widget currently *on screen*,
+  /// keyed by id (a feature declared by several instances appears once).
   ///
-  /// Scans from the app root — not a [BuildContext] — on purpose: only the
-  /// active route's subtree is mounted, so this is the whole current screen's
-  /// feature set, which is exactly what an error report or a Studio passport
-  /// wants. Call from a post-frame callback after the route settles; a widget
-  /// mounted asynchronously afterwards is picked up by the next scan.
+  /// Scans from the app root — not a [BuildContext] — on purpose: this is the
+  /// whole current screen's feature set, which is exactly what an error report
+  /// or a Studio passport wants. Call from a post-frame callback after the
+  /// route settles; a widget mounted asynchronously afterwards is picked up by
+  /// the next scan.
+  ///
+  /// Being mounted is not the same as being on screen, and the difference is
+  /// not an edge case: an inactive bottom-nav tab kept alive behind an
+  /// `IndexedStack`, or the route sitting under a pushed opaque one, stays in
+  /// the element tree. Counting those would report roughly the whole app on
+  /// every screen. So the walk stops at the three widgets Flutter itself uses
+  /// to park a subtree out of sight: an offstage [Offstage], an invisible
+  /// [Visibility] (what `IndexedStack` wraps its unselected children in) and a
+  /// disabled [TickerMode] (what `Overlay` wraps the routes below an opaque
+  /// one in).
   static List<DwFeatureSpec> scanMounted() {
     final root = WidgetsBinding.instance.rootElement;
     if (root == null) return const [];
@@ -46,6 +56,9 @@ abstract interface class DwFeature {
     final found = <String, DwFeatureSpec>{};
     void visit(Element element) {
       final widget = element.widget;
+      if (widget is Offstage && widget.offstage) return;
+      if (widget is Visibility && !widget.visible) return;
+      if (widget is TickerMode && !widget.enabled) return;
       if (widget is DwFeature) {
         final feature = (widget as DwFeature).dwFeature;
         found[feature.id] = feature;

--- a/packages/dartway_flutter/test/dw_feature_test.dart
+++ b/packages/dartway_flutter/test/dw_feature_test.dart
@@ -40,4 +40,55 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
     expect(DwFeature.scanMounted(), isEmpty);
   });
+
+  // Mounted is not the same as on screen. An app that keeps a bottom-nav tab
+  // alive behind an IndexedStack, or a route under a pushed one, leaves those
+  // subtrees mounted — and reporting them would claim every screen hosts the
+  // whole app.
+  testWidgets('DwFeature.scanMounted skips unselected IndexedStack children',
+      (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: IndexedStack(
+          index: 1,
+          children: [
+            _FeatureBox(_spec('behind')),
+            _FeatureBox(_spec('shown')),
+          ],
+        ),
+      ),
+    );
+
+    expect(DwFeature.scanMounted().map((f) => f.id), ['shown']);
+  });
+
+  testWidgets('DwFeature.scanMounted skips an offstage subtree',
+      (tester) async {
+    await tester.pumpWidget(
+      Column(
+        children: [
+          Offstage(child: _FeatureBox(_spec('parked'))),
+          _FeatureBox(_spec('shown')),
+        ],
+      ),
+    );
+
+    expect(DwFeature.scanMounted().map((f) => f.id), ['shown']);
+  });
+
+  testWidgets('DwFeature.scanMounted skips a disabled TickerMode subtree',
+      (tester) async {
+    await tester.pumpWidget(
+      Column(
+        children: [
+          // What Overlay wraps the routes below an opaque one in.
+          TickerMode(enabled: false, child: _FeatureBox(_spec('under-route'))),
+          TickerMode(enabled: true, child: _FeatureBox(_spec('shown'))),
+        ],
+      ),
+    );
+
+    expect(DwFeature.scanMounted().map((f) => f.id), ['shown']);
+  });
 }

--- a/template/dartway_starter_flutter/lib/studio/studio_bridge_binding.dart
+++ b/template/dartway_starter_flutter/lib/studio/studio_bridge_binding.dart
@@ -83,14 +83,24 @@ class _StudioBridgeBindingState extends ConsumerState<StudioBridgeBinding>
     // may mount the new screen a frame or two later (and its content can load
     // asynchronously), so re-scan over a short window until it settles.
     void reportFeaturesSoon() {
-      for (final delay in const [
+      const rescanDelays = [
         Duration(milliseconds: 50),
         Duration(milliseconds: 400),
         Duration(milliseconds: 1000),
-      ]) {
+      ];
+      for (final (index, delay) in rescanDelays.indexed) {
+        final isLastRescan = index == rescanDelays.length - 1;
         Future<void>.delayed(delay, () {
           if (!mounted) return;
-          _host?.reportFeatures(currentPath(), _mountedFeatureInfos());
+          final features = _mountedFeatureInfos();
+          // An early re-scan often lands between screens — the old one already
+          // parked under the new one, the new one not mounted yet — and finds
+          // nothing. That is "the screen is not ready", not "the screen has no
+          // features", and reporting it would flash an empty passport in
+          // Studio, which takes these reports at face value. Only the last
+          // re-scan is allowed to report emptiness, where it is real.
+          if (features.isEmpty && !isLastRescan) return;
+          _host?.reportFeatures(currentPath(), features);
         });
       }
     }


### PR DESCRIPTION
but not on screen