### PR TITLE
fix(deploy): the one deploy file nobody read is now read

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -207,7 +207,7 @@ certificate contact, and the domain serving the Flutter build. The CLI **reads**
 it never rewrites it. That is the whole reason the pair stays honest — there is no second copy of a
 domain to drift.
 
-`check` changes nothing and answers whether a deployment would work. Twelve assertions on the
+`check` changes nothing and answers whether a deployment would work. Thirteen assertions on the
 working copy, seven over the network — including that every `publicHost` resolves to the deployment
 host, which is the mistake that otherwise burns a Let's Encrypt rate limit before anyone notices.
 With the server unreachable it degrades: the SSH check fails, the rest report as skipped.
@@ -225,6 +225,13 @@ The web image gets one build argument, `DW_BACKEND_URL`, and it comes from `publ
 Serverpod configuration. A web build compiles the API address into itself, so something has to
 supply it — having the deploy do it is what keeps the domain written down once. The template's
 `main.dart` reads it through `String.fromEnvironment` and falls back to localhost for a local run.
+
+`deploy/compose.override.yml` is where a project adds what a standard deployment does not have, and
+a third local assertion guards the one thing that does not belong in it: a `build` block for the
+`web` service. Overriding `web` for a label or a limit is fine, but building it there means naming
+the API address a second time, and nothing compares the two copies — the image keeps building
+successfully against yesterday's API, which is the failure mode with no error message. A warning
+rather than an error, because only the build block reintroduces the duplicate.
 
 `run` updates the checkout, rebuilds, applies migrations and restarts, then polls every public URL.
 It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders infrastructure on

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.5.0
 
+- **`deploy check` now reads `compose.override.yml`, which nothing did before.** The override is the
+  one deploy file a project writes by hand, and the deploy copies it to the server unexamined. The
+  new `override-web-build` warns when it carries a `build` block for the `web` service: the deploy
+  builds that image itself and hands it `DW_BACKEND_URL` from `publicHost`, so an override that
+  builds it too states the API domain a second time with nothing comparing the copies — the build
+  keeps succeeding against yesterday's API. This is not hypothetical: it is what Studio's deployment
+  did, under a comment claiming a check that did not exist. Overriding `web` for a label or a limit
+  stays legitimate, which is why this is a warning and why only the build block trips it.
+
 - **`/dartway-audit` becomes `/dartway-checkup`, and looks at the project rather than at the code.**
   The audit judged the Flutter package against the clean-code contract, which left out everything
   that is not code — and that turned out to be where the worst findings live: a check declared in

--- a/packages/dartway_cli/lib/src/deploy/deploy_check.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_check.dart
@@ -210,6 +210,13 @@ const List<DwDeployCheck> dwLocalDeployChecks = [
     severity: DwCheckSeverity.error,
     evaluate: _checkEntrypointForm,
   ),
+  DwDeployCheck(
+    id: 'override-web-build',
+    title: 'The compose override leaves the web image to the deploy',
+    stage: DwDeployCheckStage.local,
+    severity: DwCheckSeverity.warning,
+    evaluate: _checkOverrideWebBuild,
+  ),
 ];
 
 Future<DwDeployVerdict> _checkPublicScheme(DwDeployContext context) async {
@@ -475,6 +482,57 @@ Future<DwDeployVerdict> _checkEntrypointForm(DwDeployContext context) async {
         'Rewrite it as exec form — ENTRYPOINT ["/app/server"] with the ordinary '
         'flags in CMD — or name the binary in server_entrypoint, which makes '
         'the deploy override the entrypoint for the migration run only.',
+  );
+}
+
+/// The deploy renders the `web` service itself, build argument included: the
+/// API address comes from `publicHost`, which is what keeps the domain written
+/// down once. An override that builds `web` states it a second time, and
+/// nothing compares the two copies — the image keeps building successfully
+/// against yesterday's API, which is a failure with no error message.
+///
+/// A warning rather than an error: overriding `web` for something that is not
+/// the build (a label, a limit, a volume) is legitimate, and only the build
+/// block reintroduces the second copy.
+Future<DwDeployVerdict> _checkOverrideWebBuild(DwDeployContext context) async {
+  final file = File(
+    p.join(context.projectRoot.path, 'deploy', 'compose.override.yml'),
+  );
+  if (!file.existsSync()) {
+    return const DwDeployVerdict.skip('no deploy/compose.override.yml');
+  }
+
+  final Object? document;
+  try {
+    document = loadYaml(file.readAsStringSync());
+  } on YamlException catch (error) {
+    return DwDeployVerdict.fail(
+      'deploy/compose.override.yml is not valid YAML: ${error.message}',
+      fix:
+          'Compose merges this file over the rendered one on the server, so a '
+          'file it cannot parse stops the deployment there rather than here.',
+    );
+  }
+
+  final services = document is YamlMap ? document['services'] : null;
+  final web = services is YamlMap ? services['web'] : null;
+  if (web is! YamlMap) {
+    return const DwDeployVerdict.pass('the web image is the deploy\'s alone');
+  }
+  if (!web.containsKey('build')) {
+    return const DwDeployVerdict.pass(
+      'the override touches web without rebuilding it',
+    );
+  }
+  return const DwDeployVerdict.fail(
+    'deploy/compose.override.yml rebuilds the web service',
+    fix:
+        'The deploy already builds web and passes it DW_BACKEND_URL from '
+        'publicHost in the Serverpod configuration. A build block here names '
+        'the API address a second time and nothing compares the copies, so a '
+        'changed domain silently ships an app talking to the old one. Drop the '
+        'build block; change the Dockerfile instead when the image itself has '
+        'to differ.',
   );
 }
 

--- a/packages/dartway_cli/test/deploy_images_test.dart
+++ b/packages/dartway_cli/test/deploy_images_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:dartway_cli/src/checker/dw_check_type.dart';
 import 'package:dartway_cli/src/deploy/deploy_check.dart';
 import 'package:dartway_cli/src/deploy/deploy_target.dart';
 import 'package:dartway_cli/src/deploy/renderer.dart';
@@ -146,6 +147,86 @@ void main() {
         expect(verdict.passed, isTrue);
       },
     );
+  });
+
+  group('override-web-build', () {
+    void writeOverride(String contents) {
+      final file = File(p.join(root.path, 'deploy', 'compose.override.yml'))
+        ..parent.createSync(recursive: true);
+      file.writeAsStringSync(contents);
+    }
+
+    test('has nothing to judge without an override', () async {
+      final verdict = await checkNamed(
+        'override-web-build',
+      ).evaluate(contextIn(root));
+
+      expect(verdict.skipped, isTrue);
+    });
+
+    test('warns when the override builds the web image itself', () async {
+      writeOverride('''
+services:
+  web:
+    build:
+      context: .
+      dockerfile: shop_flutter/Dockerfile
+      args:
+        DW_BACKEND_URL: https://api.yesterday.example.com/
+''');
+
+      final verdict = await checkNamed(
+        'override-web-build',
+      ).evaluate(contextIn(root));
+
+      expect(verdict.passed, isFalse);
+      expect(verdict.fix, contains('DW_BACKEND_URL'));
+      expect(
+        checkNamed('override-web-build').severity,
+        DwCheckSeverity.warning,
+      );
+    });
+
+    test('leaves an override that adds a service of its own alone', () async {
+      writeOverride('''
+services:
+  automation-worker:
+    build:
+      context: .
+      dockerfile: shop_server/Dockerfile.worker
+''');
+
+      final verdict = await checkNamed(
+        'override-web-build',
+      ).evaluate(contextIn(root));
+
+      expect(verdict.passed, isTrue);
+    });
+
+    test('allows overriding web for anything but the build', () async {
+      writeOverride('''
+services:
+  web:
+    restart: always
+''');
+
+      final verdict = await checkNamed(
+        'override-web-build',
+      ).evaluate(contextIn(root));
+
+      expect(verdict.passed, isTrue);
+    });
+
+    test('reports a file Compose would fail to merge on the server', () async {
+      writeOverride('services:\n  web:\n   - build\n    bad: indent\n');
+
+      final verdict = await checkNamed(
+        'override-web-build',
+      ).evaluate(contextIn(root));
+
+      expect(verdict.passed, isFalse);
+      expect(verdict.detail, contains('not valid YAML'));
+    });
   });
 
   group('rendered compose file', () {

--- a/template/deploy/README.md
+++ b/template/deploy/README.md
@@ -25,10 +25,14 @@ dartway deploy secret --help                # runtime secrets on the server
 | `nginx.d/{http,api,app}/*.conf` | extra Nginx directives, if any are ever needed |
 
 A domain appears in exactly one of the first two, and `dartway deploy check`
-fails when they disagree. `docker-compose.yml` and `nginx.conf` are rendered by
-`setup` on the server and are not part of this repository — a deploy that
-re-renders infrastructure on every push turns a routine change into an
-infrastructure one.
+fails when they disagree. One thing does not belong in the override: a `build`
+block for the `web` service. The deploy builds that image itself and passes it
+the API address from the Serverpod configuration, so building it here writes the
+domain down a second time, and `check` warns about it.
+
+`docker-compose.yml` and `nginx.conf` are rendered by `setup` on the server and
+are not part of this repository — a deploy that re-renders infrastructure on
+every push turns a routine change into an infrastructure one.
 
 ## Secrets
 


### PR DESCRIPTION
`deploy/compose.override.yml` is the only deploy file a project writes by hand, and until now nothing looked at it: no check in `dwLocalDeployChecks` opened it, and `renderer.dart` passes it through to the server verbatim.

**The check.** `override-web-build` (local, warning) fails when the override carries a `build` block for the `web` service.

The deploy builds that image itself and hands it `DW_BACKEND_URL` from `publicHost` in the Serverpod configuration — that is what keeps the API domain written down exactly once. An override that also builds `web` states the domain a second time, and nothing compares the copies: the image keeps building *successfully* against yesterday's API. It is the failure mode with no error message.

This is not hypothetical. Studio's deployment did precisely this, under a comment claiming `dartway deploy check` compared the two — a check that did not exist. Studio has since dropped its `web` override; the check is what stops the next project from rediscovering it.

**Scope kept narrow on purpose.** Overriding `web` for a label, a limit or a volume is legitimate, so only the `build` block trips the check, and it is a warning rather than an error — `deploy run` prints it and proceeds. A malformed override is reported here too, where it costs a line, rather than on the server where Compose refuses the merge mid-deploy.

**Mirrors**

- `docs/5-tooling/cli.md` — twelve local assertions became thirteen, plus the paragraph explaining what the override may and may not contain.
- `template/deploy/README.md` — the same rule stated where a project reads it.
- `packages/dartway_cli/CHANGELOG.md` — entry under the unreleased 0.5.0.

Five new tests in `deploy_images_test.dart` (skip without an override, warn on a `web` build block, pass on a service of the project's own, pass on a non-build `web` override, report invalid YAML). `dart analyze` clean, all 74 CLI tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
