### PR TITLE
docs: four rules the work proved, and where each one broke

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -21,6 +21,18 @@ monorepo — a shallow clone cached in `~/.dartway/monorepo`, on the `stable` br
 be mid-refactor. That is why the version of the CLI you installed does not decide what your
 project gets — the channel does.
 
+**The harness channel follows the framework channel, and the default is only right for a project on
+the default.** A project that takes the `dartway_*` packages from `master` and installs its harness
+from `stable` gets an agent instructed in the rules of a framework it is not running — and the
+mismatch is silent, because both halves are internally consistent. It happened: a project on
+`master` carried a `stable` harness five commits behind and was told to put code in `data/` and
+`domain/`, the two folders the current layout check rejects. Take the harness from wherever the
+packages come from:
+
+```bash
+dartway setup-ai --channel master   # a project whose pubspec points at master
+```
+
 ## `dartway quickstart` — the instruction, printed
 
 ```bash

--- a/docs/5-tooling/conventions-checker.md
+++ b/docs/5-tooling/conventions-checker.md
@@ -16,6 +16,32 @@ Three examples of what nothing else catches:
 The checker is not a second analyzer. It exists because DartWay's structural conventions are the
 part of the framework that a compiler has no opinion about.
 
+## Three commands, and none of them implies the others
+
+A DartWay project has three separate gates, and each has to be run by name:
+
+```bash
+flutter analyze            # the analyzer and the lint set
+dart run custom_lint       # DartWay's own rules
+dartway check              # the structural conventions
+```
+
+**`flutter analyze` does not execute `custom_lint` plugins.** This trips everyone once: `dartway_lints`
+is declared in `pubspec.yaml`, `custom_lint` is listed under `analyzer: plugins:`, the IDE underlines
+violations — and a CI running only `flutter analyze` reports a clean build while enforcing none of it.
+A real project shipped that way for months; the code turned out to be clean, but nothing had been
+guarding it.
+
+**A project's CI runs all three, plus its tests.** Not because CI is a virtue, but because these are
+the checks the project has already declared: a rule configured and not executed is worse than a rule
+absent, since it reads as covered. Two consequences worth stating outright:
+
+- **if a package has a `test/` folder, CI runs it.** A suite excluded from CI stops compiling, and
+  nobody learns that from the exclusion comment. One project's server tests — including the suite
+  proving one tenant cannot read another's data — had never run; the first CI run that saw them
+  found a test that only passed on the author's operating system;
+- **"it does not compile against the new API" is a red CI, not a note in a workflow file.**
+
 ## What the report looks like
 
 The report is organised **per feature**, not as a flat list of lines. A large project should read

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -21,6 +21,27 @@ Corollary: **the current usage count in existing code is not a design argument.*
 inherits whatever the API was when it was written; it migrates. Design for what is right, not for
 what there is most of right now.
 
+### The price of this principle, which is not zero
+
+"`dw` is always in scope" is true of an application and **false of a widget test**: a test pumps a
+subtree, not an app, so `DwAppRunner` never runs and nobody has built the core. Every symbol moved
+onto `dw.` therefore widens the set of tests that must boot one — including tests that only ever
+name the symbol, because `dw.somethingProvider` dereferences `dw` to *produce the provider object*,
+before riverpod mounts anything or applies a single `overrides:` entry.
+
+This is a real cost, paid by consumers, and it is invisible from inside the framework. Moving
+`userProfileProvider` onto `dw.` broke **14 widget tests** in a real project — in files about a
+feature card, which know nothing about profiles and reached the core through
+`router → project context → profile`. The failure reads `LateInitializationError` and names a
+provider the author never touched.
+
+So, when you move a symbol onto `dw.`:
+
+- **say so in the changelog as a test-contract change**, not only as an API addition;
+- expect consumers to need `initDwCore` in `setUpAll`, and keep that initializer **idempotent** so
+  no test file has to know whether another one booted the core first (the template's is);
+- prefer not to break the rule — the namespace is worth it — but do not pretend the move is free.
+
 ## 2. `dw.` is the core; `dw.plugins.<name>` is the extensions
 
 `dw.` is a **closed, known set** — the services and actions the core always provides (`dw.notify`,

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -18,6 +18,8 @@ In DartWay, **all server logic goes through CRUD configs**, not through arbitrar
 
 One `DwCrudConfig<T>` per model aggregates all the rules — it is the place both the developer and the AI look at.
 
+**One config per file, and the file is named after its model.** The rule sounds like tidiness and is not: a config carries the model's whole access story, so a file holding several of them is several access stories under one name, and the name stops being a place to look. It rots the way you would expect — a real project had `studio_issue_activity_crud_config.dart` at 556 lines with five configs inside, named after `StudioIssueActivity`, a model that has never existed. Private helpers (`_validate…`, `_prepare…`) live with the config they serve; if one is genuinely needed by two models, that is a shared file of its own, not a reason to merge two configs.
+
 ```dart
 final userProfileCrudConfig = DwCrudConfig<UserProfile>(
   table: UserProfile.t,

--- a/toolkit/skills/dartway-models/SKILL.md
+++ b/toolkit/skills/dartway-models/SKILL.md
@@ -96,6 +96,8 @@ values:
   - trial
 ```
 
+**A `default=` may not name a value that is closed.** When a path is retired — legally, commercially, or because it was replaced — the enum keeps the value for the rows that already carry it, and the default moves the same day. Otherwise every record created from then on is stamped with the way you decided not to do things, and nothing complains: it compiles, it saves, it looks deliberate. A real project kept `default=subscription` on its agent-auth enum for the whole time that path was known to be unusable, and the discrepancy surfaced in an audit rather than in a test. Retiring a value: change the default in the same change that closes the path, then migrate the existing rows, then remove the value once nothing references it.
+
 ## Model change workflow
 
 1. Edit/add a `.spy.yaml` in `lib/src/models/<domain>/`.


### PR DESCRIPTION
Everything here was found by applying the framework to a real project rather
than by reading it. **No code changes** — these are the laws that were missing
at the moment something went wrong.

## `docs/DESIGN.md` — routing a symbol through `dw.` is not free

Principle 1 says "`dw` is always in scope". True of an application; **false of a
widget test**, which pumps a subtree, never runs `DwAppRunner`, and so has no
core. Every symbol moved onto `dw.` widens the set of tests that must boot one —
including tests that only ever *name* it, because `dw.somethingProvider`
dereferences `dw` to produce the provider object, before riverpod mounts
anything or applies a single `overrides:` entry.

Moving `userProfileProvider` onto `dw.` broke **14 widget tests** in files about
a feature card, which know nothing about profiles, with a
`LateInitializationError` naming a provider their author never touched.

The principle stands — the namespace is worth it. The price is now written next
to it, with what to do about it.

## `docs/5-tooling/cli.md` — the harness channel follows the framework channel

A project taking its packages from `master` and its harness from `stable` gets
an agent instructed in the rules of a framework it is not running, and the
mismatch is silent because each half is internally consistent. One project's
`stable` harness sat five commits behind and told the agent to write into
`data/` and `domain/` — the two folders the current layout check rejects.

## `docs/5-tooling/conventions-checker.md` — three commands, none implying the others

```bash
flutter analyze            # the analyzer and the lint set
dart run custom_lint       # DartWay's own rules
dartway check              # the structural conventions
```

**`flutter analyze` does not execute `custom_lint` plugins.** Declared in
`pubspec.yaml`, listed under `analyzer: plugins:`, underlined in the IDE — and a
CI running only the analyzer reports a clean build while enforcing none of it.

Plus what follows for tests: a suite excluded from CI stops compiling, and
nobody learns that from the exclusion comment. One project's server tests —
including the suite proving one tenant cannot read another's data — had never
run; the first CI run that saw them found a test that only passed on its
author's operating system.

## `toolkit/skills/dartway-crud-config` — one config per file, named after its model

A file holding several is several access stories under one name, and the name
stops being a place to look. A real one reached 556 lines with five configs,
named after `StudioIssueActivity` — a model that has never existed.

## `toolkit/skills/dartway-models` — a `default=` may not name a value that is closed

When a path is retired the enum keeps the value for the rows that carry it, but
the default moves the same day. Otherwise every record created from then on is
stamped with the way you decided *not* to do things, and nothing complains: it
compiles, it saves, it looks deliberate.

## Verified

Toolkit invariant clean (the examples are written as "a real project", not as a
project name). `dartway check` exit 0 on `example/` and `template/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
