### PR TITLE
fix(check): the checker sees every feature, and stops contradicting its exit code

### DIFF
--- a/docs/5-tooling/conventions-checker.md
+++ b/docs/5-tooling/conventions-checker.md
@@ -62,6 +62,7 @@ commit over a 210-line file is a check people disable.
 | `invalidFeatureStructure` | error | A feature folder with more than one root file |
 | `forbiddenFeatureImport` | error | Reaching into another feature's `widgets/` or `logic/` |
 | `featureSpecMissing` | warning | A feature widget that declares no `DwFeatureSpec` |
+| `notAFeature` | error | A folder in a zone whose entry point declares no widget |
 | `unusedFeatureFile` | warning | A file in `widgets/`/`logic/` that its own feature never mentions |
 | `barrelFile` | error | A file that only re-exports |
 | `widgetSizesItself` | error | `Expanded` or `SizedBox.expand` returned straight from `build` |
@@ -79,10 +80,23 @@ ordinary Flutter and means exactly the same thing — a screen deciding how it l
 file; behaviour a sibling also needs belongs in a feature of its own. A widget with no story of its
 own is not a feature at all — it is a building block, it lives in `lib/shared/`, and the checker
 never asks it for a spec.
-`featureSpecMissing` is checked only when the entry point is a widget — a feature whose entry
-point is an extension or a plain function has nothing to hang a spec on. The spec matters because
-error reports, Studio and the agent all read it: without one the feature exists in the code and
-says nothing about itself.
+**`notAFeature` and `featureSpecMissing` are one rule read from both ends**, and neither works
+alone. A zone holds features: a folder in one whose entry point declares no widget is not a feature
+at all (`notAFeature`), and one that does declare a widget owes a passport (`featureSpecMissing`).
+While only the second existed, a provider-only folder passed *because* it was not a widget — a real
+project accumulated ten of them, every one graded A.
+
+Where they go instead: state that several features watch is wiring, so `lib/core/`; a helper with no
+story of its own is a building block, so `lib/shared/`.
+
+The widget test asks whether a **public class extends anything named `*Widget`**, not whether it
+matches a list of base classes. The list used to be
+`(Stateless|Stateful|Consumer|HookConsumer|Hook)Widget` and silently missed `ConsumerStatefulWidget`
+— what every form and dialog extends, which is to say the features with the most behaviour to
+describe. A list of remembered names goes stale in silence; a shape does not.
+
+The spec matters because error reports, Studio and the agent all read it: without one the feature
+exists in the code and says nothing about itself.
 
 **`unusedFeatureFile`** (warning) is the one check the analyzer structurally cannot replace. A public
 class is always "possibly used from somewhere else" — unless the somewhere else is a finite place,

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.0
+
+- **`dartway check` now sees the features it had been walking past, and stops contradicting its own
+  exit code.** Three findings, one cause: the checker recognised a widget by matching a list of base
+  class names — `(Stateless|Stateful|Consumer|HookConsumer|Hook)Widget` — which silently missed
+  `ConsumerStatefulWidget`, the class every form and dialog extends. It now asks whether a public
+  class extends anything named `*Widget`: a shape rather than a memory. Its twin, the new
+  `notAFeature` (error), closes the other end — a folder in a zone whose entry point declares no
+  widget is not a feature, and belongs in `core/` (state several features watch) or `shared/` (a
+  helper with no story). While only the spec check existed, a provider-only folder passed *because*
+  it was not a widget; a real project had ten of them, every one graded A. Finally, the verdict line
+  moves out of the Flutter inspector and into the command: the inspector knew nothing of the layout
+  check that ran before it, so a run could print two layout errors, announce "No errors — check
+  passes", and exit 1.
+
 ## 0.3.0
 
 - **The deploy now supplies the web build's API address, and the template ships the two Dockerfiles

