### PR TITLE
chore(release): core 0.4.0 and CLI 0.3.0, so that dartway create resolves again

### DIFF
--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0
 
 - **The deploy now supplies the web build's API address, and the template ships the two Dockerfiles
   the compose file has always named.** The rendered compose file builds `<project>_server/Dockerfile`

--- a/packages/dartway_cli/pubspec.yaml
+++ b/packages/dartway_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_cli
 description: "DartWay command-line tool: print the agent setup brief, check prerequisites, create projects from the canonical template, install the AI toolkit, run convention checks."
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_server: ^0.3.0
+  dartway_serverpod_core_server: ^0.4.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.4.0 is the
+Flutter side gaining `dw.userProfileProvider` / `dw.requireUserProfileProvider` — see the changelog
+of `dartway_serverpod_core_flutter`. Nothing in this package changed.
+
 ## 0.3.0
 
 **Generic CRUD is closed to anonymous callers by default.** `DwCrudEndpoint` never overrode

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.4.0
+
+**The signed-in profile is a framework provider now: `dw.userProfileProvider` and
+`dw.requireUserProfileProvider`.** The core knew the signed-in id (`watchSignedInUserId`) but stopped
+short of the profile itself, so every project wrote the same derived provider over
+`sessionProvider` — with the same null-guard for the case where the app runs without an auth key
+manager, and the same `!` at each reading. It never needed to be the project's: `DwCore` is generic
+over the profile model, so a provider declared on it comes out typed as the app's own `UserProfile`.
+
+The pair splits the way `maybeModel` and `model` do. `userProfileProvider` returns `UserProfile?` —
+signed out is a legal answer for a splash, a router guard, the auth zone. `requireUserProfileProvider`
+returns a non-nullable profile and throws a `StateError` naming `DwUserAsyncScope` when nobody is
+signed in, because under an authenticated subtree that is a wiring mistake, not a state to render.
+Being non-nullable it also makes `.select` usable — `requireUserProfileProvider.select((p) => p.name)`
+rebuilds on one field, which a `UserProfile?` provider cannot express.
+
+Nothing breaks: a project's own provider keeps working. What `dartway create` scaffolds shrinks to
+the two getters `ref.watchUserProfile` / `ref.readUserProfile` over the framework provider — they
+stay in the project because Dart has no generic getters, and an extension on `Ref` inside the package
+cannot name your profile model.
+
 ## 0.3.0
 
 **Generic CRUD is closed to anonymous callers by default.** `DwCrudEndpoint` never overrode
@@ -139,25 +160,6 @@ with `ambiguous_extension_member_access` — on the app's line, in the app's fil
 wrote its first future call rather than the day it upgraded. The barrel now hides it. Nothing is
 lost: the core arms its own jobs through `DwRecurringJobs.startAll`. If an app worked around this
 with a `hide` of its own, the workaround can go.
-
-**The signed-in profile is a framework provider now: `dw.userProfileProvider` and
-`dw.requireUserProfileProvider`.** The core knew the signed-in id (`watchSignedInUserId`) but stopped
-short of the profile itself, so every project wrote the same derived provider over
-`sessionProvider` — with the same null-guard for the case where the app runs without an auth key
-manager, and the same `!` at each reading. It never needed to be the project's: `DwCore` is generic
-over the profile model, so a provider declared on it comes out typed as the app's own `UserProfile`.
-
-The pair splits the way `maybeModel` and `model` do. `userProfileProvider` returns `UserProfile?` —
-signed out is a legal answer for a splash, a router guard, the auth zone. `requireUserProfileProvider`
-returns a non-nullable profile and throws a `StateError` naming `DwUserAsyncScope` when nobody is
-signed in, because under an authenticated subtree that is a wiring mistake, not a state to render.
-Being non-nullable it also makes `.select` usable — `requireUserProfileProvider.select((p) => p.name)`
-rebuilds on one field, which a `UserProfile?` provider cannot express.
-
-Nothing breaks: a project's own provider keeps working. What `dartway create` scaffolds shrinks to
-the two getters `ref.watchUserProfile` / `ref.readUserProfile` over the framework provider — they
-stay in the project because Dart has no generic getters, and an extension on `Ref` inside the package
-cannot name your profile model.
 
 ## 0.2.3
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -19,8 +19,8 @@ dependencies:
   serverpod_client: ^3.4.11
 
   dartway_flutter: ^0.4.0
-  dartway_serverpod_core_client: ^0.3.0
-  dartway_serverpod_core_shared: ^0.3.0
+  dartway_serverpod_core_client: ^0.4.0
+  dartway_serverpod_core_shared: ^0.4.0
 
   collection: ^1.19.1
   flutter_riverpod: ^3.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.4.0 is the
+Flutter side gaining `dw.userProfileProvider` / `dw.requireUserProfileProvider` — see the changelog
+of `dartway_serverpod_core_flutter`. Nothing in this package changed.
+
 ## 0.3.0
 
 **Generic CRUD is closed to anonymous callers by default.** `DwCrudEndpoint` never overrode

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_shared: ^0.3.0
+  dartway_serverpod_core_shared: ^0.4.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.4.0 is the
+Flutter side gaining `dw.userProfileProvider` / `dw.requireUserProfileProvider` — see the changelog
+of `dartway_serverpod_core_flutter`. Nothing in this package changed.
+
 ## 0.3.0
 
 **Generic CRUD is closed to anonymous callers by default.** `DwCrudEndpoint` never overrode

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/template/dartway_starter_client/pubspec.yaml
+++ b/template/dartway_starter_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.3.0
+  dartway_serverpod_core_client: ^0.4.0
 
 # Inside the monorepo — a local build. `dartway create` removes this block.
 dependency_overrides:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.3.0
+  dartway_serverpod_core_flutter: ^0.4.0
 
   dartway_studio_bridge: ^0.6.0
 
@@ -62,7 +62,7 @@ dev_dependencies:
     sdk: flutter
 
 
-  dartway_cli: ^0.1.0
+  dartway_cli: ^0.3.0
 
   # The UI-kit law is enforced here, not just written down: raw Color/TextStyle/
   # BorderRadius and direct theme access outside `ui_kit/` are lints. Needs

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.3.0
+  dartway_serverpod_core_server: ^0.4.0
 
   http: ^1.5.0
 


### PR DESCRIPTION
`dartway create` currently hands out a project that does not build.

The template calls `dw.userProfileProvider`, which arrived in [#24](https://github.com/dartway/dartway/pull/24), but the four core packages kept version 0.3.0 — the version already on pub.dev, published before that API existed. A project resolving from pub.dev therefore gets a core that has never heard of the provider its own scaffolding uses. The changelog entry for the new API was filed under 0.3.0 too, describing a release that does not contain it. `dartway_lints` has the same shape of problem from the other side: 0.2.0 is in this repository and the template asks for it, while pub.dev has 0.1.1.

- **Core to 0.4.0**, all four in lockstep as they always move. The provider entry moves to a 0.4.0 section in `dartway_serverpod_core_flutter`; the three that only follow along say exactly that.
- **CLI to 0.3.0.** Its Unreleased section has been collecting since 0.2.0 shipped: the top-level layout checker, and the whole deploy story from [#25](https://github.com/dartway/dartway/pull/25).
- **Constraints follow:** template on core `^0.4.0`, and `dartway_cli` `^0.3.0` — it was pinned to `^0.1.0`, below what was already published. The unpublished push server moves to `^0.4.0` so the workspace stays consistent.

Analyze and tests are green (the one warning is pre-existing dead code in serverpod-generated transport). Publication to pub.dev follows this merge, then the promotion to `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)