### PR TITLE
feat: feature can be found by tapping its point on screen

### DIFF
--- a/docs/6-studio/studio-bridge.md
+++ b/docs/6-studio/studio-bridge.md
@@ -11,9 +11,10 @@ The open `dartway_studio_bridge` package is the only integration surface:
   language your team works in) in your app's code. Screens are identified by
   route path strings, so any router works.
 - **Runtime protocol** — a versioned `postMessage` protocol between Studio and
-  the app's web build running in an iframe: Studio navigates the live app and
-  switches its UI locale (when the manifest declares `supportedLocales`), the
-  app reports route, session and locale changes.
+  the app's web build running in an iframe: Studio navigates the live app,
+  switches its UI locale (when the manifest declares `supportedLocales`) and
+  asks what is declared at a point on screen; the app reports route, session
+  and locale changes.
 - **Demo personas are configured in Studio, not in the app.** Test users and
   their verification codes live in the platform's project config; on switch
   Studio sends them over the bridge and the app runs its **regular** auth flow
@@ -44,6 +45,15 @@ The open `dartway_studio_bridge` package is the only integration surface:
   but a running app cannot fill it: Dart has no reflection, so only mounted
   widgets are observable. Enumerating every feature of a project is a job for
   static analysis of the sources, not for the app.
+
+- **Tap to inspect.** Studio can point at a spot in the live preview and get
+  the feature declared there (`DwFeature.hitTest` on the app side), so a
+  passport is reachable by pointing rather than by knowing the feature's id.
+  The point crosses the bridge as fractions of the app's viewport, not pixels —
+  Studio may be showing the preview scaled or framed, and only the app knows
+  its own logical size, so the app converts. A feature is matched on the area
+  it actually paints into: something scaled down, scrolled out of its viewport
+  or clipped away does not answer for a point where the user sees nothing.
 
 See the package [README](../packages/dartway_studio_bridge/README.md) for the
 full API, and `example/dartway_example_flutter/lib/studio/` for the reference

--- a/example/dartway_example_flutter/lib/studio/studio_bridge_binding.dart
+++ b/example/dartway_example_flutter/lib/studio/studio_bridge_binding.dart
@@ -12,18 +12,38 @@ import 'logic/studio_session_state_provider.dart';
 /// The project wiring point between the app's semantic layer and the bridge:
 /// features are discovered from mounted [DwFeature] widgets and mapped onto
 /// the bridge wire model.
+StudioFeatureInfo _toWireModel(DwFeatureSpec feature) => StudioFeatureInfo(
+  id: feature.id,
+  title: feature.title,
+  purpose: feature.purpose,
+  behaviors: feature.behaviors,
+  requirements: feature.requirements,
+  implementationNotes: feature.implementationNotes,
+  knownIssues: feature.knownIssues,
+);
+
 List<StudioFeatureInfo> _mountedFeatureInfos() => [
-  for (final feature in DwFeature.scanMounted())
-    StudioFeatureInfo(
-      id: feature.id,
-      title: feature.title,
-      purpose: feature.purpose,
-      behaviors: feature.behaviors,
-      requirements: feature.requirements,
-      implementationNotes: feature.implementationNotes,
-      knownIssues: feature.knownIssues,
-    ),
+  for (final feature in DwFeature.scanMounted()) _toWireModel(feature),
 ];
+
+/// Answers Studio's "pencil" tap-to-inspect flow: the point arrives as
+/// fractions of this app's own logical viewport, converted here (not by
+/// Studio, which only knows how it is displaying the preview, framed or
+/// scaled) into an [Offset] [DwFeature.hitTest] can use.
+StudioFeatureInfo? _featureAtPoint(
+  double horizontalFraction,
+  double verticalFraction,
+) {
+  final view = WidgetsBinding.instance.platformDispatcher.views.first;
+  final logicalSize = view.physicalSize / view.devicePixelRatio;
+  final feature = DwFeature.hitTest(
+    Offset(
+      horizontalFraction * logicalSize.width,
+      verticalFraction * logicalSize.height,
+    ),
+  );
+  return feature == null ? null : _toWireModel(feature);
+}
 
 /// Connects the app to DartWay Studio when it runs embedded in the Studio
 /// preview frame: attaches the bridge host, reports route/session changes and
@@ -80,6 +100,7 @@ class _StudioBridgeBindingState extends ConsumerState<StudioBridgeBinding>
       validateAccessKey: studioHashAccessValidator(
         const String.fromEnvironment('STUDIO_KEY_HASH'),
       ),
+      inspectPoint: _featureAtPoint,
     );
     if (_host == null) return;
 

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -269,7 +269,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.4.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -298,28 +298,28 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.2.3"
+    version: "0.3.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.2.3"
+    version: "0.3.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.2.3"
+    version: "0.3.0"
   dartway_studio_bridge:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.6.0"
   dbus:
     dependency: transitive
     description:

--- a/packages/dartway_flutter/CHANGELOG.md
+++ b/packages/dartway_flutter/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 
+## 0.4.0
+
+**A feature can be found by pointing at it.** `DwFeature.hitTest(globalPosition)` answers what is
+declared at a point on screen — the other half of `scanMounted`, which answers what is declared on
+the screen at all. Studio's tap-to-inspect is the first caller: pick a spot in the live preview, get
+that feature's passport, with no id to look up and no map to keep in your head.
+
+The innermost declaration wins. A card and the "more actions" row inside it both cover the tap, and
+the row is what the finger landed on — so the walk goes depth-first and takes the last match, not
+the first.
+
+A feature is matched on the area it actually **paints** into, not the one it lays out in. The two
+differ more often than they sound like they would: a subtree under a `Transform.scale` draws
+smaller than it measures, and a list item scrolled past the edge of its viewport keeps its layout
+position while painting nothing at all — and being deeper in the tree, it would have won over the
+feature you can see. Both are cut out by transforming through to the root and intersecting with
+every ancestor clip.
+
+Same rule as `scanMounted` for subtrees Flutter parks out of sight (offstage, invisible, disabled
+ticker) — being mounted is not being on screen, and now neither is being laid out.
+
 ## 0.3.0
 
 **A feature can say what is wrong with it.** `DwFeatureSpec` gains `knownIssues` — a setting nothing

