### PR TITLE
chore: the template asks for the CLI version that has the checker fix

### DIFF
--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dev_dependencies:
     sdk: flutter
 
 
-  dartway_cli: ^0.3.0
+  dartway_cli: ^0.4.0
 
   # The UI-kit law is enforced here, not just written down: raw Color/TextStyle/
   # BorderRadius and direct theme access outside `ui_kit/` are lints. Needs

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -255,7 +255,7 @@ packages:
       path: "../../packages/dartway_cli"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_flutter:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dev_dependencies:
     sdk: flutter
 
 
-  dartway_cli: ^0.3.0
+  dartway_cli: ^0.4.0
 
   # The UI-kit law is enforced here, not just written down: raw Color/TextStyle/
   # BorderRadius and direct theme access outside `ui_kit/` are lints. Needs


### PR DESCRIPTION
[#28](https://github.com/dartway/dartway/pull/28) bumped `dartway_cli` to 0.4.0 and left `template/` and `example/` asking for `^0.3.0`, which excludes it: a new project would have installed the checker that misses every `ConsumerStatefulWidget` — the bug that PR fixed.

`dartway_cli` 0.4.0 is on pub.dev now, so the constraint can name it. The template's lock follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)