--- a/packages/dartway_cli/lib/src/checker/dw_check_type.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_check_type.dart
@@ -39,6 +39,16 @@ enum DwCheckType {
   /// reports, Studio and the agent see it as a blank.
   featureSpecMissing,
 
+  /// A folder in a zone whose entry point declares no widget. A zone holds
+  /// features; a provider several features watch is wiring (`core/`), and a
+  /// helper with no story of its own is a building block (`shared/`).
+  ///
+  /// The twin of [featureSpecMissing], and neither works without the other:
+  /// while only widgets were asked for a spec, a folder that was not a widget
+  /// passed *because* it was not one. A real project accumulated ten of them,
+  /// every one graded A.
+  notAFeature,
+
   /// An `assets/...` path that points at no file. Nothing else catches this:
   /// the code compiles and the screen renders a blank where the image was.
   assetPathMissing,

--- a/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
@@ -79,6 +79,11 @@ class DwFlutterInspector {
   final _findings = <_Finding>[];
   final _stats = <DwCheckType, int>{};
 
+  /// The kinds of finding this run made. Exposed for the tests, the same way
+  /// [DwLayoutInspector] exposes its findings: the report is printed, but what
+  /// the rule *said* is the thing worth asserting.
+  Set<DwCheckType> get findingTypes => _stats.keys.toSet();
+
   late final String _packageName = _readPackageName();
 
   String get _libPath => p.join(packageDir.path, 'lib');
@@ -173,7 +178,7 @@ class DwFlutterInspector {
           rel,
         );
       } else {
-        _checkFeatureSpec(node, rel);
+        _checkFeatureEntryPoint(node, rel);
       }
     }
 
@@ -182,19 +187,40 @@ class DwFlutterInspector {
     }
   }
 