--- a/packages/dartway_flutter/example/pubspec.lock
+++ b/packages/dartway_flutter/example/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
+++ b/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
@@ -92,6 +92,12 @@ abstract interface class DwFeature {
   /// The [DwFeatureSpec]s of every [DwFeature] widget currently *on screen*,
   /// keyed by id (a feature declared by several instances appears once).
   ///
+  /// Deduplication is per id and never prunes a subtree: the walk continues
+  /// through a feature it has already seen. A list of near-identical cards
+  /// therefore yields one entry for the card, plus any nested feature that only
+  /// some of the cards build — collapsing to the first card's subtree instead
+  /// would silently drop the extras the later ones carry.
+  ///
   /// Scans from the app root — not a [BuildContext] — on purpose: this is the
   /// whole current screen's feature set, which is exactly what an error report
   /// or a Studio passport wants. Call from a post-frame callback after the
@@ -113,13 +119,9 @@ abstract interface class DwFeature {
 
     final found = <String, DwFeatureSpec>{};
     void visit(Element element) {
-      final widget = element.widget;
-      if (widget is Offstage && widget.offstage) return;
-      if (widget is Visibility && !widget.visible) return;
-      if (widget is TickerMode && !widget.enabled) return;
-      if (widget is DwFeature) {
-        final feature = (widget as DwFeature).dwFeature;
-        found[feature.id] = feature;
+      if (_isParkedOffscreen(element.widget)) return;
+      if (element.widget case DwFeature feature) {
+        found[feature.dwFeature.id] = feature.dwFeature;
       }
       element.visitChildren(visit);
     }
@@ -127,4 +129,42 @@ abstract interface class DwFeature {
     root.visitChildren(visit);
     return found.values.toList();
   }
+
+  /// The [DwFeatureSpec] at [globalPosition] (Studio's inspect-by-tap: pick a
+  /// screen point, describe whatever is there), or null over nothing declared.
+  ///
+  /// The last match wins rather than the first: a card and a "more actions"
+  /// row inside it can both contain the same point, and the row is what the
+  /// tap actually landed on. Depth-first order with no early return already
+  /// gives this for free — a child is visited, and so overwrites `found`,
+  /// after its parent.
+  static DwFeatureSpec? hitTest(Offset globalPosition) {
+    final root = WidgetsBinding.instance.rootElement;
+    if (root == null) return null;
+
+    DwFeatureSpec? found;
+    void visit(Element element) {
+      if (_isParkedOffscreen(element.widget)) return;
+      if (element.widget case DwFeature feature) {
+        final renderObject = element.renderObject;
+        if (renderObject is RenderBox && renderObject.attached) {
+          final rect = renderObject.localToGlobal(Offset.zero) &
+              renderObject.size;
+          if (rect.contains(globalPosition)) found = feature.dwFeature;
+        }
+      }
+      element.visitChildren(visit);
+    }
+
+    root.visitChildren(visit);
+    return found;
+  }
+
+  /// Whether [widget] roots a subtree Flutter itself parks out of sight:
+  /// see [scanMounted] for why being mounted is not the same as being on
+  /// screen.
+  static bool _isParkedOffscreen(Widget widget) =>
+      (widget is Offstage && widget.offstage) ||
+      (widget is Visibility && !widget.visible) ||
+      (widget is TickerMode && !widget.enabled);
 }

--- a/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
+++ b/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
@@ -138,6 +138,12 @@ abstract interface class DwFeature {
   /// tap actually landed on. Depth-first order with no early return already
   /// gives this for free — a child is visited, and so overwrites `found`,
   /// after its parent.
+  ///
+  /// A feature is matched on the area it actually *paints* into — see
+  /// [_paintedGlobalRect] for what that excludes. This is a walk of the widget
+  /// tree, not Flutter's own hit test: going from the hit render objects back
+  /// to the widgets that declared them needs an element, and a `RenderObject`
+  /// has no way back to one outside debug mode.
   static DwFeatureSpec? hitTest(Offset globalPosition) {
     final root = WidgetsBinding.instance.rootElement;
     if (root == null) return null;
@@ -146,11 +152,9 @@ abstract interface class DwFeature {
     void visit(Element element) {
       if (_isParkedOffscreen(element.widget)) return;
       if (element.widget case DwFeature feature) {
-        final renderObject = element.renderObject;
-        if (renderObject is RenderBox && renderObject.attached) {
-          final rect = renderObject.localToGlobal(Offset.zero) &
-              renderObject.size;
-          if (rect.contains(globalPosition)) found = feature.dwFeature;
+        final rect = _paintedGlobalRect(element.renderObject);
+        if (rect != null && rect.contains(globalPosition)) {
+          found = feature.dwFeature;
         }
       }
       element.visitChildren(visit);
@@ -158,6 +162,48 @@ abstract interface class DwFeature {
 
     root.visitChildren(visit);
     return found;
+  }
+
+  /// Where [renderObject] lands on screen, in global coordinates — or null if
+  /// it lands nowhere visible.
+  ///
+  /// Two things a plain `localToGlobal(Offset.zero) & size` gets wrong, and
+  /// both of them make [hitTest] name a feature the user cannot see at that
+  /// point:
+  ///
+  /// * **Transforms.** The size is the *unscaled* one, so a subtree under a
+  ///   `Transform.scale(0.5)` (a zoomable canvas, a running page transition)
+  ///   claims twice the area it draws. The full transform to the root fixes
+  ///   both the scale and any rotation's bounding box.
+  /// * **Clips.** A list item scrolled past the edge of its viewport keeps its
+  ///   layout position and answers for a point where it paints nothing — and
+  ///   being deeper in the tree, it would beat the visible feature there.
+  ///   Every ancestor clip cuts the rect down; an empty result means the
+  ///   feature is scrolled or clipped away entirely.
+  static Rect? _paintedGlobalRect(RenderObject? renderObject) {
+    if (renderObject is! RenderBox ||
+        !renderObject.attached ||
+        !renderObject.hasSize) {
+      return null;
+    }
+
+    var rect = MatrixUtils.transformRect(
+      renderObject.getTransformTo(null),
+      Offset.zero & renderObject.size,
+    );
+
+    var child = renderObject as RenderObject;
+    for (var ancestor = child.parent;
+        ancestor != null;
+        child = ancestor, ancestor = ancestor.parent) {
+      final clip = ancestor.describeApproximatePaintClip(child);
+      if (clip == null) continue;
+      rect = rect.intersect(
+        MatrixUtils.transformRect(ancestor.getTransformTo(null), clip),
+      );
+      if (rect.isEmpty) return null;
+    }
+    return rect;
   }
 
   /// Whether [widget] roots a subtree Flutter itself parks out of sight:

--- a/packages/dartway_flutter/pubspec.yaml
+++ b/packages/dartway_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_flutter
 description: "The Flutter skeleton of a DartWay app: bootstrap runner, guarded UI actions, the AsyncValue rendering contract, notifications and error reporting. Riverpod-native."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_flutter/test/dw_feature_test.dart
+++ b/packages/dartway_flutter/test/dw_feature_test.dart
@@ -225,5 +225,61 @@ void main() {
 
       expect(DwFeature.hitTest(const Offset(50, 50)), isNull);
     });
+
+    // A scaled subtree draws smaller than it lays out. Matching on the
+    // unscaled size would claim the empty space next to it — the case a
+    // zoomable canvas or a running page transition puts on screen.
+    testWidgets('matches the scaled area, not the laid-out one',
+        (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: Transform.scale(
+              scale: 0.5,
+              alignment: Alignment.topLeft,
+              child: _SizedFeature(_spec('scaled')),
+            ),
+          ),
+        ),
+      );
+
+      // Laid out 100x100, drawn 50x50 at the top-left corner.
+      expect(DwFeature.hitTest(const Offset(20, 20))?.id, 'scaled');
+      expect(DwFeature.hitTest(const Offset(70, 70)), isNull);
+    });
+
+    // A list item scrolled past the edge of its viewport keeps its layout
+    // position and paints nothing. Being deeper in the tree it would win the
+    // last-match-wins rule, so it has to be cut by the viewport's clip.
+    testWidgets('skips a feature clipped away by a scroll viewport',
+        (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 100,
+              height: 100, // one item tall
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    _SizedFeature(_spec('in-view')),
+                    _SizedFeature(_spec('below-the-fold')),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(DwFeature.hitTest(const Offset(50, 50))?.id, 'in-view');
+      // 'below-the-fold' lays out at y 100..200 — outside the viewport, drawn
+      // nowhere.
+      expect(DwFeature.hitTest(const Offset(50, 150)), isNull);
+    });
   });
 }

