### PR TITLE
feat(core): the signed-in profile is the framework's provider, not every project's

### DIFF
--- a/docs/3-flutter/data-layer.md
+++ b/docs/3-flutter/data-layer.md
@@ -60,6 +60,32 @@ callback or an action; `ref.refresh(provider.future)` discards and refetches. Th
 `ref.read(dwGlobalRefreshStateProvider.notifier).refresh()` rebuilds all of them at once. That is a
 last resort, not an everyday tool.
 
+### The signed-in profile is not one of these reads
+
+The current user is a special source, not a row you fetch by id. It arrives with the session and is
+kept up to date by it, so it has its own pair of providers on `dw` — never
+`dw.repo.model<UserProfile>(...)`:
+
+```dart
+// UserProfile? — signed out is a legal answer: splash, router guards, the auth zone
+ref.watch(dw.userProfileProvider)
+
+// UserProfile — non-nullable, for anything drawn under DwUserAsyncScope
+ref.watch(dw.requireUserProfileProvider)
+ref.watch(dw.requireUserProfileProvider.select((p) => p.firstName))
+```
+
+The split is the same one as `maybeModel` vs `model`, for the same reason: `require` throws a
+`StateError` when nobody is signed in, because on an authenticated screen that is a wiring mistake
+and not a state to render.
+
+Both are typed by the profile model you gave `DwCore<Client, UserProfile>`, so your own model comes
+out of them without a provider of your own. `dartway create` still scaffolds
+`lib/core/user_profile_provider.dart` on top — `ref.watchUserProfile` / `ref.readUserProfile`, two
+getters over `requireUserProfileProvider`, because Dart has no generic getters and the framework
+cannot name your model in an extension on `Ref`. They are shorthand, not the source: delete the file
+and the providers still work.
+
 ## Rendering a list
 
 An `AsyncValue` has three branches, and writing `when(loading:, error:, data:)` in every feature is

--- a/example/dartway_example_flutter/lib/core/router/app_router_state.dart
+++ b/example/dartway_example_flutter/lib/core/router/app_router_state.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../user_profile_provider.dart';
+import '../dw_core.dart';
 import '../user_profile_roles.dart';
 
 /// True once a user profile is loaded (i.e. signed in).
 final isSignedInProvider = Provider<bool>((ref) {
-  return ref.watch(userProfileProvider) != null;
+  return ref.watch(dw.userProfileProvider) != null;
 });
 
 /// True when the signed-in user is a club admin — gates the `/admin` zone.
 final isAdminProvider = Provider<bool>((ref) {
-  return ref.watch(userProfileProvider)?.isClubAdmin ?? false;
+  return ref.watch(dw.userProfileProvider)?.isClubAdmin ?? false;
 });
 
 /// Refresh listenable for the DartWay router. Tracks sign-in and admin state and

--- a/example/dartway_example_flutter/lib/core/studio/logic/studio_session_state_provider.dart
+++ b/example/dartway_example_flutter/lib/core/studio/logic/studio_session_state_provider.dart
@@ -1,14 +1,14 @@
 import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../user_profile_provider.dart';