-  /// A feature's public widget is expected to declare what the feature is —
-  /// `implements DwFeature` with a `DwFeatureSpec`. Checked only for widgets:
-  /// a feature whose entry point is an extension or a plain function has
-  /// nothing to hang a spec on.
-  void _checkFeatureSpec(DwFeatureNode node, String rel) {
+  /// What a feature's entry point has to be, read from both ends.
+  ///
+  /// A zone holds features and nothing else, so a folder in one whose entry
+  /// point declares no widget is not a feature — and a folder that does declare
+  /// one owes a `DwFeatureSpec`. Those are the same rule, and until both were
+  /// checked each covered for the other's absence: a provider-only folder was
+  /// silently accepted *because* it was not a widget.
+  ///
+  /// The widget test asks whether a **public class extends anything named
+  /// `*Widget`**, rather than matching a list of base classes. The list was
+  /// `(Stateless|Stateful|Consumer|HookConsumer|Hook)Widget` and quietly missed
+  /// `ConsumerStatefulWidget` — the base class of every form and dialog, which
+  /// is to say the features with the most behaviour to describe. A list of
+  /// remembered names goes stale in silence; a shape does not.
+  void _checkFeatureEntryPoint(DwFeatureNode node, String rel) {
     final entry = node.entryFile;
     if (entry == null) return;
 
     final content = entry.readAsStringSync();
-    final isWidget = RegExp(
-      r'extends\s+(Stateless|Stateful|Consumer|HookConsumer|Hook)Widget',
+    final declaresPublicWidget = RegExp(
+      r'class\s+[A-Z]\w*\s+extends\s+\w*Widget\b',
     ).hasMatch(content);
-    if (!isWidget) return;
+
+    if (!declaresPublicWidget) {
+      _add(
+        DwCheckType.notAFeature,
+        '$rel — a zone holds features, and this entry point declares no '
+        'widget. State that several features watch is wiring and belongs in '
+        'lib/core/; a helper with no story of its own is a building block and '
+        'belongs in lib/shared/',
+        rel,
+      );
+      return;
+    }
 
     if (!content.contains('DwFeature')) {
       _add(
@@ -569,15 +595,14 @@ class DwFlutterInspector {
       );
     }
 
-    final errorCount = _stats.entries
+    // The verdict is not printed here. This inspector knows its own findings
+    // and nothing about the layout check that ran before it, and printing
+    // "No errors" from inside it is how the report came to contradict the exit
+    // code: two layout errors on screen, "check passes" underneath, and a
+    // process exiting 1. Whoever counts both says it.
+    return _stats.entries
         .where((entry) => entry.key.severity == DwCheckSeverity.error)
         .fold(0, (sum, entry) => sum + entry.value);
-    if (errorCount > 0) {
-      print('\n🔴 Errors: $errorCount (warnings/infos do not fail the check)');
-    } else {
-      print('\n🟡 No errors — only warnings/infos, check passes');
-    }
-    return errorCount;
   }
 
   void _printNode(

--- a/packages/dartway_cli/lib/src/commands/check_command.dart
+++ b/packages/dartway_cli/lib/src/commands/check_command.dart
@@ -88,6 +88,18 @@ class CheckCommand extends Command<int> {
       targetDirPath: results.option('dir'),
     ).run();
 
+    // Said once, by the only place that has both counts. The Flutter inspector
+    // used to print it from inside itself, knowing nothing of the layout check
+    // that ran first — so a run could show two layout errors and then announce
+    // that the check passes, while exiting 1.
+    if (errorCount > 0) {
+      stdout.writeln(
+        '\n🔴 Errors: $errorCount (warnings/infos do not fail the check)',
+      );
+    } else {
+      stdout.writeln('\n🟡 No errors — only warnings/infos, check passes');
+    }
+
     return errorCount > 0 ? 1 : 0;
   }
 

--- a/packages/dartway_cli/pubspec.yaml
+++ b/packages/dartway_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_cli
 description: "DartWay command-line tool: print the agent setup brief, check prerequisites, create projects from the canonical template, install the AI toolkit, run convention checks."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_cli/test/feature_entry_point_test.dart
+++ b/packages/dartway_cli/test/feature_entry_point_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/checker/dw_check_type.dart';
+import 'package:dartway_cli/src/checker/dw_flutter_inspector.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// What a zone folder's entry point has to be.
+///
+/// Both findings here were written after a real project ran clean while
+/// breaking the rule in ten places. The old widget test matched a list of base
+/// class names, so `ConsumerStatefulWidget` — every form and dialog — was
+/// invisible; and a folder that declared no widget at all passed *because* it
+/// was not a widget. Each gap hid the other.
+void main() {
+  late Directory sandbox;
+
+  setUp(() {
+    sandbox = Directory.systemTemp.createTempSync('dw_feature_entry');
+  });
+
+  tearDown(() {
+    sandbox.deleteSync(recursive: true);
+  });
+
+  /// Writes a one-feature app zone and returns the findings for it.
+  Future<Set<DwCheckType>> checkZoneFeature(String entryPointSource) async {
+    File(p.join(sandbox.path, 'pubspec.yaml'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('name: sandbox_flutter\n');
+
+    File(p.join(sandbox.path, 'lib', 'app', 'thing', 'thing.dart'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(entryPointSource);
+
+    final inspector = DwFlutterInspector(packageDir: sandbox);
+    await inspector.run();
+    return inspector.findingTypes;
+  }
+
+  group('a feature declares a widget, and the widget declares a spec', () {
+    test('a widget with a spec is what the rule wants', () async {
+      final findings = await checkZoneFeature('''
+class ThingPage extends StatelessWidget implements DwFeature {
+  DwFeatureSpec get dwFeature => const DwFeatureSpec(id: 'thing');
+}
+''');
+
+      expect(findings, isNot(contains(DwCheckType.notAFeature)));
+      expect(findings, isNot(contains(DwCheckType.featureSpecMissing)));
+    });
+
+    test('a widget without a spec is asked for one', () async {
+      final findings = await checkZoneFeature('''
+class ThingPage extends StatelessWidget {}
+''');
+
+      expect(findings, contains(DwCheckType.featureSpecMissing));
+    });
+  });
+
+  group('the base class is a shape, not a list of remembered names', () {
+    // The regression this file exists for. `ConsumerStatefulWidget` is what a
+    // feature with a controller or a text field extends, so the check was blind
+    // exactly where a passport says the most.
+    for (final baseClass in [
+      'StatelessWidget',
+      'StatefulWidget',
+      'ConsumerWidget',
+      'ConsumerStatefulWidget',
+      'HookConsumerWidget',
+      'HookWidget',
+    ]) {
+      test('$baseClass without a spec is caught', () async {
+        final findings = await checkZoneFeature('''
+class ThingPage extends $baseClass {}
+''');
+
+        expect(
+          findings,
+          contains(DwCheckType.featureSpecMissing),
+          reason: '$baseClass has to read as a widget',
+        );
+        expect(findings, isNot(contains(DwCheckType.notAFeature)));
+      });
+    }
+  });
+
+  group('a zone folder that declares no widget is not a feature', () {
+    test('a bare provider is reported', () async {
+      final findings = await checkZoneFeature('''
+final thingProvider = Provider<bool>((ref) => false);
+''');
+
+      expect(findings, contains(DwCheckType.notAFeature));
+      // Not both: a folder that is not a feature is not asked for a passport.
+      expect(findings, isNot(contains(DwCheckType.featureSpecMissing)));
+    });
+
+    test('an extension is reported', () async {
+      final findings = await checkZoneFeature('''
+extension ThingLabel on Thing {
+  String get label => 'thing';
+}
+''');
+
+      expect(findings, contains(DwCheckType.notAFeature));
+    });
+
+    test('a private widget does not make the folder a feature', () async {
+      // Only a public class counts: a file whose sole widget is private has no
+      // entry point for anyone to import.
+      final findings = await checkZoneFeature('''
+final thingProvider = Provider<bool>((ref) => false);
+
+class _ThingView extends StatelessWidget {}
+''');
+
+      expect(findings, contains(DwCheckType.notAFeature));
+    });
+  });
+}

--- a/template/dartway_starter_flutter/lib/core/dw_core.dart
+++ b/template/dartway_starter_flutter/lib/core/dw_core.dart
@@ -20,9 +20,22 @@ String exampleAppVersion = 'local';
 /// backend URL can be supplied as a runtime development parameter.
 late final DwCore<Client, UserProfile> dw;
 
-/// Builds the global [dw] core using the development [backendUrl]. Called once
-/// from `DartwayStarterApp.run` before any widget reads `dw`.
+bool _coreInitialized = false;
+
+/// Builds the global [dw] core using the development [backendUrl]. Called from
+/// `DartwayStarterApp.run` before any widget reads `dw`.
+///
+/// Calling it again does nothing, and that is what makes it usable from a
+/// widget test's `setUpAll`. Tests need it more often than it looks: anything
+/// reached through `dw.` — `dw.userProfileProvider` among them — needs the core
+/// to exist merely to be *named*, so a test that pumps a subtree touching the
+/// router needs a booted core even when it knows nothing about the session.
+/// Without the guard, the second test file in a run would meet a
+/// `LateInitializationError` on an already-initialized field.
 void initExampleDwCore({required String backendUrl}) {
+  if (_coreInitialized) return;
+  _coreInitialized = true;
+
   dw = DwCore<Client, UserProfile>(
     config: DwConfig(
       defaultModelGetter: dwGetDefault,

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -138,6 +138,15 @@ Live migrations (delete an entry once no project is on the old shape):
   building blocks in `lib/shared/`, a block described by a doc comment. *A passport with nothing in it
   is deleted with the move, not reworded* — an empty spec means the thing was never a feature.
 
+- **State and queries out of zones → `core/` and `shared/` (Law 3).** *You have the old shape if:*
+  `dartway check` reports `notAFeature` — a folder in a zone whose entry point declares no widget.
+  Until that check existed the "how to tell" was a reading, and a reading is what let one project
+  gather ten such folders with every one graded A. *Target:* state that several features watch is
+  wiring, so `lib/core/`; a query or helper with no story of its own is a building block, so
+  `lib/shared/`. *What has accumulated:* move it as you touch the feature that reads it — and note
+  that a provider named in tests through `overrideWith` stays a named provider, it just changes
+  address.
+
 ## Skills and commands
 
 - Skills (`.claude/skills/`): `dartway-run`, `dartway-requirements`, `dartway-plan`, `dartway-clean-code`, `dartway-navigation`, `dartway-feature-scaffold`, `dartway-crud-config`, `dartway-ui-kit`, `dartway-data-layer`, `dartway-models`, `dartway-push-delivery`, `dartway-finish` — loaded by relevance to the task.

--- a/toolkit/skills/dartway-feature-scaffold/SKILL.md
+++ b/toolkit/skills/dartway-feature-scaffold/SKILL.md
@@ -148,6 +148,13 @@ Create the entry point (a Page or a Widget), sketch the layout (buttons, lists, 
 
 The entry-point widget **declares what feature it is** — `implements DwFeature` with a `DwFeatureSpec` right in its own file (see "Feature spec" below). Without it, `dartway check` emits a `featureSpecMissing` warning.
 
+**A folder in a zone whose entry point is not a widget is not a feature**, and `dartway check`
+reports it as `notAFeature` (error). The case that produces it is always the same: a provider that
+several features watch, given a folder of its own because it felt like it deserved one. It does not
+belong in a zone — **state several features watch is wiring (`lib/core/`), and a helper with no
+story of its own is a building block (`lib/shared/`)**. The tell is the passport: if you cannot
+write `purpose` and `behaviors` for it without restating the type name, it was never a feature.
+
 **Showing a feature that is not a route.** A sheet, a dialog or an overlay publishes itself as a
 **static method on its own widget**, taking `BuildContext` first — `static Future<void> show(BuildContext context, …)`,
 or `showCreate` / `showEdit` when there are several ways in:


### PR DESCRIPTION
Three findings with one cause. All of them came from running `dartway check`
against a real project it had been reporting as clean.

## A widget was recognised by a list of remembered names

```dart
extends (Stateless|Stateful|Consumer|HookConsumer|Hook)Widget
```

That does not match `ConsumerStatefulWidget` — the class every form and dialog
extends, which is to say the features with the most behaviour to describe. Six
of one project's twenty-five entry points were invisible to
`featureSpecMissing`.

It now asks whether a **public class extends anything named `*Widget`**: a shape
instead of a memory, which does not go stale the next time Flutter or riverpod
adds a base class.

## `notAFeature` closes the other end

A zone holds features, so a folder in one whose entry point declares no widget
is not a feature. Until now such a folder passed **because** it was not a
widget — the two gaps covered for each other, and one project accumulated ten
provider-only folders with every one graded **A**.

Where they belong is not a new rule: state several features watch is wiring
(`core/`), a helper with no story of its own is a building block (`shared/`).

## The verdict moves to the command

The Flutter inspector printed it while knowing nothing about the layout check
that ran before it. So a run could print two layout errors, announce
*"🟡 No errors — check passes"*, and exit 1. The exit code was right and the
sentence under it was wrong. Now the only place holding both counts is the one
that says it.

## Also here

The template's core initializer becomes idempotent. Anything reached through
`dw.` needs the core to exist merely to be *named*, so a widget test pumping a
subtree that touches the router needs a booted core even when it knows nothing
about sessions — and without the guard the second test file in a run meets a
`LateInitializationError`.

## Synchronisation

- `example/` and `template/` — verified green under the new rules;
- `toolkit/skills/dartway-feature-scaffold` — says where a provider goes instead;
- `toolkit/CLAUDE.md` — the migration entry now points at the check rather than
  asking for a judgement call;
- `docs/5-tooling/conventions-checker.md` — the new check and why the two are
  one rule;
- `dartway_cli` 0.3.0 → 0.4.0 with a changelog entry.

The ten folders that prompted this were in Studio, and they moved before this
lands, so nothing goes red on arrival.

## Verified

69 CLI tests including a new `feature_entry_point_test.dart` covering all six
widget base classes, the provider case, the extension case and the
private-widget case. `dartway check` exit 0 on both `example/` and `template/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
