### PR TITLE
feat(core): an update can leave the process that sends it

### DIFF
--- a/docs/2-core/realtime.md
+++ b/docs/2-core/realtime.md
@@ -78,6 +78,29 @@ saveConfig: DwSaveConfig<SessionBooking>(
 `sendUpdates` takes the channels and the models explicitly. `sendUpdatesToUser` is the shortcut for
 the one audience that is always safe — a single known user — and delegates to it.
 
+## Sending from a process the clients are not connected to
+
+Both take a `global` flag, default `false`, and the default is right for the common case: an app that
+is one server process, where every client is connected to the process doing the sending.
+
+**Pass `global: true` when the sender is somewhere else** — a background worker in its own container,
+a future call, a cron job. The message then travels through Redis to the other instances, and reaches
+the clients hanging off the API server.
+
+```dart
+// inside a worker process, whose own connections list is empty
+session.sendUpdatesToUser(job.requestedByProfileId, updatedModels: [job], global: true);
+```
+
+**Get this wrong and nothing tells you.** The call compiles, throws nothing, and delivers to nobody:
+the sending process has no subscribers on that channel, and an audience of zero is not an error. It is
+the whole reason the flag is documented here rather than left in the signature — a real project found
+it only by reading Serverpod's own `postMessage`, and had hand-assembled the transport to get at it.
+
+A test will not catch it either, unless you go out of your way: a worker's publisher is usually
+injected, so the suite exercises *who* the recipients are while the delivery itself is a fake — and
+`redis: enabled: false` in a test config is normal.
+
 ## Declaring a channel
 
 A channel name reaches the server as a plain string chosen by the client. Nothing else in the system

--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.4.0
+  dartway_serverpod_core_client: ^0.5.0
 
   # The client half of the optional push module. Required because the generated
   # protocol imports it — the server consumes the module, so its `Caller` shows

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -298,21 +298,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_studio_bridge:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.4.0
+  dartway_serverpod_core_flutter: ^0.5.0
 
   dartway_studio_bridge: ^0.6.0
 

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.4.0
+  dartway_serverpod_core_server: ^0.5.0
 
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.

--- a/packages/dartway_push/dartway_push_client/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_client/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   # wrapper types. Inside the workspace this resolved without being declared,
   # which is exactly the kind of dependency that only fails once the package is
   # published and somebody else resolves it.
-  dartway_serverpod_core_client: ^0.4.0
+  dartway_serverpod_core_client: ^0.5.0

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_server: ^0.4.0
+  dartway_serverpod_core_server: ^0.5.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.5.0 is the
+server side gaining a `global` flag on `sendUpdates` / `sendUpdatesToUser` — see the changelog of
+`dartway_serverpod_core_server`.
+
 ## 0.4.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.4.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.5.0 is the
+server side gaining a `global` flag on `sendUpdates` / `sendUpdatesToUser` — see the changelog of
+`dartway_serverpod_core_server`.
+
 ## 0.4.0
 
 **The signed-in profile is a framework provider now: `dw.userProfileProvider` and

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -19,8 +19,8 @@ dependencies:
   serverpod_client: ^3.4.11
 
   dartway_flutter: ^0.4.0
-  dartway_serverpod_core_client: ^0.4.0
-  dartway_serverpod_core_shared: ^0.4.0
+  dartway_serverpod_core_client: ^0.5.0
+  dartway_serverpod_core_shared: ^0.5.0
 
   collection: ^1.19.1
   flutter_riverpod: ^3.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.5.0
+
+- **`sendUpdates` and `sendUpdatesToUser` take `global`, so an update can leave the process that
+  sends it.** Default `false` — the right answer while an app is one server process, where the
+  clients are connected to the process doing the sending. Pass `true` from somewhere else: a
+  background worker in its own container, a future call, a cron job. The message then travels through
+  Redis and reaches the clients hanging off the API server.
+
+  Until now the flag was not reachable at all: the extension called Serverpod's `postMessage` without
+  it. **A worker calling `sendUpdatesToUser` therefore compiled, threw nothing and delivered to
+  nobody** — its own process has no subscribers on that channel, and an audience of zero is not an
+  error. A real project found this only by reading Serverpod's own source, and had hand-assembled
+  `DwUpdatesTransport` to get at the flag; the workaround was correct and should never have been
+  necessary. Its tests did not catch it and could not have: a worker's publisher is injected, so the
+  suite checked *who* the recipients were while delivery was a fake, and `redis: enabled: false` in a
+  test config looks perfectly ordinary.
+
+  Existing calls are unaffected — the default preserves today's behaviour, and the trap is now
+  written down in the doc comment, in `docs/2-core/realtime.md` and in the `dartway-data-layer` skill.
+
 ## 0.4.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.4.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/dw_session_extension.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/dw_session_extension.dart
@@ -40,10 +40,22 @@ extension DwSessionExtension on Session {
   /// would have shown them that row through the API. Scope the channel to the
   /// audience that may see the data — per chat, per team, per user — rather than
   /// sending private rows to a wide one.
+  ///
+  /// **[global] decides whether the message can leave this process.** Default
+  /// `false`: delivery to the clients connected to *this* server, which is every
+  /// client when the app is one process. Pass `true` when the sender is not the
+  /// process holding the connections — a background worker, a future call, a
+  /// cron job: the message then travels through Redis to the other instances.
+  ///
+  /// Getting this wrong fails silently, which is the reason it is documented
+  /// here rather than left to be discovered. A worker calling this without
+  /// [global] compiles, throws nothing, and delivers to nobody — its own process
+  /// has no subscribers, and no error is raised for an audience of zero.
   sendUpdates({
     required List<String> channels,
     List<TableRow?>? updatedModels,
     List<TableRow?>? deletedModels,
+    bool global = false,
   }) {
     if (channels.isEmpty) return;
 
@@ -58,19 +70,24 @@ extension DwSessionExtension on Session {
     );
 
     for (final channel in channels) {
-      messages.postMessage(channel, transport);
+      messages.postMessage(channel, transport, global: global);
     }
   }
 
   /// Sends the models to one user's private channel — the common case of
   /// [sendUpdates], and the safe one: the audience is a single known user.
+  ///
+  /// [global] carries the same meaning as on [sendUpdates], and the same trap:
+  /// a worker process sending without it reaches nobody, quietly.
   sendUpdatesToUser(
     int userProfileId, {
     List<TableRow?>? updatedModels,
     List<TableRow?>? deletedModels,
+    bool global = false,
   }) => sendUpdates(
     channels: [DwCoreConst.userUpdatesChannel(userProfileId)],
     updatedModels: updatedModels,
     deletedModels: deletedModels,
+    global: global,
   );
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_shared: ^0.4.0
+  dartway_serverpod_core_shared: ^0.5.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.5.0 is the
+server side gaining a `global` flag on `sendUpdates` / `sendUpdatesToUser` — see the changelog of
+`dartway_serverpod_core_server`.
+
 ## 0.4.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.4.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/template/dartway_starter_client/pubspec.yaml
+++ b/template/dartway_starter_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.4.0
+  dartway_serverpod_core_client: ^0.5.0
 
 # Inside the monorepo — a local build. `dartway create` removes this block.
 dependency_overrides:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -284,21 +284,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_starter_client:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.4.0
+  dartway_serverpod_core_flutter: ^0.5.0
 
   dartway_studio_bridge: ^0.6.0
 

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.4.0
+  dartway_serverpod_core_server: ^0.5.0
 
   http: ^1.5.0
 

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -328,6 +328,14 @@ session.sendUpdates(
 );
 ```
 
+**Sending from a worker, a future call or a cron job — `global: true`.** Both methods take the flag, default `false`, and the default is right while the app is one process: the clients are connected to the process doing the sending. A background worker in its own container is not that process, and its own subscriber list is empty.
+
+```dart
+session.sendUpdatesToUser(job.requestedByProfileId, updatedModels: [job], global: true);
+```
+
+**Forgetting it fails silently** — the call compiles, throws nothing and delivers to nobody, because an audience of zero is not an error. Tests do not save you either: a worker's publisher is normally injected, so the suite checks *who* the recipients are while the delivery is a fake, and a test config with `redis: enabled: false` looks perfectly ordinary.
+
 A channel can be narrowed to the audience you need and built from the context — `['chat:${ctx.currentModel.chatId}']`. Then a screen subscribes to it precisely:
 
 ```dart


### PR DESCRIPTION
`sendUpdates` and `sendUpdatesToUser` take a `global` flag, default `false`.

The default is right while an app is one server process: the clients are
connected to the process doing the sending, and nothing has to travel. Pass
`true` from anywhere else — a background worker in its own container, a future
call, a cron job — and the message goes through Redis to the other instances,
reaching the clients hanging off the API server.

```dart
// inside a worker process, whose own subscriber list is empty
session.sendUpdatesToUser(job.requestedByProfileId, updatedModels: [job], global: true);
```

## Until now the flag was not reachable at all

The extension called Serverpod's `postMessage` without it. So a worker calling
`sendUpdatesToUser` **compiled, threw nothing, and delivered to nobody** — its own
process has no subscribers on that channel, and an audience of zero is not an
error.

A real project hit exactly this. It worked around it correctly: hand-assembling
`DwUpdatesTransport` and calling `postMessage(..., global: true)` itself, because
that was the only way to reach the flag. **The workaround was right and should
never have been necessary** — it comes out once that project takes this version.
(The audit that found it first read it as the project inventing its own realtime.
It wasn't; the framework was incomplete.)

## A test would not have told you

That project's suite passes. A worker's publisher is injected, so it exercises
*who* the recipients are while delivery itself is a fake, and `redis: enabled:
false` in a test config looks perfectly ordinary. This is documented alongside the
flag, because a silent failure that only appears once an app grows a second
process is not something to leave for the next person to rediscover.

## Synchronisation

- **`docs/2-core/realtime.md`** — a section on sending from a process the clients
  are not connected to;
- **`toolkit/skills/dartway-data-layer`** — the same, shorter, for the agent;
- **CHANGELOG** in all four `dartway_serverpod_core_*` packages, which move to
  **0.5.0** in lockstep — and the eleven constraints naming 0.4.0 move with them:
  both `dartway_push` packages, the core's own cross-references, `template/` and
  `example/`.

Existing calls are unaffected — the default preserves today's behaviour.

## Verified

42 core tests · `dart analyze` clean on both push packages, both server apps ·
`flutter analyze` clean on both Flutter apps · `dartway check` exit 0 on
`example/` and `template/` · toolkit invariant clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
