### PR TITLE
chore: the committed locks record the versions that were just published

### DIFF
--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -255,7 +255,7 @@ packages:
       path: "../../packages/dartway_cli"
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   dartway_example_client:
     dependency: "direct main"
     description:
@@ -298,21 +298,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_studio_bridge:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -255,7 +255,7 @@ packages:
       path: "../../packages/dartway_cli"
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   dartway_flutter:
     dependency: "direct main"
     description:
@@ -284,21 +284,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_starter_client:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Build reproducibility across the monorepo is held by the committed `pubspec.lock` (see Standards in `CLAUDE.md`), and after [#26](https://github.com/dartway/dartway/pull/26) the template's and the example's still named core 0.3.0 and the CLI 0.2.0. Resolving them against the freshly published versions updates four lines in each.

Last step before promoting to `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)