--- a/packages/dartway_flutter/test/dw_feature_test.dart
+++ b/packages/dartway_flutter/test/dw_feature_test.dart
@@ -14,6 +14,39 @@ class _FeatureBox extends StatelessWidget implements DwFeature {
   Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
+/// A feature that hosts a subtree — the shape of a card that may or may not
+/// build a nested feature of its own.
+class _FeatureGroup extends StatelessWidget implements DwFeature {
+  const _FeatureGroup(this.spec, {this.child});
+
+  final DwFeatureSpec spec;
+  final Widget? child;
+
+  @override
+  DwFeatureSpec get dwFeature => spec;
+
+  @override
+  Widget build(BuildContext context) => child ?? const SizedBox.shrink();
+}
+
+/// A [DwFeature] widget with a concrete, hit-testable size — [_FeatureBox]
+/// renders a zero-size box, which never intersects a hit-test point. A
+/// [child] gets the same size as its parent (`SizedBox` imposes tight
+/// constraints), which is exactly what a card's nested row does.
+class _SizedFeature extends StatelessWidget implements DwFeature {
+  const _SizedFeature(this.spec, {this.child});
+
+  final DwFeatureSpec spec;
+  final Widget? child;
+
+  @override
+  DwFeatureSpec get dwFeature => spec;
+
+  @override
+  Widget build(BuildContext context) =>
+      SizedBox(width: 100, height: 100, child: child);
+}
+
 DwFeatureSpec _spec(String id) =>
     DwFeatureSpec(id: id, title: id, behaviors: const ['does a thing']);
 
@@ -32,6 +65,30 @@ void main() {
 
     final ids = DwFeature.scanMounted().map((f) => f.id).toList();
     expect(ids.toSet(), {'a', 'b'});
+    expect(ids.length, 2);
+  });
+
+  // Deduplication is per id, not per subtree, and the walk never stops at a
+  // feature it has already seen. It matters for a list of near-identical cards:
+  // collapsing to the first card's subtree would lose a nested feature only
+  // some cards build — a "more actions" row on the one card that has extras.
+  testWidgets('DwFeature.scanMounted keeps a nested feature only one instance '
+      'of a repeated card builds', (tester) async {
+    await tester.pumpWidget(
+      Column(
+        children: [
+          _FeatureGroup(_spec('ad/card')),
+          _FeatureGroup(_spec('ad/card')),
+          _FeatureGroup(
+            _spec('ad/card'),
+            child: _FeatureBox(_spec('ad/card/more-actions')),
+          ),
+        ],
+      ),
+    );
+
+    final ids = DwFeature.scanMounted().map((feature) => feature.id).toList();
+    expect(ids.toSet(), {'ad/card', 'ad/card/more-actions'});
     expect(ids.length, 2);
   });
 
@@ -90,5 +147,83 @@ void main() {
     );
 
     expect(DwFeature.scanMounted().map((f) => f.id), ['shown']);
+  });
+
+  group('DwFeature.hitTest', () {
+    testWidgets('returns the feature under the point', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _SizedFeature(_spec('left')),
+              _SizedFeature(_spec('right')),
+            ],
+          ),
+        ),
+      );
+
+      Offset centerOf(String id) => tester.getCenter(
+            find.byWidgetPredicate(
+              (widget) => widget is _SizedFeature && widget.spec.id == id,
+            ),
+          );
+
+      expect(DwFeature.hitTest(centerOf('left'))?.id, 'left');
+      expect(DwFeature.hitTest(centerOf('right'))?.id, 'right');
+    });
+
+    testWidgets('is null over a point nothing declared covers', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: _SizedFeature(_spec('only')),
+        ),
+      );
+
+      expect(DwFeature.hitTest(const Offset(9999, 9999)), isNull);
+    });
+
+    // A card and a "more actions" row it may or may not build can both cover
+    // the same point — the tap landed on whichever is actually drawn there,
+    // and that is the nested one.
+    testWidgets(
+      'returns the innermost feature when nested features overlap',
+      (tester) async {
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: _SizedFeature(
+              _spec('ad/card'),
+              child: _SizedFeature(_spec('ad/card/more-actions')),
+            ),
+          ),
+        );
+
+        final center = tester.getCenter(
+          find.byWidgetPredicate(
+            (widget) => widget is _SizedFeature && widget.spec.id == 'ad/card',
+          ),
+        );
+        expect(DwFeature.hitTest(center)?.id, 'ad/card/more-actions');
+      },
+    );
+
+    // hitTest bypasses Flutter's own hit-testing (it checks render bounds
+    // directly), so it must repeat the offstage/invisible/disabled-ticker
+    // skip itself — an offstage subtree still lays out with a real size.
+    testWidgets('skips an offstage feature', (tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Offstage(child: _SizedFeature(_spec('parked'))),
+        ),
+      );
+
+      expect(DwFeature.hitTest(const Offset(50, 50)), isNull);
+    });
   });
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   serverpod_client: ^3.4.11
 
-  dartway_flutter: ^0.3.0
+  dartway_flutter: ^0.4.0
   dartway_serverpod_core_client: ^0.3.0
   dartway_serverpod_core_shared: ^0.3.0
 

--- a/packages/dartway_shared_preferences/pubspec.yaml
+++ b/packages/dartway_shared_preferences/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.3.0
+  dartway_flutter: ^0.4.0
   flutter_riverpod: ^3.0.0
   shared_preferences: ^2.3.0
 

--- a/packages/dartway_studio_bridge/CHANGELOG.md
+++ b/packages/dartway_studio_bridge/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
 
+## 0.6.0
+
+**Studio can ask what is at a point on screen.** A new request/answer pair —
+`InspectPointRequestMessage` / `InspectPointResultMessage` — carries the "pencil" tap-to-inspect
+flow: Studio names a spot in the live preview, the app answers with the feature declared there, or
+with nothing. `StudioBridgeClient.inspectPoint()` is the Studio side; `StudioBridgeHost.attach`
+takes an `inspectPoint` callback for the app side (a DartWay app hands it `DwFeature.hitTest`).
+
+**The point travels as fractions of the app's viewport, not pixels.** Studio shows the preview
+scaled, framed, letterboxed — whatever the panel needs — and only the app knows its own logical
+size. A fraction means the same point under every one of those, so the conversion happens once, in
+the app, instead of Studio guessing.
+
+**The request carries an id and the answer echoes it back.** Inspect is the first message that can
+be in flight twice: a second tap while a slow first one is still being answered. Matching on
+"whatever result arrives next" would resolve the second tap with the first tap's answer — a
+confidently wrong passport, which is worse than none. Requests that time out are forgotten, so
+their late answers are dropped rather than handed to whoever is waiting now.
+
+An app that predates this message stays silent, and the requester's timeout reads that as "nothing
+declared here" — the same as a real miss, never a hang. An app whose `inspectPoint` throws still
+answers (with nothing) and reports the error through `FlutterError.reportError`: silence would have
+cost Studio its full timeout and disguised a crash as an empty spot.
+
 ## 0.5.0
 
 `StudioFeatureInfo` follows `DwFeatureSpec` (package `dartway_flutter` 0.3.0) and carries