+import '../../dw_core.dart';
 import 'studio_persona_switcher.dart';
 
 /// The session as reported to Studio: signed-in state, who it is (by phone —
 /// Studio matches it against its configured personas) and whether a requested
 /// sign-in is in flight.
 final studioSessionStateProvider = Provider<StudioSessionState>((ref) {
-  final profile = ref.watch(userProfileProvider);
+  final profile = ref.watch(dw.userProfileProvider);
   final isBusy = ref.watch(studioPersonaSwitcherProvider);
 
   if (profile == null) {

--- a/example/dartway_example_flutter/lib/core/user_profile_provider.dart
+++ b/example/dartway_example_flutter/lib/core/user_profile_provider.dart
@@ -1,26 +1,24 @@
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:dartway_example_client/dartway_example_client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'dw_core.dart';
 
-/// Currently signed-in profile, derived from the DartWay session.
-/// `null` while signed out or before the session is initialized.
-final userProfileProvider = Provider<UserProfile?>((ref) {
-  final session = dw.sessionProvider;
-  if (session == null) return null;
-  return ref.watch(session).signedInUserProfile;
-});
-
+/// Shorthand for the framework's profile providers. `dw` is typed with this
+/// project's [UserProfile], so `dw.requireUserProfileProvider` already returns
+/// it — these getters only spare you the `ref.watch(...)` around it.
+///
+/// Both throw when nobody is signed in: use them under an authenticated
+/// subtree (`DwUserAsyncScope`). Where the user may be signed out, read
+/// `dw.userProfileProvider`; to rebuild on one field only, watch
+/// `dw.requireUserProfileProvider.select(...)` directly.
 extension UserProfileWidgetRefExtension on WidgetRef {
-  /// Non-null current profile. Only use inside an authenticated subtree
-  /// (e.g. under [DwUserAsyncScope]); throws if no user is signed in.
-  UserProfile get watchUserProfile => watch(userProfileProvider)!;
+  UserProfile get watchUserProfile => watch(dw.requireUserProfileProvider);
 
-  UserProfile get readUserProfile => read(userProfileProvider)!;
+  UserProfile get readUserProfile => read(dw.requireUserProfileProvider);
 }
 
 extension UserProfileRefExtension on Ref {
-  UserProfile get watchUserProfile => watch(userProfileProvider)!;
+  UserProfile get watchUserProfile => watch(dw.requireUserProfileProvider);
 
-  UserProfile get readUserProfile => read(userProfileProvider)!;
+  UserProfile get readUserProfile => read(dw.requireUserProfileProvider);
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -140,6 +140,25 @@ wrote its first future call rather than the day it upgraded. The barrel now hide
 lost: the core arms its own jobs through `DwRecurringJobs.startAll`. If an app worked around this
 with a `hide` of its own, the workaround can go.
 
+**The signed-in profile is a framework provider now: `dw.userProfileProvider` and
+`dw.requireUserProfileProvider`.** The core knew the signed-in id (`watchSignedInUserId`) but stopped
+short of the profile itself, so every project wrote the same derived provider over
+`sessionProvider` — with the same null-guard for the case where the app runs without an auth key
+manager, and the same `!` at each reading. It never needed to be the project's: `DwCore` is generic
+over the profile model, so a provider declared on it comes out typed as the app's own `UserProfile`.
+
+The pair splits the way `maybeModel` and `model` do. `userProfileProvider` returns `UserProfile?` —
+signed out is a legal answer for a splash, a router guard, the auth zone. `requireUserProfileProvider`
+returns a non-nullable profile and throws a `StateError` naming `DwUserAsyncScope` when nobody is
+signed in, because under an authenticated subtree that is a wiring mistake, not a state to render.
+Being non-nullable it also makes `.select` usable — `requireUserProfileProvider.select((p) => p.name)`
+rebuilds on one field, which a `UserProfile?` provider cannot express.
+
+Nothing breaks: a project's own provider keeps working. What `dartway create` scaffolds shrinks to
+the two getters `ref.watchUserProfile` / `ref.readUserProfile` over the framework provider — they
+stay in the project because Dart has no generic getters, and an extension on `Ref` inside the package
+cannot name your profile model.
+
 ## 0.2.3
 
 Moves to `dartway_flutter` 0.2.0, whose `DwFeatureSpec` dropped `description` for the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/example/README.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/example/README.md
@@ -82,7 +82,8 @@ AppButton.primary(
 
 (`AppButton` is the app's own kit widget — DartWay ships no design system; `dartway create`
 scaffolds the kit into `lib/ui_kit/` as source you own. `myProfileId` is the signed-in profile:
-the session service holds it, and apps usually expose it as a one-line provider — see
+it comes from `dw.requireUserProfileProvider`, typed with the profile model you gave `DwCore`, and
+apps usually wrap it in the `ref.watchUserProfile` getter — see
 `lib/core/user_profile_provider.dart` in the example app.)
 
 If the session is full, `validateSave` on the server rejects the write and its message

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/app/session/state/dw_user_profile_providers.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/app/session/state/dw_user_profile_providers.dart
@@ -1,0 +1,43 @@
+import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+
+import '../domain/dw_session_state_model.dart';
+
+/// The profile pair `DwCore` hands out as `dw.userProfileProvider` and
+/// `dw.requireUserProfileProvider`.
+///
+/// Held apart from `DwCore` because all these providers need from a session is
+/// something listenable carrying a [DwSessionStateModel] — which lets them be
+/// built over a stand-in, and a core that admits only one instance per process
+/// leaves no other way to exercise them.
+class DwUserProfileProviders<UserProfileClass extends SerializableModel> {
+  /// [_sessionProvider] is `null` when the app runs without an auth key
+  /// manager: then nobody is ever signed in, and that is not an error.
+  DwUserProfileProviders(this._sessionProvider);
+
+  final ProviderListenable<DwSessionStateModel<UserProfileClass>>?
+  _sessionProvider;
+
+  late final Provider<UserProfileClass?> userProfile =
+      Provider<UserProfileClass?>((ref) {
+        final sessionProvider = _sessionProvider;
+        if (sessionProvider == null) return null;
+        return ref.watch(
+          sessionProvider.select((state) => state.signedInUserProfile),
+        );
+      });
+
+  late final Provider<UserProfileClass> requireUserProfile =
+      Provider<UserProfileClass>((ref) {
+        final signedInUserProfile = ref.watch(userProfile);
+        if (signedInUserProfile == null) {
+          throw StateError(
+            'No signed-in user profile. dw.requireUserProfileProvider is only '
+            'valid under an authenticated subtree (DwUserAsyncScope); where '
+            'the user may be signed out, read dw.userProfileProvider instead.',
+          );
+        }
+        return signedInUserProfile;
+      });
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/core/dw_core.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../app/session/domain/dw_session_state_model.dart';
 import '../app/session/service/dw_session_service.dart';
 import '../app/session/state/dw_session_state_notifier.dart';
+import '../app/session/state/dw_user_profile_providers.dart';
 import '../app/socket/service/dw_socket_service.dart';
 import '../private/dw_singleton.dart';
 import '../repository/dw_repository.dart';
@@ -28,6 +29,34 @@ class DwCore<
     DwSessionStateModel<UserProfileClass>
   >?
   sessionProvider;
+
+  /// Built on first read rather than in the constructor: an app that never asks
+  /// for the profile never gets the providers. [sessionProvider] is assigned by
+  /// then — the constructor has to have finished for anyone to reach this.
+  late final DwUserProfileProviders<UserProfileClass> _userProfileProviders =
+      DwUserProfileProviders<UserProfileClass>(sessionProvider);
+
+  /// The signed-in profile, or `null` while signed out, before the session is
+  /// initialized, or when the app runs without an auth key manager at all.
+  ///
+  /// Typed by this core's `UserProfileClass`, so an app reads its own model out
+  /// of it without declaring a provider of its own. Use it where the user may
+  /// legitimately be absent — a splash screen, a router guard, the auth zone.
+  /// Under an authenticated subtree reach for [requireUserProfileProvider]
+  /// instead and stop writing `!`.
+  Provider<UserProfileClass?> get userProfileProvider =>
+      _userProfileProviders.userProfile;
+
+  /// The signed-in profile as a non-nullable value, for everything drawn under
+  /// an authenticated subtree (see `DwUserAsyncScope`).
+  ///
+  /// Throws when nobody is signed in — that is a wiring mistake, not a state to
+  /// render, and the message says where to look. (A [StateError], reaching the
+  /// reader inside Riverpod's own `ProviderException`.) Being non-nullable it
+  /// also makes `.select` usable:
+  /// `ref.watch(dw.requireUserProfileProvider.select((p) => p.name))`.
+  Provider<UserProfileClass> get requireUserProfileProvider =>
+      _userProfileProviders.requireUserProfile;
 
   late final dartway.Caller endpointCaller;
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_user_profile_providers_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_user_profile_providers_test.dart
@@ -1,0 +1,100 @@
+import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart';
+import 'package:dartway_serverpod_core_flutter/src/app/session/domain/dw_session_state_model.dart';
+import 'package:dartway_serverpod_core_flutter/src/app/session/state/dw_user_profile_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('userProfile', () {
+    test('follows the session in and out', () {
+      final providers = DwUserProfileProviders<_FakeProfile>(_session);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      // Nothing is watching yet, so the pair has to see the state the session
+      // is already in — a profile loaded before the first widget builds.
+      container.read(_session.notifier).signIn(_FakeProfile(1));
+
+      expect(container.read(providers.userProfile)?.id, 1);
+      expect(container.read(providers.requireUserProfile).id, 1);
+
+      container.read(_session.notifier).signOut();
+
+      expect(container.read(providers.userProfile), isNull);
+    });
+
+    test('is null when the app runs without an auth key manager', () {
+      // sessionProvider is null in that case, and nobody is ever signed in.
+      final providers = DwUserProfileProviders<_FakeProfile>(null);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(providers.userProfile), isNull);
+    });
+  });
+
+  group('requireUserProfile', () {
+    test('throws with a message pointing at the scope when signed out', () {
+      final providers = DwUserProfileProviders<_FakeProfile>(_session);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Riverpod 3 rethrows what a provider threw wrapped in a
+      // ProviderException, so the assertion is on the message reaching the
+      // developer, not on the exception type.
+      expect(
+        () => container.read(providers.requireUserProfile),
+        throwsA(
+          isA<Object>().having(
+            (error) => error.toString(),
+            'toString',
+            allOf(
+              contains('DwUserAsyncScope'),
+              contains('dw.userProfileProvider'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('recovers once a user signs in', () {
+      final providers = DwUserProfileProviders<_FakeProfile>(_session);
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(() => container.read(providers.requireUserProfile), throwsA(anything));
+
+      container.read(_session.notifier).signIn(_FakeProfile(7));
+
+      expect(container.read(providers.requireUserProfile).id, 7);
+    });
+  });
+}
+
+final _session =
+    NotifierProvider<_SessionStub, DwSessionStateModel<_FakeProfile>>(
+      _SessionStub.new,
+    );
+
+/// Stands in for `dw.sessionProvider`: the profile pair only ever listens to
+/// the state it carries.
+class _SessionStub extends Notifier<DwSessionStateModel<_FakeProfile>> {
+  @override
+  DwSessionStateModel<_FakeProfile> build() =>
+      const DwSessionStateModel<_FakeProfile>();
+
+  void signIn(_FakeProfile profile) => state = DwSessionStateModel(
+    signedInUserProfile: profile,
+    signedInUserId: profile.id,
+  );
+
+  void signOut() => state = const DwSessionStateModel<_FakeProfile>();
+}
+
+class _FakeProfile implements SerializableModel {
+  _FakeProfile(this.id);
+
+  final int id;
+
+  @override
+  Map<String, dynamic> toJson() => {'id': id};
+}

--- a/template/dartway_starter_flutter/lib/core/router/app_router_state.dart
+++ b/template/dartway_starter_flutter/lib/core/router/app_router_state.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../user_profile_provider.dart';
+import '../dw_core.dart';
 import '../user_profile_roles.dart';
 
 /// True once a user profile is loaded (i.e. signed in).
 final isSignedInProvider = Provider<bool>((ref) {
-  return ref.watch(userProfileProvider) != null;
+  return ref.watch(dw.userProfileProvider) != null;
 });
 
 /// True when the signed-in user is an admin — gates the `/admin` zone.
 final isAdminProvider = Provider<bool>((ref) {
-  return ref.watch(userProfileProvider)?.isAdmin ?? false;
+  return ref.watch(dw.userProfileProvider)?.isAdmin ?? false;
 });
 
 /// Refresh listenable for the DartWay router. Tracks sign-in and admin state and

--- a/template/dartway_starter_flutter/lib/core/studio/logic/studio_session_state_provider.dart
+++ b/template/dartway_starter_flutter/lib/core/studio/logic/studio_session_state_provider.dart
@@ -1,14 +1,14 @@
 import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../user_profile_provider.dart';
+import '../../dw_core.dart';
 import 'studio_persona_switcher.dart';
 
 /// The session as reported to Studio: signed-in state, who it is (by phone —
 /// Studio matches it against its configured personas) and whether a requested
 /// sign-in is in flight.
 final studioSessionStateProvider = Provider<StudioSessionState>((ref) {
-  final profile = ref.watch(userProfileProvider);
+  final profile = ref.watch(dw.userProfileProvider);
   final isBusy = ref.watch(studioPersonaSwitcherProvider);
 
   if (profile == null) {

--- a/template/dartway_starter_flutter/lib/core/user_profile_provider.dart
+++ b/template/dartway_starter_flutter/lib/core/user_profile_provider.dart
@@ -1,26 +1,24 @@
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:dartway_starter_client/dartway_starter_client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'dw_core.dart';
 
-/// Currently signed-in profile, derived from the DartWay session.
-/// `null` while signed out or before the session is initialized.
-final userProfileProvider = Provider<UserProfile?>((ref) {
-  final session = dw.sessionProvider;
-  if (session == null) return null;
-  return ref.watch(session).signedInUserProfile;
-});
-
+/// Shorthand for the framework's profile providers. `dw` is typed with this
+/// project's [UserProfile], so `dw.requireUserProfileProvider` already returns
+/// it — these getters only spare you the `ref.watch(...)` around it.
+///
+/// Both throw when nobody is signed in: use them under an authenticated
+/// subtree (`DwUserAsyncScope`). Where the user may be signed out, read
+/// `dw.userProfileProvider`; to rebuild on one field only, watch
+/// `dw.requireUserProfileProvider.select(...)` directly.
 extension UserProfileWidgetRefExtension on WidgetRef {
-  /// Non-null current profile. Only use inside an authenticated subtree
-  /// (e.g. under [DwUserAsyncScope]); throws if no user is signed in.
-  UserProfile get watchUserProfile => watch(userProfileProvider)!;
+  UserProfile get watchUserProfile => watch(dw.requireUserProfileProvider);
 
-  UserProfile get readUserProfile => read(userProfileProvider)!;
+  UserProfile get readUserProfile => read(dw.requireUserProfileProvider);
 }
 
 extension UserProfileRefExtension on Ref {
-  UserProfile get watchUserProfile => watch(userProfileProvider)!;
+  UserProfile get watchUserProfile => watch(dw.requireUserProfileProvider);
 
-  UserProfile get readUserProfile => read(userProfileProvider)!;
+  UserProfile get readUserProfile => read(dw.requireUserProfileProvider);
 }

--- a/toolkit/skills/dartway-clean-code/SKILL.md
+++ b/toolkit/skills/dartway-clean-code/SKILL.md
@@ -541,7 +541,7 @@ final authService = ref.read(authServiceProvider); // -> FirebaseAuthService und
 ```dart
 // ❌ initState() { userName = GlobalAppState.userName; }  save() { GlobalAppState.userName = userName; }
 // ✅ the widget reads and writes directly through the provider — one source of truth
-final userName = ref.watch(userProfileProvider.select((p) => p.name));
+final userName = ref.watch(dw.requireUserProfileProvider.select((p) => p.name));
 ```
 
 ---

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -261,8 +261,6 @@ dw.notify.info('Upload started');
 
 **Why:** the current profile is a special source, not an ordinary model. Don't pull it through `watchModel<UserProfile>()`.
 
-**These getters are the project's, not the framework's.** `dartway create` scaffolds them into `__FLUTTER_PKG__/lib/core/user_profile_provider.dart`, because the framework does not know your profile model — it only knows the signed-in id (`watchSignedInUserId` / `readSignedInUserId`). So don't look for `watchUserProfile` in the packages, and don't remove the file it lives in.
-
 ```dart
 // ❌ the profile through ordinary CRUD
 final me = ref.watch(dw.repo.model<UserProfile>(...));
@@ -270,6 +268,19 @@ final me = ref.watch(dw.repo.model<UserProfile>(...));
 // ✅ special getters (no parentheses!) — they return UserProfile directly
 final isMine = post.authorProfileId == ref.watchUserProfile.id;   // reactive
 final myId   = ref.readUserProfile.id;                            // one-off
+```
+
+**The providers underneath are the framework's, the getters are the project's.** `dw` carries a pair, already typed with your profile model:
+
+- `dw.userProfileProvider` → `UserProfile?` — where signed out is a legal answer: router guards, the auth zone, a splash;
+- `dw.requireUserProfileProvider` → `UserProfile` — everything under `DwUserAsyncScope`; throws a `StateError` when nobody is signed in.
+
+The getters above are two lines of shorthand over the second one, scaffolded by `dartway create` into `__FLUTTER_PKG__/lib/core/user_profile_provider.dart` (Dart has no generic getters, so the framework cannot name your model in an extension on `Ref`). Don't delete that file — but don't reimplement the providers in it either.
+
+Reach for the provider directly in two cases: the user may be signed out, or you want to rebuild on one field only —
+
+```dart
+final name = ref.watch(dw.requireUserProfileProvider.select((p) => p.firstName));
 ```
 
 ## 7. Sign-out — through `sessionProvider`
@@ -372,7 +383,7 @@ Neighbouring forms: `pickAndUploadImage()` (returns a `DwCloudFile` with size an
 - [ ] Narrowing by query — `backendFilter`; local filtering you do yourself with `.where` in the widget (the framework doesn't provide it).
 - [ ] Actions from the UI — `dw.action((context) async {...})`, not a raw `onPressed`/`() async {}`.
 - [ ] Notifications — `dw.notify.success/warning/error/info`, not `SnackBar`/`ScaffoldMessenger`.
-- [ ] Profile — `ref.watchUserProfile`/`readUserProfile` (getters), not `watchModel<UserProfile>()`.
+- [ ] Profile — `ref.watchUserProfile`/`readUserProfile` (getters), not `watchModel<UserProfile>()`. Signed out is a legal answer, or you want `.select` — `dw.userProfileProvider` / `dw.requireUserProfileProvider`.
 - [ ] Sign-out — `ref.read(dw.sessionProvider!.notifier).signOut()`.
 - [ ] Must **another** user see the update? `dw.repo.modelList` doesn't do that by itself — `broadcastTo` in the config (public), a channel with the group id (group), `sendUpdatesToUser` (private).
 - [ ] Putting `broadcastTo` with a public channel — have you answered "any user is entitled to read this row"? If not — a narrower channel or `sendUpdatesToUser`.


### PR DESCRIPTION
Every project on the framework rewrote the same derived provider over `sessionProvider` — same null-guard for the app that runs without an auth key manager, same `!` at each reading. It never needed to be the project's: `DwCore` is generic over the profile model, so a provider declared on it comes out typed as the app's own `UserProfile`.

## The pair

Split the way `maybeModel` and `model` are:

- **`dw.userProfileProvider`** → `UserProfile?`. Signed out is a legal answer — a splash, a router guard, the auth zone.
- **`dw.requireUserProfileProvider`** → `UserProfile`. Throws a `StateError` naming `DwUserAsyncScope`, because under an authenticated subtree an absent profile is a wiring mistake, not a state to render.

Being non-nullable, the second also makes `.select` usable — `requireUserProfileProvider.select((p) => p.name)` rebuilds on one field, which a nullable provider cannot express. The clean-code skill had been teaching exactly that call over a nullable provider, where it does not compile; fixed here.

## What projects keep

Nothing breaks — a project holding on to its own provider is unaffected. What `example` and `template` scaffold shrinks to the two getters `ref.watchUserProfile` / `readUserProfile` over the framework provider. Those stay in the project because Dart has no generic getters: an extension on `Ref` inside the package cannot name the app's model.

## Shape

The pair lives in a `DwUserProfileProviders` of its own rather than inline in the constructor. All it needs from a session is something listenable carrying a `DwSessionStateModel`, so it can be built over a stand-in — the only way to test it at all, `DwCore` admitting one instance per process. Everything is `late final` with an initializer: an app that never asks for the profile never builds the providers.

## Synchronisation

`example`, `template`, `docs/3-flutter/data-layer.md` (a section next to `model`/`maybeModel`, where the same fork is explained), `dartway-data-layer` §6 and its checklist, `dartway-clean-code`, the package README and CHANGELOG 0.3.0.

## Verification

`dart analyze` over core_flutter, example and template — clean. 33 tests in core_flutter green, four of them new: reactivity in and out of a session, the no-auth-key-manager case, and the error message surviving Riverpod 3's `ProviderException` wrapping.

Not run: the app end to end (server + database). Compilation and unit tests only.

Studio consumes this from its own repository — it can drop its local `userProfileProvider` once it moves to this version of `dartway_serverpod_core_flutter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
