### PR TITLE
docs: a project may keep documents, and one kind has rules

### DIFF
--- a/docs/1-getting-started/project-layout.md
+++ b/docs/1-getting-started/project-layout.md
@@ -18,12 +18,18 @@ my_app/
   .github/           a Claude PR-review workflow (delete it to turn review off)
 ```
 
-**There is no `docs/` folder, deliberately.** What a screen does belongs in its
+**A new project gets no `docs/` folder, deliberately.** What a screen does belongs in its
 [`DwFeatureSpec`](../3-flutter/features-and-specs.md), the server-side rules in doc comments above
 the CRUD config, a cross-cutting registry — analytics events, settings keys, roles — in code under
 `lib/core/`, where the compiler knows the list and a typo is an error. A document sitting apart from
 the code goes stale without anything failing: nothing compiles it, no checker sees it, and the next
 reader — increasingly an agent — believes it.
+
+A project may still keep the documents it genuinely needs there, and one kind is known to the
+framework because it keeps being reinvented: **`docs/adr/` — the decisions and what they ruled out**.
+An ADR exists for the one thing that cannot live beside code — the *rejected* alternatives, which
+have no file to sit next to. The rules for writing one (and for never editing it) are in the agent
+toolkit's `CLAUDE.md`; `dartway-plan` reads the folder before proposing an approach.
 
 ## Why three packages
 

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -73,7 +73,7 @@ A project is free to decide otherwise (a large asset library, union types where 
 
 **Why so.** A doc sitting apart from the code drifts from it silently: the compiler does not check it, the checker does not see it, and the agent reads it and believes it. On a production project such a doc described an API deleted a year earlier, and non-working code was written from it. A spec in the feature's file and a comment above the config survive a code edit because they lie in the same diff — they are impossible to miss.
 
-**There is no `docs/` folder, and a new project does not get one.** The rule has no exception carved out for "but this one is architectural": a document nobody compiles is a document nobody notices going stale, and the architectural ones rot fastest, because the code they describe changes under them without a single error.
+**A new project gets no `docs/` folder, and most of what you would put in one belongs elsewhere.** A document nobody compiles is a document nobody notices going stale, and the ones about architecture rot fastest, because the code they describe changes under them without a single error.
 
 The cases that used to justify one, and where they go instead:
 
@@ -85,7 +85,29 @@ The cases that used to justify one, and where they go instead:
 | "How this app is put together" | The skills. That is what they are: the methodology ships from the framework and is updated with it, and a copy inside the project would only fall behind it |
 | An audit report | The chat. `/dartway-audit` writes no files on purpose; what deserves to survive becomes a line in that feature's `knownIssues` |
 
-If you feel the urge to start a document, name what it would say that a `DwFeatureSpec`, a doc comment or a piece of code cannot. Usually the answer is that the spec is silent where it should not be, and the fix is in the spec.
+Before starting any document, name what it would say that a `DwFeatureSpec`, a doc comment or a piece of code cannot. Usually the answer is that the spec is silent where it should not be, and the fix is in the spec.
+
+**`docs/` is for what survives that question** — the documents this project genuinely needs. One kind is known to the framework and has rules, because it is the one that keeps being reinvented.
+
+### `docs/adr/` — the decisions, and what they ruled out
+
+An ADR records **the alternatives that were rejected, and why**. That is the one thing which cannot live beside the code: a rejected option has no file to sit next to. What the decision *produced* is in the code already.
+
+**The admission test is one question:** is there an alternative someone will propose again in six months? If not, this is not an ADR, and what you wanted to write belongs in a spec or a doc comment.
+
+`docs/adr/NNNN-slug.md` — four digits, flat, written in this project's language. Each one carries:
+
+- **Status** — `accepted` or `superseded by NNNN` — and the date;
+- **Context** — what forced a choice;
+- **Decision** — what was chosen;
+- **Rejected alternatives, each with its reason** — without this section the document is not an ADR;
+- **Limitations accepted knowingly** — what you are choosing to live with.
+
+**Never write "how it works now".** That is the part that rots, and it rots silently, because the code changes under it without an error. A real ADR described a `--dart-define` as the source of an app's URL while the README on the very same commit said that mechanism was gone.
+
+**An ADR is never edited — it is superseded by a new one**, and the old one gets `superseded by NNNN` in its status. Editing destroys the only thing it is for: what was known at the moment of the choice. A record you may rewrite is not a record.
+
+**Planning reads them.** `dartway-plan` looks in `docs/adr/` before proposing an approach, so a decision whose alternatives were already weighed is not re-argued from scratch — and a plan that itself makes such a choice proposes a new ADR as one of its steps.
 
 ## Cleanliness and finishing
 

--- a/toolkit/skills/dartway-plan/SKILL.md
+++ b/toolkit/skills/dartway-plan/SKILL.md
@@ -21,6 +21,8 @@ The plan follows the DartWay order of layers (domain-first, CRUD-first): first t
 
 Record: the agreed requirement + the **chosen implementation option** (from `dartway-requirements`). If no option is chosen or the requirements are not agreed — stop and send it back to `dartway-requirements`.
 
+**Read `docs/adr/` if the project has it.** Those are decisions already taken, each with the alternatives it ruled out and why. Two things follow: an approach listed there as rejected is not proposed again as if it were new — and if you believe it should be reconsidered, say so explicitly, naming the ADR and what has changed since. A decision quietly re-litigated is how a project ends up arguing the same question twice a year. Skip an ADR whose status says `superseded by NNNN` and read that one instead.
+
 ## Phase B — Re-analysis for the chosen option
 
 Determine precisely what and where you are touching (Glob/Grep/Read): the specific `.spy.yaml` models, the CRUD configs, the Flutter features and their `DwFeatureSpec`. What is **reused** (existing models/widgets/extensions), which layer patterns apply — lean on `dartway-models`, `dartway-crud-config`, `dartway-data-layer`, `dartway-navigation`, `dartway-ui-kit`, `dartway-feature-scaffold`.
@@ -36,6 +38,7 @@ Order the steps end-to-end. Each step: **what to do → which files → which sk
 5. **Flutter** — navigation (the route) → the feature's entry point → data layer (watch/save) → UI Kit → specials. `dartway-feature-scaffold` / `dartway-data-layer` / `dartway-navigation` / `dartway-ui-kit`.
 6. **Tests** — non-trivial logic / Event models / permissions; for a bugfix — the failing test first.
 7. **Description** — reconcile the feature's `DwFeatureSpec` with the new behaviour, server-side rules go in doc comments above the CRUD config. No separate doc is created for a feature.
+8. **An ADR — only if this plan itself settles a choice.** The test is whether a real alternative was rejected here: a second storage, a different protocol, a library not taken, a shape of the API that lost. If so, the plan's last step is `docs/adr/NNNN-slug.md` with the alternatives and the reasons — that is the part which cannot be read off the code afterwards. If nothing was rejected, there is no ADR, and inventing one produces exactly the document the framework tells projects not to write.
 
 ## Phase D — Subtleties and risks
 


### PR DESCRIPTION
The law said a project has no `docs/` folder and carved out no exception — *"not
even for the architectural ones"*. It was aimed at the right failure: a document
nobody compiles goes stale silently. But it also banned the one document with a
job nothing else can do — recording **which alternatives were rejected, and
why**. A rejected option has no file to sit next to. What a decision produced is
in the code; what it ruled out is nowhere.

So `docs/` may now hold the documents a project genuinely needs, and `docs/adr/`
is the kind the framework knows about, because it is the one that keeps being
reinvented.

## The regulation, and what each line is defending against

| Rule | The way ADRs rot |
|---|---|
| **Admission test:** is there an alternative someone will propose again in six months? If not, it is not an ADR | folders of "decisions" that are really descriptions |
| **Rejected alternatives are a required section** — without it the document is not an ADR | the reasons evaporate, and the same option comes back |
| **"How it works now" is forbidden** | that is the part that rots, and it rots without an error |
| **Never edited — superseded by a new one** | an edited record loses what was known *at the time*, which is the only thing it holds |

The third one is not hypothetical. A real ADR described a `--dart-define` as the
source of an app's URL while the README on the very same commit said the
mechanism no longer existed.

## Planning reads them

`dartway-plan` looks in `docs/adr/` before proposing an approach, so an
alternative already weighed is not re-argued from scratch — and when it thinks a
past decision deserves reopening it says so explicitly, naming the ADR and what
changed. A plan that itself settles such a choice adds writing the ADR as its
last step, and **only** then: nothing rejected, no ADR, because inventing one
produces exactly the document the framework tells projects not to write.

## Details

- `docs/adr/NNNN-slug.md` — flat, four digits;
- written in the project's language, like feature specs and `dartway_notes.md`;
- the same law lived in two files, so both move together: the toolkit
  `CLAUDE.md` that ships into projects, and
  `docs/1-getting-started/project-layout.md`.

## Deliberately not here

No `dartway check` rule: the checker reads `lib/`, not the project root, and the
failure that matters — a stale ADR — is not mechanically detectable. Only the
*shape* is (a status line, a rejected-alternatives heading), and that is a
separate decision. `create` does not ship an empty `docs/adr/` either — an empty
folder in every new project is an invitation to fill it, and the rule is the
opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