--- a/packages/dartway_studio_bridge/README.md
+++ b/packages/dartway_studio_bridge/README.md
@@ -69,6 +69,7 @@ final host = StudioBridgeHost.attach(
   validateAccessKey: studioHashAccessValidator(
     const String.fromEnvironment('STUDIO_KEY_HASH'),
   ),
+  inspectPoint: featureAtPoint, // what is declared at a point (see below)
 );
 host?.reportRoute(newPath, routeName: 'scheduleList'); // on router changes
 host?.reportSession(newState);  // on auth changes
@@ -110,6 +111,36 @@ Report after the new screen has built — a route change fires before its widget
 mount, so reporting in the same turn describes the screen you just left. See
 `example/dartway_example_flutter/lib/studio/studio_bridge_binding.dart` for the
 reference binding.
+
+## Inspecting a point (the "pencil" flow)
+
+Studio can also ask the other question — not "what is on this screen" but "what
+is *here*", from a tap in the live preview:
+
+```dart
+final feature = await client.inspectPoint(0.42, 0.65); // Studio side
+```
+
+The point travels as **fractions** of the app's viewport (0.0 top/left, 1.0
+bottom/right), never pixels: Studio shows the preview scaled, framed or
+letterboxed, and only the app knows its own logical size. The app converts once,
+on its side:
+
+```dart
+StudioFeatureInfo? featureAtPoint(double horizontal, double vertical) {
+  final view = WidgetsBinding.instance.platformDispatcher.views.first;
+  final size = view.physicalSize / view.devicePixelRatio;
+  final feature = DwFeature.hitTest(
+    Offset(horizontal * size.width, vertical * size.height),
+  );
+  return feature == null ? null : toWireModel(feature);
+}
+```
+
+Each request carries an id the app echoes back, so a second tap sent while a
+slow first one is still being answered gets its own answer instead of the
+previous one's. An app that predates the message stays silent and the caller's
+timeout reports "nothing here" — a miss, never a hang.
 
 `attach` returns null when the app is not running on web inside an iframe —
 the app stays fully functional and the bridge dormant. The channel pins the

--- a/packages/dartway_studio_bridge/lib/src/client/studio_bridge_client.dart
+++ b/packages/dartway_studio_bridge/lib/src/client/studio_bridge_client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import '../models/studio_feature_info.dart';
 import '../protocol/studio_bridge_message.dart';
 import '../transport/studio_message_channel.dart';
 import 'studio_bridge_event.dart';
@@ -23,6 +24,7 @@ class StudioBridgeClient {
   final Duration connectRetryInterval;
 
   final _events = StreamController<StudioProjectEvent>.broadcast();
+  final _inspectResults = StreamController<StudioFeatureInfo?>.broadcast();
   StreamSubscription<StudioBridgeMessage>? _subscription;
   Timer? _retryTimer;
   bool _connected = false;
@@ -71,6 +73,8 @@ class StudioBridgeClient {
         );
       case LocaleChangedMessage(:final locale):
         _events.add(StudioProjectLocaleChanged(locale));
+      case InspectPointResultMessage(:final feature):
+        _inspectResults.add(feature);
       default:
         break; // Studio → app messages echoed back are ignored.
     }
@@ -96,9 +100,31 @@ class StudioBridgeClient {
   void requestLocale(String locale) =>
       _channel.send(LocaleRequestMessage(locale));
 
+  /// The feature at a point given as fractions of the app's viewport (see
+  /// [InspectPointRequestMessage]) — the "pencil" tap-to-inspect flow.
+  /// Null when nothing is declared there, or the app never answers: an app
+  /// built against an older bridge doesn't know this message and simply stays
+  /// silent, which [timeout] turns into the same "nothing here" as a real
+  /// miss rather than a hang.
+  Future<StudioFeatureInfo?> inspectPoint(
+    double horizontalFraction,
+    double verticalFraction, {
+    Duration timeout = const Duration(seconds: 3),
+  }) {
+    final next = _inspectResults.stream.first;
+    _channel.send(
+      InspectPointRequestMessage(
+        horizontalFraction: horizontalFraction,
+        verticalFraction: verticalFraction,
+      ),
+    );
+    return next.timeout(timeout, onTimeout: () => null);
+  }
+
   void dispose() {
     _retryTimer?.cancel();
     _subscription?.cancel();
     _events.close();
+    _inspectResults.close();
   }
 }

--- a/packages/dartway_studio_bridge/lib/src/client/studio_bridge_client.dart
+++ b/packages/dartway_studio_bridge/lib/src/client/studio_bridge_client.dart
@@ -24,7 +24,13 @@ class StudioBridgeClient {
   final Duration connectRetryInterval;
 
   final _events = StreamController<StudioProjectEvent>.broadcast();
-  final _inspectResults = StreamController<StudioFeatureInfo?>.broadcast();
+
+  /// Inspect requests still waiting for their answer, by request id. Keyed
+  /// rather than kept as a single "latest" future because two taps can be in
+  /// flight at once — see [InspectPointRequestMessage.requestId].
+  final _pendingInspects = <String, Completer<StudioFeatureInfo?>>{};
+  int _inspectCounter = 0;
+
   StreamSubscription<StudioBridgeMessage>? _subscription;
   Timer? _retryTimer;
   bool _connected = false;
@@ -73,8 +79,10 @@ class StudioBridgeClient {
         );
       case LocaleChangedMessage(:final locale):
         _events.add(StudioProjectLocaleChanged(locale));
-      case InspectPointResultMessage(:final feature):
-        _inspectResults.add(feature);
+      case InspectPointResultMessage(:final requestId, :final feature):
+        // An answer whose request is gone (already timed out) is dropped, not
+        // handed to whoever is waiting now.
+        _pendingInspects.remove(requestId)?.complete(feature);
       default:
         break; // Studio → app messages echoed back are ignored.
     }
@@ -106,25 +114,41 @@ class StudioBridgeClient {
   /// built against an older bridge doesn't know this message and simply stays
   /// silent, which [timeout] turns into the same "nothing here" as a real
   /// miss rather than a hang.
+  ///
+  /// Safe to call again while an earlier call is still pending: each request
+  /// resolves with its own answer, and a request abandoned to [timeout] is
+  /// forgotten rather than left to catch the next one's result.
   Future<StudioFeatureInfo?> inspectPoint(
     double horizontalFraction,
     double verticalFraction, {
     Duration timeout = const Duration(seconds: 3),
   }) {
-    final next = _inspectResults.stream.first;
+    final requestId = 'inspect-${++_inspectCounter}';
+    final pending = Completer<StudioFeatureInfo?>();
+    _pendingInspects[requestId] = pending;
     _channel.send(
       InspectPointRequestMessage(
+        requestId: requestId,
         horizontalFraction: horizontalFraction,
         verticalFraction: verticalFraction,
       ),
     );
-    return next.timeout(timeout, onTimeout: () => null);
+    return pending.future.timeout(timeout, onTimeout: () {
+      _pendingInspects.remove(requestId);
+      return null;
+    });
   }
 
   void dispose() {
     _retryTimer?.cancel();
     _subscription?.cancel();
     _events.close();
-    _inspectResults.close();
+    // Resolve, don't abandon: a caller awaiting an inspect when the preview
+    // closes gets the same "nothing here" as a miss, instead of an error out
+    // of a disposed client.
+    for (final pending in _pendingInspects.values) {
+      if (!pending.isCompleted) pending.complete(null);
+    }
+    _pendingInspects.clear();
   }
 }

