### PR TITLE
chore(example): the last git references to this repository are gone

### DIFF
--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -13,11 +13,7 @@ dependencies:
   # protocol imports it — the server consumes the module, so its `Caller` shows
   # up in this package's `client.dart`. Drop both together if an app does not
   # need push.
-  dartway_push_client:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: stable
-      path: packages/dartway_push/dartway_push_client
+  dartway_push_client: ^0.1.0
 
 # Inside the monorepo — a local build. In a standalone project, drop this block.
 dependency_overrides:

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -13,11 +13,7 @@ dependencies:
 
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.
-  dartway_push_server:
-    git:
-      url: https://github.com/dartway/dartway.git
-      ref: stable
-      path: packages/dartway_push/dartway_push_server
+  dartway_push_server: ^0.1.0
 
   http: ^1.5.0
 


### PR DESCRIPTION
`dartway_push_client` and `dartway_push_server` 0.1.0 are on pub.dev ([#32](https://github.com/dartway/dartway/pull/32) made them publishable), so the example asks for them by version like everything else. **Nothing in the example points at `dartway.git` any more.**

A person who downloads the three packages and deletes the `dependency_overrides` block now gets a project that resolves entirely from pub.dev — no monorepo clone per dependency, no dependence on whatever state a branch happens to be in.

### Verification

Done as a stranger would: copied the three packages out, deleted the overrides, resolved. The server pulls `dartway_push_server` 0.1.0 from the hosted repository and compiles to a native executable; the app resolves and `flutter analyze` is clean. Inside the monorepo the overrides still point at the working copy and the example analyzes clean there too, so the synchronisation law is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)