### PR TITLE
chore(example): the reference app installs from pub.dev, like anything else

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,31 +1,48 @@
-# DartWay Project Template
+# DartWay example — a fitness club
 
-Starter template for creating new projects with **DartWay** (Flutter + Serverpod).  
-This repository provides the base structure for:
-- `dartway_example_flutter` — Flutter application
-- `dartway_example_server` — Serverpod backend
-- `dartway_example_client` — generated API client
+A complete application built on [DartWay](https://dartway.dev) (Flutter + Serverpod): sessions,
+bookings, coaches, an admin panel, roles, uploads, real-time lists. Three packages:
 
-## 🚀 Quickstart
+- `dartway_example_server` — Serverpod backend (models, CRUD configs, logic)
+- `dartway_example_flutter` — Flutter app (features, UI kit, navigation)
+- `dartway_example_client` — generated API client (**do not edit by hand**)
 
-Follow the step-by-step guide to create a new project:  
-👉 [DartWay Quickstart Guide](https://dartway.dev/docs/quick-start)
+**This is a reference to read and run, not a project to inherit.** Starting your own app from it
+means deleting somebody else's fitness club before writing yours — `dartway create` exists for
+that and hands you a skeleton with no domain in it. Read this one to see what a finished DartWay
+app looks like: how a `DwCrudConfig` replaces an endpoint, how a feature declares its own spec, how
+the UI kit stays the only source of styles.
 
-## Features
+## Running it
 
-- Pre-configured **DartWay rules** for Cursor/AI coding
-- Ready-to-use Flutter + Serverpod integration
-- Structured project layout (app, server, client)
-- Scripts for renaming and setting up your own project
+The three packages depend on the framework from pub.dev, so they run outside this monorepo. Copy
+them somewhere, then **delete the `dependency_overrides:` block from each of the three
+`pubspec.yaml` files** — inside the monorepo those overrides point at sibling folders so the
+example builds against the framework's working copy, and in a standalone checkout they lead
+nowhere.
 
-## How to use
+```bash
+# backend
+cd dartway_example_server
+dart pub get
+docker compose up -d                                       # Postgres on 8090, MinIO on 8100
+dart bin/main.dart --apply-migrations --role maintenance    # apply the schema
+dart bin/seed_dev.dart --mode development                   # seed the club and its people
+dart bin/main.dart                                          # run the server
+```
 
-1. Clone this repo as your new project folder  
-2. Run the rename script to replace `dartway_example` with your project’s name  
-3. Install dependencies and generate code  
-4. Start coding your app 🚀
+```bash
+# app — in another terminal
+cd dartway_example_flutter
+flutter pub get
+flutter run
+```
 
-See [DartWay Quickstart Guide](https://dartway.dev/docs/quick-start) for full details.
+Sign in as **79990000003** (a client), **79990000002** (a coach) or **79990000001** (the admin).
+There are no passwords: the one-time code is printed in the server console.
+
+`dartway doctor` says whether this machine has what any of it needs — Dart, Flutter, a responding
+Docker daemon, a `serverpod_cli` matching the pin.
 
 ## Tests
 

--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -7,11 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: master
-      path: packages/dartway_serverpod_core/dartway_serverpod_core_client
+  dartway_serverpod_core_client: ^0.4.0
 
   # The client half of the optional push module. Required because the generated
   # protocol imports it — the server consumes the module, so its `Caller` shows
@@ -20,7 +16,7 @@ dependencies:
   dartway_push_client:
     git:
       url: https://github.com/dartway/dartway.git
-      ref: master
+      ref: stable
       path: packages/dartway_push/dartway_push_client
 
 # Inside the monorepo — a local build. In a standalone project, drop this block.

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -255,7 +255,7 @@ packages:
       path: "../../packages/dartway_cli"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_example_client:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -38,25 +38,13 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: master
-      path: packages/dartway_flutter
+  dartway_flutter: ^0.4.0
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: master
-      path: packages/dartway_serverpod_core/dartway_serverpod_core_flutter
+  dartway_serverpod_core_flutter: ^0.4.0
 
-  dartway_studio_bridge:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: master
-      path: packages/dartway_studio_bridge
+  dartway_studio_bridge: ^0.6.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -74,22 +62,14 @@ dev_dependencies:
     sdk: flutter
 
 
-  dartway_cli:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: master
-      path: packages/dartway_cli
+  dartway_cli: ^0.3.0
 
   # The UI-kit law is enforced here, not just written down: raw Color/TextStyle/
   # BorderRadius and direct theme access outside `ui_kit/` are lints. Needs
   # `analyzer: plugins: [custom_lint]` in analysis_options.yaml, and runs in the
   # IDE and via `dart run custom_lint`.
   custom_lint: ^0.8.0
-  dartway_lints:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: master
-      path: packages/dartway_lints
+  dartway_lints: ^0.2.0
 
 # Inside the monorepo the example builds against the LOCAL framework packages.
 # Copied out into a standalone project — drop the whole dependency_overrides block.

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -9,18 +9,14 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: master
-      path: packages/dartway_serverpod_core/dartway_serverpod_core_server
+  dartway_serverpod_core_server: ^0.4.0
 
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.
   dartway_push_server:
     git:
       url: https://github.com/dartway/dartway.git
-      ref: master
+      ref: stable
       path: packages/dartway_push/dartway_push_server
 
   http: ^1.5.0


### PR DESCRIPTION
The example is meant to be downloaded and run. It could not be, comfortably.

It took the framework through **git references to this very repository**, pinned to `master` — which the monorepo's own standards forbid ("dependencies between packages resolve through the workspace, not through git references to `dartway.git`"), and which made "download it and run it" mean cloning the whole monorepo once per dependency, at whatever state the trunk happened to be in.

Everything it needs is now published, so it asks for versions: core `^0.4.0`, `dartway_flutter` `^0.4.0`, the bridge `^0.6.0`, the CLI and lints in dev. **The push module is the one exception** — it has never been published — so it stays a git reference, moved from `master` to `stable` so a reader gets a verified state. Publishing `dartway_push_client`/`dartway_push_server` 0.1.0 would remove the last two git references; that is a separate decision, since it claims two names on pub.dev for good.

The README was still calling the example a starter template and telling people to run a rename script that has not existed for a long time — the opposite of what this folder is for, and the exact mistake `dartway create` exists to prevent. It now says what the example is, that it is read rather than inherited, and how to run it: drop the `dependency_overrides` block from the three pubspecs, bring it up, sign in as one of the seeded phones.

### Verification

Done the way a stranger would: copied the three packages out of the monorepo, deleted the overrides, and resolved. Both packages resolve from pub.dev, `flutter analyze` is clean, and the server compiles to a native executable with no monorepo anywhere near it. Inside the monorepo the example still resolves through the overrides and analyzes clean, so the synchronisation law is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)