--- a/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
+++ b/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+
 import '../models/studio_feature_info.dart';
 import '../models/studio_project_manifest.dart';
 import '../models/studio_session_state.dart';
@@ -124,17 +126,47 @@ class StudioBridgeHost {
       case LocaleRequestMessage(:final locale):
         _delegate.onLocaleRequest(locale);
       case InspectPointRequestMessage(
+          :final requestId,
           :final horizontalFraction,
           :final verticalFraction,
         ):
-        Future.sync(
-          () => _inspectPoint(horizontalFraction, verticalFraction),
-        ).then(
-          (feature) => _channel.send(InspectPointResultMessage(feature)),
+        unawaited(
+          _answerInspectPoint(
+            requestId,
+            horizontalFraction,
+            verticalFraction,
+          ),
         );
       default:
         break; // App → Studio messages echoed back are ignored.
     }
+  }
+
+  /// Answers an inspect request — and answers it even when the app's own
+  /// [StudioInspectPoint] throws. Staying silent would be indistinguishable
+  /// from an app that predates the message, so Studio would sit out its whole
+  /// timeout and report a crash as "nothing declared here". The error is not
+  /// swallowed either: it goes to [FlutterError.reportError], which in a
+  /// DartWay app is the same path every other UI error takes.
+  Future<void> _answerInspectPoint(
+    String requestId,
+    double horizontalFraction,
+    double verticalFraction,
+  ) async {
+    StudioFeatureInfo? feature;
+    try {
+      feature = await _inspectPoint(horizontalFraction, verticalFraction);
+    } catch (error, stackTrace) {
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'dartway_studio_bridge',
+        context: ErrorDescription('answering a Studio inspect-point request'),
+      ));
+    }
+    _channel.send(
+      InspectPointResultMessage(requestId: requestId, feature: feature),
+    );
   }
 
   void _sendManifest() => _channel.send(ManifestMessage(

--- a/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
+++ b/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
@@ -26,6 +26,15 @@ abstract interface class StudioBridgeHostDelegate {
   void onLocaleRequest(String locale);
 }
 
+/// What is declared at a screen point, for the "pencil" tap-to-inspect flow.
+/// The point arrives as fractions of the app's own viewport (see
+/// [InspectPointRequestMessage]) — convert with the app's own logical
+/// viewport size, not any size Studio thinks the frame is.
+typedef StudioInspectPoint = FutureOr<StudioFeatureInfo?> Function(
+  double horizontalFraction,
+  double verticalFraction,
+);
+
 /// The app-side end of the Studio bridge: announces the app, answers the
 /// handshake with the manifest, reports route/session changes and dispatches
 /// Studio's requests to the [StudioBridgeHostDelegate].
@@ -39,6 +48,7 @@ class StudioBridgeHost {
     this._currentFeatures,
     this._currentLocale,
     this._validateAccessKey,
+    this._inspectPoint,
   ) {
     _subscription = _channel.messages.listen(_onMessage);
     _channel.send(const AppReadyMessage());
@@ -65,6 +75,11 @@ class StudioBridgeHost {
     // validator that always returns true) accepts any Studio — fine for local
     // dev, wide open in production.
     Future<bool> Function(String accessKey)? validateAccessKey,
+    // Answers the "pencil" tap-to-inspect flow. Null (the default for an app
+    // that hasn't wired it) means every inspect request finds nothing —
+    // Studio's own timeout treats that exactly like an old app that doesn't
+    // know the message at all.
+    StudioInspectPoint? inspectPoint,
   }) {
     final channel = createStudioHostChannel();
     if (channel == null) return null;
@@ -77,6 +92,7 @@ class StudioBridgeHost {
       currentFeatures ?? () => const [],
       currentLocale ?? () => '',
       validateAccessKey ?? (_) async => true,
+      inspectPoint ?? (_, _) => null,
     );
   }
 
@@ -88,6 +104,7 @@ class StudioBridgeHost {
   final List<StudioFeatureInfo> Function() _currentFeatures;
   final String Function() _currentLocale;
   final Future<bool> Function(String accessKey) _validateAccessKey;
+  final StudioInspectPoint _inspectPoint;
   late final StreamSubscription<StudioBridgeMessage> _subscription;
 
   void _onMessage(StudioBridgeMessage message) {
@@ -106,6 +123,15 @@ class StudioBridgeHost {
         unawaited(_delegate.onSignOutRequest());
       case LocaleRequestMessage(:final locale):
         _delegate.onLocaleRequest(locale);
+      case InspectPointRequestMessage(
+          :final horizontalFraction,
+          :final verticalFraction,
+        ):
+        Future.sync(
+          () => _inspectPoint(horizontalFraction, verticalFraction),
+        ).then(
+          (feature) => _channel.send(InspectPointResultMessage(feature)),
+        );
       default:
         break; // App → Studio messages echoed back are ignored.
     }

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
@@ -141,3 +141,31 @@ class SessionChangedMessage extends StudioBridgeMessage {
         ),
       );
 }
+
+/// App → Studio: the answer to an [InspectPointRequestMessage] — the feature
+/// at that point, or null when nothing declared covers it (or the app
+/// predates this message and never answers at all, which the requester's own
+/// timeout handles the same way).
+class InspectPointResultMessage extends StudioBridgeMessage {
+  const InspectPointResultMessage(this.feature);
+
+  final StudioFeatureInfo? feature;
+
+  @override
+  String get type => StudioBridgeProtocol.inspectPointResult;
+
+  @override
+  Map<String, dynamic> payloadToJson() => {
+        if (feature != null) 'feature': feature!.toJson(),
+      };
+
+  factory InspectPointResultMessage.fromPayload(
+    Map<String, dynamic> payload,
+  ) =>
+      InspectPointResultMessage(
+        switch (payload['feature']) {
+          final Map<String, dynamic> json => StudioFeatureInfo.fromJson(json),
+          _ => null,
+        },
+      );
+}

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
@@ -147,7 +147,13 @@ class SessionChangedMessage extends StudioBridgeMessage {
 /// predates this message and never answers at all, which the requester's own
 /// timeout handles the same way).
 class InspectPointResultMessage extends StudioBridgeMessage {
-  const InspectPointResultMessage(this.feature);
+  const InspectPointResultMessage({required this.requestId, this.feature});
+
+  /// The [InspectPointRequestMessage.requestId] this answers, echoed back
+  /// untouched — the requester matches on it and drops anything else, so a
+  /// late answer to an abandoned tap cannot be read as the answer to the
+  /// current one.
+  final String requestId;
 
   final StudioFeatureInfo? feature;
 
@@ -156,6 +162,7 @@ class InspectPointResultMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
+        'requestId': requestId,
         if (feature != null) 'feature': feature!.toJson(),
       };
 
@@ -163,7 +170,8 @@ class InspectPointResultMessage extends StudioBridgeMessage {
     Map<String, dynamic> payload,
   ) =>
       InspectPointResultMessage(
-        switch (payload['feature']) {
+        requestId: payload['requestId'] as String? ?? '',
+        feature: switch (payload['feature']) {
           final Map<String, dynamic> json => StudioFeatureInfo.fromJson(json),
           _ => null,
         },

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
@@ -52,6 +52,8 @@ sealed class StudioBridgeMessage {
         FeaturesChangedMessage.fromPayload(payload),
       StudioBridgeProtocol.localeChanged =>
         LocaleChangedMessage.fromPayload(payload),
+      StudioBridgeProtocol.inspectPointResult =>
+        InspectPointResultMessage.fromPayload(payload),
       StudioBridgeProtocol.studioConnect =>
         StudioConnectMessage.fromPayload(payload),
       StudioBridgeProtocol.navigateRequest =>
@@ -61,6 +63,8 @@ sealed class StudioBridgeMessage {
       StudioBridgeProtocol.signOutRequest => const SignOutRequestMessage(),
       StudioBridgeProtocol.localeRequest =>
         LocaleRequestMessage.fromPayload(payload),
+      StudioBridgeProtocol.inspectPointRequest =>
+        InspectPointRequestMessage.fromPayload(payload),
       _ => null,
     };
   }

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_protocol.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_protocol.dart
@@ -25,6 +25,7 @@ abstract final class StudioBridgeProtocol {
   static const sessionChanged = 'sessionChanged';
   static const featuresChanged = 'featuresChanged';
   static const localeChanged = 'localeChanged';
+  static const inspectPointResult = 'inspectPointResult';
 
   // Studio → app.
   static const studioConnect = 'studioConnect';
@@ -32,4 +33,5 @@ abstract final class StudioBridgeProtocol {
   static const signInRequest = 'signInRequest';
   static const signOutRequest = 'signOutRequest';
   static const localeRequest = 'localeRequest';
+  static const inspectPointRequest = 'inspectPointRequest';
 }

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_request_messages.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_request_messages.dart
@@ -100,15 +100,26 @@ class LocaleRequestMessage extends StudioBridgeMessage {
 
 /// Studio → app: what feature, if any, is at this point on screen — the
 /// "pencil" flow's tap-to-inspect. The point is given as *fractions* of the
-/// app's own
-/// viewport (0.0 top/left, 1.0 bottom/right), not pixels: Studio may be
-/// showing the preview scaled or letterboxed, but a fraction of the viewport
-/// means the same point regardless of how it is currently displayed.
+/// app's own viewport (0.0 top/left, 1.0 bottom/right), not pixels: Studio may
+/// be showing the preview scaled or letterboxed, but a fraction of the
+/// viewport means the same point regardless of how it is currently displayed.
 class InspectPointRequestMessage extends StudioBridgeMessage {
   const InspectPointRequestMessage({
+    required this.requestId,
     required this.horizontalFraction,
     required this.verticalFraction,
   });
+
+  /// Ties this request to the one answer that belongs to it. The app echoes it
+  /// back untouched in [InspectPointResultMessage.requestId], and the
+  /// requester matches on it instead of taking whatever result arrives next:
+  /// inspect is the one request that can be in flight twice (a second tap
+  /// while a slow first one is still being answered), and without an id the
+  /// late answer to the first tap resolves the second — Studio would show a
+  /// confidently wrong passport rather than nothing.
+  ///
+  /// Unique within one requester's session; the app treats it as opaque.
+  final String requestId;
 
   final double horizontalFraction;
   final double verticalFraction;
@@ -118,6 +129,7 @@ class InspectPointRequestMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
+        'requestId': requestId,
         'horizontalFraction': horizontalFraction,
         'verticalFraction': verticalFraction,
       };
@@ -126,6 +138,7 @@ class InspectPointRequestMessage extends StudioBridgeMessage {
     Map<String, dynamic> payload,
   ) =>
       InspectPointRequestMessage(
+        requestId: payload['requestId'] as String? ?? '',
         horizontalFraction:
             (payload['horizontalFraction'] as num?)?.toDouble() ?? 0,
         verticalFraction:

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_request_messages.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_request_messages.dart
@@ -97,3 +97,38 @@ class LocaleRequestMessage extends StudioBridgeMessage {
   factory LocaleRequestMessage.fromPayload(Map<String, dynamic> payload) =>
       LocaleRequestMessage(payload['locale'] as String? ?? '');
 }
+
+/// Studio → app: what feature, if any, is at this point on screen — the
+/// "pencil" flow's tap-to-inspect. The point is given as *fractions* of the
+/// app's own
+/// viewport (0.0 top/left, 1.0 bottom/right), not pixels: Studio may be
+/// showing the preview scaled or letterboxed, but a fraction of the viewport
+/// means the same point regardless of how it is currently displayed.
+class InspectPointRequestMessage extends StudioBridgeMessage {
+  const InspectPointRequestMessage({
+    required this.horizontalFraction,
+    required this.verticalFraction,
+  });
+
+  final double horizontalFraction;
+  final double verticalFraction;
+
+  @override
+  String get type => StudioBridgeProtocol.inspectPointRequest;
+
+  @override
+  Map<String, dynamic> payloadToJson() => {
+        'horizontalFraction': horizontalFraction,
+        'verticalFraction': verticalFraction,
+      };
+
+  factory InspectPointRequestMessage.fromPayload(
+    Map<String, dynamic> payload,
+  ) =>
+      InspectPointRequestMessage(
+        horizontalFraction:
+            (payload['horizontalFraction'] as num?)?.toDouble() ?? 0,
+        verticalFraction:
+            (payload['verticalFraction'] as num?)?.toDouble() ?? 0,
+      );
+}

--- a/packages/dartway_studio_bridge/pubspec.yaml
+++ b/packages/dartway_studio_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_studio_bridge
 description: "Open bridge between a DartWay app and DartWay Studio: in-code screen spec registry models and the runtime postMessage protocol."
-version: 0.5.0
+version: 0.6.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_studio_bridge/test/studio_bridge_client_inspect_point_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_client_inspect_point_test.dart
@@ -22,6 +22,12 @@ class _FakeChannel implements StudioMessageChannel {
   void dispose() => _incoming.close();
 }
 
+/// The inspect requests the client put on the wire, in order.
+extension on _FakeChannel {
+  List<InspectPointRequestMessage> get inspectRequests =>
+      sent.whereType<InspectPointRequestMessage>().toList();
+}
+
 void main() {
   group('StudioBridgeClient.inspectPoint', () {
     test('sends the fractional point and resolves with the app\'s answer',
@@ -48,8 +54,9 @@ void main() {
       );
 
       channel.emit(
-        const InspectPointResultMessage(
-          StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
+        InspectPointResultMessage(
+          requestId: channel.inspectRequests.single.requestId,
+          feature: const StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
         ),
       );
 
@@ -71,6 +78,78 @@ void main() {
 
       expect(result, isNull);
       client.dispose();
+    });
+
+    // Without correlation this is the bug that bites in the real flow: tap a
+    // spot the app is slow to answer, give up on it, tap elsewhere — and the
+    // late answer to the first tap resolves the second, so Studio shows a
+    // confidently wrong passport instead of nothing.
+    test('drops a late answer to a request that already timed out', () async {
+      final channel = _FakeChannel();
+      final client = StudioBridgeClient(channel: channel)..start();
+
+      final abandoned = await client.inspectPoint(
+        0.1,
+        0.1,
+        timeout: const Duration(milliseconds: 20),
+      );
+      expect(abandoned, isNull);
+
+      final current = client.inspectPoint(
+        0.9,
+        0.9,
+        timeout: const Duration(milliseconds: 100),
+      );
+      channel.emit(
+        InspectPointResultMessage(
+          requestId: channel.inspectRequests.first.requestId,
+          feature: const StudioFeatureInfo(id: 'stale', title: 'Stale'),
+        ),
+      );
+
+      expect(await current, isNull);
+      client.dispose();
+    });
+
+    test('gives two in-flight requests their own answers', () async {
+      final channel = _FakeChannel();
+      final client = StudioBridgeClient(channel: channel)..start();
+
+      final first = client.inspectPoint(0.1, 0.1);
+      final second = client.inspectPoint(0.9, 0.9);
+      final requests = channel.inspectRequests;
+      expect(requests, hasLength(2));
+      expect(requests.first.requestId, isNot(requests.last.requestId));
+
+      // Answered out of order, as a busy app may well do.
+      channel.emit(
+        InspectPointResultMessage(
+          requestId: requests.last.requestId,
+          feature: const StudioFeatureInfo(id: 'second', title: 'Second'),
+        ),
+      );
+      channel.emit(
+        InspectPointResultMessage(
+          requestId: requests.first.requestId,
+          feature: const StudioFeatureInfo(id: 'first', title: 'First'),
+        ),
+      );
+
+      expect((await first)?.id, 'first');
+      expect((await second)?.id, 'second');
+      client.dispose();
+    });
+
+    // Closing the preview panel mid-inspect must not surface an error out of
+    // a disposed client — the awaiting caller just learns nothing was found.
+    test('resolves a pending request with null on dispose', () async {
+      final channel = _FakeChannel();
+      final client = StudioBridgeClient(channel: channel)..start();
+
+      final pending = client.inspectPoint(0.5, 0.5);
+      client.dispose();
+
+      expect(await pending, isNull);
     });
   });
 }

--- a/packages/dartway_studio_bridge/test/studio_bridge_client_inspect_point_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_client_inspect_point_test.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// An in-memory two-way pipe standing in for the real `postMessage`
+/// transport: [sent] records what the client sent, and [emit] simulates a
+/// message arriving from the app.
+class _FakeChannel implements StudioMessageChannel {
+  final sent = <StudioBridgeMessage>[];
+  final _incoming = StreamController<StudioBridgeMessage>.broadcast();
+
+  @override
+  Stream<StudioBridgeMessage> get messages => _incoming.stream;
+
+  @override
+  void send(StudioBridgeMessage message) => sent.add(message);
+
+  void emit(StudioBridgeMessage message) => _incoming.add(message);
+
+  @override
+  void dispose() => _incoming.close();
+}
+
+void main() {
+  group('StudioBridgeClient.inspectPoint', () {
+    test('sends the fractional point and resolves with the app\'s answer',
+        () async {
+      final channel = _FakeChannel();
+      final client = StudioBridgeClient(channel: channel)..start();
+
+      final result = client.inspectPoint(0.25, 0.5);
+      expect(
+        channel.sent,
+        contains(
+          isA<InspectPointRequestMessage>()
+              .having(
+                (message) => message.horizontalFraction,
+                'horizontalFraction',
+                0.25,
+              )
+              .having(
+                (message) => message.verticalFraction,
+                'verticalFraction',
+                0.5,
+              ),
+        ),
+      );
+
+      channel.emit(
+        const InspectPointResultMessage(
+          StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
+        ),
+      );
+
+      expect((await result)?.id, 'ad/card');
+      client.dispose();
+    });
+
+    test('resolves with null when the app never answers', () async {
+      final channel = _FakeChannel();
+      final client = StudioBridgeClient(channel: channel)..start();
+
+      // An app built against an older bridge doesn't know this message and
+      // stays silent — the timeout must still resolve, not hang.
+      final result = await client.inspectPoint(
+        0.1,
+        0.1,
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      expect(result, isNull);
+      client.dispose();
+    });
+  });
+}

--- a/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
@@ -90,6 +90,35 @@ void main() {
       expect((decoded as LocaleChangedMessage).locale, 'en');
     });
 
+    test('inspectPointRequest carries the fractional point', () {
+      final decoded = _roundTrip(
+        const InspectPointRequestMessage(
+          horizontalFraction: 0.25,
+          verticalFraction: 0.75,
+        ),
+      );
+      final request = decoded as InspectPointRequestMessage;
+      expect(request.horizontalFraction, 0.25);
+      expect(request.verticalFraction, 0.75);
+    });
+
+    test('inspectPointResult carries the feature found there', () {
+      final decoded = _roundTrip(
+        const InspectPointResultMessage(
+          StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
+        ),
+      );
+      expect(
+        (decoded as InspectPointResultMessage).feature?.id,
+        'ad/card',
+      );
+    });
+
+    test('inspectPointResult carries null when nothing was found there', () {
+      final decoded = _roundTrip(const InspectPointResultMessage(null));
+      expect((decoded as InspectPointResultMessage).feature, isNull);
+    });
+
     test('sessionChanged carries the session', () {
       final decoded = _roundTrip(
         const SessionChangedMessage(

--- a/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
@@ -90,14 +90,16 @@ void main() {
       expect((decoded as LocaleChangedMessage).locale, 'en');
     });
 
-    test('inspectPointRequest carries the fractional point', () {
+    test('inspectPointRequest carries the fractional point and request id', () {
       final decoded = _roundTrip(
         const InspectPointRequestMessage(
+          requestId: 'inspect-7',
           horizontalFraction: 0.25,
           verticalFraction: 0.75,
         ),
       );
       final request = decoded as InspectPointRequestMessage;
+      expect(request.requestId, 'inspect-7');
       expect(request.horizontalFraction, 0.25);
       expect(request.verticalFraction, 0.75);
     });
@@ -105,18 +107,21 @@ void main() {
     test('inspectPointResult carries the feature found there', () {
       final decoded = _roundTrip(
         const InspectPointResultMessage(
-          StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
+          requestId: 'inspect-7',
+          feature: StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
         ),
       );
-      expect(
-        (decoded as InspectPointResultMessage).feature?.id,
-        'ad/card',
-      );
+      final result = decoded as InspectPointResultMessage;
+      expect(result.requestId, 'inspect-7');
+      expect(result.feature?.id, 'ad/card');
     });
 
     test('inspectPointResult carries null when nothing was found there', () {
-      final decoded = _roundTrip(const InspectPointResultMessage(null));
-      expect((decoded as InspectPointResultMessage).feature, isNull);
+      final decoded =
+          _roundTrip(const InspectPointResultMessage(requestId: 'inspect-7'));
+      final result = decoded as InspectPointResultMessage;
+      expect(result.requestId, 'inspect-7');
+      expect(result.feature, isNull);
     });
 
     test('sessionChanged carries the session', () {

--- a/packages/dartway_telegram/pubspec.yaml
+++ b/packages/dartway_telegram/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.3.0
+  dartway_flutter: ^0.4.0
   telegram_web_app: ^0.3.3
 
 dev_dependencies:

--- a/template/dartway_starter_flutter/ios/Flutter/Debug.xcconfig
+++ b/template/dartway_starter_flutter/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/template/dartway_starter_flutter/ios/Flutter/Release.xcconfig
+++ b/template/dartway_starter_flutter/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/template/dartway_starter_flutter/ios/Podfile
+++ b/template/dartway_starter_flutter/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/template/dartway_starter_flutter/lib/studio/studio_bridge_binding.dart
+++ b/template/dartway_starter_flutter/lib/studio/studio_bridge_binding.dart
@@ -12,9 +12,7 @@ import 'logic/studio_session_state_provider.dart';
 /// The project wiring point between the app's semantic layer and the bridge:
 /// features are discovered from mounted [DwFeature] widgets and mapped onto
 /// the bridge wire model.
-List<StudioFeatureInfo> _mountedFeatureInfos() => [
-  for (final feature in DwFeature.scanMounted())
-    StudioFeatureInfo(
+StudioFeatureInfo _toWireModel(DwFeatureSpec feature) => StudioFeatureInfo(
       id: feature.id,
       title: feature.title,
       purpose: feature.purpose,
@@ -22,8 +20,29 @@ List<StudioFeatureInfo> _mountedFeatureInfos() => [
       requirements: feature.requirements,
       implementationNotes: feature.implementationNotes,
       knownIssues: feature.knownIssues,
+    );
+
+List<StudioFeatureInfo> _mountedFeatureInfos() =>
+    [for (final feature in DwFeature.scanMounted()) _toWireModel(feature)];
+
+/// Answers Studio's "pencil" tap-to-inspect flow: the point arrives as
+/// fractions of this app's own logical viewport, converted here (not by
+/// Studio, which only knows how it is displaying the preview, framed or
+/// scaled) into an [Offset] [DwFeature.hitTest] can use.
+StudioFeatureInfo? _featureAtPoint(
+  double horizontalFraction,
+  double verticalFraction,
+) {
+  final view = WidgetsBinding.instance.platformDispatcher.views.first;
+  final logicalSize = view.physicalSize / view.devicePixelRatio;
+  final feature = DwFeature.hitTest(
+    Offset(
+      horizontalFraction * logicalSize.width,
+      verticalFraction * logicalSize.height,
     ),
-];
+  );
+  return feature == null ? null : _toWireModel(feature);
+}
 
 /// Connects the app to DartWay Studio when it runs embedded in the Studio
 /// preview frame: attaches the bridge host, reports route/session changes and
@@ -80,6 +99,7 @@ class _StudioBridgeBindingState extends ConsumerState<StudioBridgeBinding>
       validateAccessKey: studioHashAccessValidator(
         const String.fromEnvironment('STUDIO_KEY_HASH'),
       ),
+      inspectPoint: _featureAtPoint,
     );
     if (_host == null) return;
 

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -262,7 +262,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -284,21 +284,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.2.3"
+    version: "0.3.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.2.3"
+    version: "0.3.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.2.3"
+    version: "0.3.0"
   dartway_starter_client:
     dependency: "direct main"
     description:
@@ -312,7 +312,7 @@ packages:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dbus:
     dependency: transitive
     description:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -262,7 +262,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -312,7 +312,7 @@ packages:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.6.0"
   dbus:
     dependency: transitive
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -38,13 +38,13 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.3.0
+  dartway_flutter: ^0.4.0
 
   dartway_router: ^1.1.1
 
   dartway_serverpod_core_flutter: ^0.3.0
 
-  dartway_studio_bridge: ^0.5.0
+  dartway_studio_bridge: ^0.6.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/toolkit/setup-claude.sh
+++ b/toolkit/setup-claude.sh
@@ -94,13 +94,15 @@ cp -r "$SRC/commands/." .claude/commands/
 cp "$SRC/CLAUDE.md" .claude/CLAUDE.md
 
 find .claude/skills/dartway-* .claude/commands/commit.md .claude/commands/dartway-audit.md .claude/CLAUDE.md -type f -name '*.md' -print0 | while IFS= read -r -d '' f; do
-  sed -i \
+  # Через временный файл, а не `sed -i`: у BSD sed (macOS) `-i` требует аргумент-суффикс,
+  # и `-i -e` там съедает первое выражение — установщик падает на маках.
+  sed \
     -e "s/__SERVER_PKG__/$SERVER_PKG/g" \
     -e "s/__FLUTTER_PKG__/$FLUTTER_PKG/g" \
     -e "s/__CLIENT_PKG__/$CLIENT_PKG/g" \
     -e "s/__SHARED_PKG__/$SHARED_PKG/g" \
     -e "s/__BASE_BRANCH__/$BASE_BRANCH/g" \
-    "$f"
+    "$f" > "$f.tmp" && mv "$f.tmp" "$f"
 done
 
 echo "Готово: .claude/CLAUDE.md, .claude/skills и .claude/commands установлены с подстановками."


### PR DESCRIPTION
Studio can point at a spot in the live preview and get the feature declared there — a passport reachable by pointing instead of by knowing the feature's id.

## The wire format

Two new messages, `inspectPointRequest` / `inspectPointResult`:

```jsonc
// Studio → app
{ "type": "inspectPointRequest",
  "payload": { "requestId": "inspect-3", "horizontalFraction": 0.42, "verticalFraction": 0.65 } }

// app → Studio
{ "type": "inspectPointResult",
  "payload": { "requestId": "inspect-3", "feature": { /* StudioFeatureInfo, omitted when nothing is there */ } } }
```

**Fractions, not pixels.** Studio shows the preview scaled, framed or letterboxed, and only the app knows its own logical size — so the app converts, once, on its side.

**The request id is not decoration.** Inspect is the first bridge message that can be in flight twice: a second tap while a slow first one is still being answered. Without correlation the late answer to the first tap resolves the second, and Studio shows a confidently wrong passport — worse than showing nothing. Abandoned requests are forgotten, so their answers are dropped rather than reused.

**Silence is always a miss, never a hang.** An app too old to know the message never answers, and the caller's timeout reads that as "nothing declared here". An app whose `inspectPoint` throws still answers (with nothing) and reports the error through `FlutterError.reportError` — otherwise a crash would be indistinguishable from an empty spot, at the cost of Studio's full timeout.

## The app side

`DwFeature.hitTest(globalPosition)` — the counterpart to `scanMounted`: what is declared *here*, rather than what is declared on this screen.

The innermost declaration wins: a card and the "more actions" row inside it both cover the tap, and the row is what the finger landed on.

A feature is matched on the area it actually **paints** into, not the one it lays out in — the two differ more often than they sound like they would. A subtree under `Transform.scale` draws smaller than it measures; a list item scrolled past the edge of its viewport keeps its layout position while painting nothing, and being deeper in the tree would have beaten the feature you can actually see. Both are cut out by transforming through to the root and intersecting with every ancestor clip.

## Law of synchronisation

- `example/` and `template/` both answer inspect requests (the example is the reference integration the docs point at).
- `docs/6-studio/studio-bridge.md` and the package README describe the flow.
- CHANGELOG + minor bump: `dartway_flutter` 0.4.0, `dartway_studio_bridge` 0.6.0; dependents' constraints and lockfiles follow.

**The other side of the contract is not in this repo.** `dartway/dartway_studio` has no `inspectPoint` caller yet — the bridge is ready, the Studio UI that uses it is a separate change there.

## Also in here (unrelated to the feature)

- `toolkit/setup-claude.sh`: BSD `sed` (macOS) needs an argument after `-i`, so the installer failed on Macs — it now writes through a temp file.
- `template/.../ios/Podfile` and the two xcconfig `#include?` lines: standard CocoaPods files, previously missing from the template.

## Verification

`flutter analyze` clean and tests green in `dartway_flutter` (28) and `dartway_studio_bridge` (49); `analyze` also clean in `template/` and `example/`. `framework-finish` reports no desync.
