### PR TITLE
feat(studio-bridge): the app half of the bridge, in JavaScript, for the teams that are not on Flutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ build/
 .flutter-plugins
 .flutter-plugins-dependencies
 
+# JavaScript packages under js/: dependencies and compiler output. The Dart
+# side has no `node_modules` or `dist` of its own, so both patterns are safe
+# repository-wide — and one rule at the root beats one per package, which is
+# how a second JS package would end up committing its build.
+node_modules/
+dist/
+
 # Machine-local Claude Code settings. Everything else under .claude/ is
 # tracked: the skills there are how this framework is developed.
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This is the repository of **the DartWay framework itself** (fullstack Dart: Flut
 | `toolkit/` | The Claude harness for application projects (`dartway-*` skills, `__*__` tokens, the installer) |
 | `docs/` | Framework documentation and the single source of content for the dartway.dev site (see "Neighbours") |
 | `packages/dartway_studio_bridge` | The open bridge between an application and Studio: screen-spec models (in the application's code) plus the runtime postMessage protocol (host in the application, client in Studio) |
+| `js/studio-bridge` | The same bridge's application half for JavaScript apps (`@dartway/studio-bridge` on npm: core + React and Vue bindings). **Outside `packages/`**: that tree is the pub workspace (`packages/*`), and while pub does skip a folder without a `pubspec.yaml`, a JS package has no business sitting inside a Dart resolution. A second implementation of one protocol: it is held to the Dart one by golden wire strings in its tests, not by a shared schema |
 
 This repository is self-contained: everything it holds lives here. There are no foreign repositories nested in the tree.
 

--- a/docs/6-studio/studio-bridge.md
+++ b/docs/6-studio/studio-bridge.md
@@ -65,3 +65,24 @@ The open `dartway_studio_bridge` package is the only integration surface:
 See the package [README](../packages/dartway_studio_bridge/README.md) for the
 full API, and `example/dartway_example_flutter/lib/core/studio/` for the reference
 integration (manifest, sign-in executor, binding widget).
+
+## Apps that are not Flutter
+
+Studio previews a web build in an iframe, and nothing in the protocol is
+Flutter-specific — so an app written in React or Vue connects to the same
+Studio, unmodified. The app half of the bridge exists a second time as
+`js/studio-bridge` (`@dartway/studio-bridge` on npm): one core plus two thin
+bindings (`/react`, `/vue`), speaking the same protocol version, checking the
+same signature against the same shipped public key.
+
+Two things differ, and neither of them on the wire. A JS app **can** enumerate
+its features, because a declaration is a component and components are what a
+framework already tracks — where a Flutter app reports what is mounted, a React
+or Vue app declares `<StudioFeature>` and the registry does the rest. And every
+Studio command is gated on the handshake there, not just the manifest.
+
+The two implementations are kept honest by golden wire strings in the JS
+package's tests: the Dart encoder's exact output, key order included. Change the
+protocol on one side and those tests fail — which is the point, since the two
+packages version independently and a pilot team's preview is a poor place to
+discover a rename.

--- a/js/studio-bridge/CHANGELOG.md
+++ b/js/studio-bridge/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 0.1.0
+
+First release: the app side of the Studio bridge for JavaScript apps, speaking
+**protocol version 4** — the same wire format as the Dart package
+`dartway_studio_bridge` 0.7.0. A React or Vue app connects to an unmodified
+Studio; nothing on the Studio side knows which implementation it is talking to.
+
+- `attachStudioBridge` — the handshake, the manifest, route/session/locale/
+  feature reports and Studio's requests (navigate, sign in with test
+  credentials, sign out, switch locale, inspect a point). Returns `null` outside
+  an iframe, so the call needs no environment guard.
+- **Access is proved by a signature.** The public half of Studio's Ed25519 key
+  ships in the package; a build names the origin it answers at and accepts only
+  a live token signed for that origin. A build that names none accepts any
+  connection — the zero-config local-dev mode.
+- **Feature declarations** live in a registry independent of the bridge, so
+  declaring is free, cannot fail and does not depend on load order:
+  `declareStudioFeature` in plain JS, `<StudioFeature>` / `useStudioFeature` in
+  `@dartway/studio-bridge/react` and `@dartway/studio-bridge/vue`. A declaration
+  bound to an element also answers Studio's tap-to-inspect.
+- Route changes are picked up from `history` and `popstate`, so any router
+  reports itself without wiring.
+
+Two deliberate differences from the Dart implementation, neither of them visible
+on the wire:
+
+- **Every command is gated on the handshake**, not just the manifest — an
+  embedding page that presents no accepted token cannot navigate the app or sign
+  it in.
+- **Nothing is reported before a Studio has been let in**, so passports do not
+  travel to a frame that never proved who it was.

--- a/js/studio-bridge/LICENSE
+++ b/js/studio-bridge/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 DartWay contributors (https://dartway.dev)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/js/studio-bridge/README.md
+++ b/js/studio-bridge/README.md
@@ -1,0 +1,176 @@
+# @dartway/studio-bridge
+
+The app side of the [DartWay Studio](https://dartway.dev) bridge for JavaScript
+apps. Your app describes itself — navigation zones, screen passports, the
+features on the current screen — and Studio shows a live preview of the running
+build with that description attached to it: your client opens a screen, taps a
+block, and reads what it is meant to do.
+
+One package, three entry points: the core (`@dartway/studio-bridge`) and two
+thin bindings (`/react`, `/vue`). The protocol, the handshake and the access
+check live in the core, so the bindings cannot drift apart from each other — or
+from the Dart implementation of the same protocol that DartWay's Flutter apps
+use.
+
+```bash
+npm install @dartway/studio-bridge
+```
+
+## Connect
+
+One call, in your entry point. Outside a Studio frame it returns `null` and does
+nothing at all — there is nothing to guard with an environment check.
+
+```ts
+// main.ts
+import { attachStudioBridge } from '@dartway/studio-bridge';
+import { router } from './router';
+
+attachStudioBridge({
+  manifest: {
+    projectName: 'Fitness club',
+    zones: [
+      {
+        label: 'Client app',
+        rootPath: '/schedule',
+        access: 'signedIn',
+        screens: [
+          {
+            path: '/schedule',
+            title: 'Schedule',
+            purpose: 'The week ahead, so a client can find a class and book it',
+            discussionQuestions: ['Should a full session still be shown?'],
+          },
+        ],
+      },
+    ],
+    supportedLocales: ['en', 'ru'],
+  },
+
+  // Where this build answers. Studio is let in only with a token signed for
+  // exactly this origin. Left out, the app accepts any connection — which is
+  // what makes previewing your dev server zero-config.
+  appOrigin: import.meta.env.VITE_STUDIO_APP_ORIGIN,
+
+  onNavigate: (path) => router.push(path),
+  onSignIn: (identifier, secret) => auth.signIn(identifier, secret),
+  onSignOut: () => auth.signOut(),
+  onLocale: (locale) => i18n.use(locale),
+
+  currentSession: () => ({
+    isSignedIn: auth.isSignedIn,
+    userIdentifier: auth.phone,
+    displayLabel: auth.name,
+  }),
+});
+```
+
+Route changes are picked up from `history` and `popstate`, so any router works
+without wiring. Have your router call `host.reportRoute(path, routeName)`
+instead if your routes carry names worth sending; session and locale changes are
+reported with `reportSession` / `reportLocale` from wherever they happen.
+
+Studio's test credentials go through your **regular** sign-in — the app ships no
+test users and no special path for them.
+
+## Declare features
+
+This is the part that earns the integration. A feature says what it is next to
+its own code, and the app reports the ones on screen right now — so what your
+client reads is what the running build actually does, with nothing stored on
+Studio's side that could drift away from the code.
+
+```tsx
+// React
+import { StudioFeature } from '@dartway/studio-bridge/react';
+
+<StudioFeature
+  id="schedule/session-list"
+  title="Session list"
+  purpose="Lets a client find a class and book it"
+  behaviors={['Shows the coming week', 'A full session is marked as such']}
+  knownIssues={['A cancelled session still takes up its slot']}
+>
+  <SessionList />
+</StudioFeature>;
+```
+
+```vue
+<!-- Vue -->
+<script setup lang="ts">
+import { StudioFeature } from '@dartway/studio-bridge/vue'
+</script>
+
+<template>
+  <StudioFeature
+    id="schedule/session-list"
+    title="Session list"
+    purpose="Lets a client find a class and book it"
+    :behaviors="['Shows the coming week', 'A full session is marked as such']"
+  >
+    <SessionList />
+  </StudioFeature>
+</template>
+```
+
+Both bindings also come as a composable — `useStudioFeature(feature)` returns a
+ref to put on an element you already render, when you would rather not add a
+wrapper. Outside Studio a declaration costs one map entry and nothing else, so
+declare freely; a feature nobody declared is a feature nobody can point at.
+
+- `title`, `purpose`, `behaviors` — what a client reads.
+- `requirements`, `implementationNotes`, `knownIssues` — written for the team;
+  Studio shows them apart and flags every feature that carries an open issue.
+- `id` is a contract: it is what feedback and tracker items refer to, so give it
+  a stable name and never rename it in place.
+
+Binding the element also makes the feature reachable by **tapping** it in the
+preview: Studio asks what is at a point, and the innermost declaration around
+what is painted there answers.
+
+## Let Studio embed you
+
+The preview is an iframe, so the deployment has to allow being framed. On the
+preview deployment only:
+
+```text
+Content-Security-Policy: frame-ancestors https://<studio-origin>
+```
+
+and **no** `X-Frame-Options: DENY | SAMEORIGIN` — it is the older header, it
+takes precedence in some browsers, and it does not understand an allowed origin.
+
+If your auth rides on cookies, they have to survive a third-party frame:
+`SameSite=None; Secure` (which also means the preview must be served over
+https). Session storage in `localStorage` needs nothing.
+
+## Ship a branch
+
+Deploy the branch the way you normally deploy previews (Vercel, Netlify, a
+static bucket — the bridge does not care), then:
+
+1. give the build its own address —
+   `VITE_STUDIO_APP_ORIGIN=https://feature-x.preview.example.com`;
+2. add the header above to that deployment;
+3. paste the preview URL into Studio.
+
+The token Studio presents is short-lived, signed with its Ed25519 key and issued
+for that one origin, so a token taken off the wire is worthless anywhere else.
+**Your build holds no secret**: the public half of the pair ships inside this
+package, a public key can only check signatures and never make them, and it is
+the same for every project. There is nothing to copy out of Studio, store, or
+rotate.
+
+A build that names no origin (`appOrigin` left out) accepts any connection.
+That is deliberate — it is what makes `npm run dev` previewable with no keys at
+all — and it is why a deployed build should always name its address.
+
+Signature checking uses Ed25519 in WebCrypto (Chrome 137+, Safari 17+, Firefox
+130+) in a secure context. Where it is unavailable the app refuses the
+connection rather than trusting an unchecked token; the local-dev mode above is
+unaffected, since it verifies nothing.
+
+## Licence
+
+Apache-2.0, as the rest of the [DartWay](https://github.com/dartway/dartway)
+framework.

--- a/js/studio-bridge/package-lock.json
+++ b/js/studio-bridge/package-lock.json
@@ -1,0 +1,374 @@
+{
+  "name": "@dartway/studio-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dartway/studio-bridge",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "react": "^19.0.0",
+        "typescript": "^5.7.0",
+        "vue": "^3.5.0"
+      },
+      "engines": {
+        "node": ">=22.6"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "vue": ">=3.3"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+      "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+      "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/runtime-core": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+      "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
+      "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-sfc": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/server-renderer": "3.5.41",
+        "@vue/shared": "3.5.41"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/js/studio-bridge/package.json
+++ b/js/studio-bridge/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@dartway/studio-bridge",
+  "version": "0.1.0",
+  "description": "App side of the DartWay Studio bridge for JavaScript apps: declare your screens and features, let Studio preview and drive the running build.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "homepage": "https://dartway.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dartway/dartway.git",
+    "directory": "js/studio-bridge"
+  },
+  "bugs": "https://github.com/dartway/dartway/issues",
+  "keywords": ["dartway", "studio", "preview", "react", "vue"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "default": "./dist/react/index.js"
+    },
+    "./vue": {
+      "types": "./dist/vue/index.d.ts",
+      "default": "./dist/vue/index.js"
+    }
+  },
+  "files": ["dist", "README.md", "CHANGELOG.md", "LICENSE"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test",
+    "check": "npm run typecheck && npm test && npm run build"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "vue": ">=3.3"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": true },
+    "vue": { "optional": true }
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "typescript": "^5.7.0",
+    "vue": "^3.5.0"
+  },
+  "engines": {
+    "node": ">=22.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/js/studio-bridge/src/access/token.ts
+++ b/js/studio-bridge/src/access/token.ts
@@ -1,0 +1,170 @@
+/**
+ * The public half of the key pair DartWay Studio signs bridge access tokens
+ * with: base64 of the 32 raw Ed25519 public-key bytes.
+ *
+ * It ships inside this package deliberately. A public key only *checks*
+ * signatures — it cannot make them — so it is harmless in the open, and it is
+ * the same for every project, which is the whole point: a team connecting its
+ * app to Studio has nothing to copy out of Studio, nothing to keep secret and
+ * nothing to replace when the pair is rotated. They update this package.
+ *
+ * The same constant, byte for byte, ships in the Dart package.
+ */
+export const studioSigningPublicKey = 'gpXp+7p3BGDYFMvR2JHaBYuT1DaRsKhVeIBSgye44LM=';
+
+/** Separates a token's payload from its signature. */
+const tokenSegmentSeparator = '.';
+
+export interface VerifyStudioBridgeTokenOptions {
+  /** This app's own public address. An empty one matches nothing. */
+  appOrigin: string;
+  /** Defaults to {@link studioSigningPublicKey}. */
+  publicKey?: string | undefined;
+  /** Defaults to the current time. */
+  now?: Date | undefined;
+}
+
+/**
+ * Verifies an access token presented by a connecting Studio.
+ *
+ * **The wire format** — two base64url segments, unpadded, joined by a dot:
+ *
+ * ```text
+ * <payload>.<signature>
+ * payload   = base64url( utf8( {"origin":"https://app.example","exp":1765540000} ) )
+ * signature = base64url( ed25519_sign( privateKey, ascii(payload) ) )
+ * ```
+ *
+ * `origin` is the address the token is good for and `exp` is its expiry in
+ * whole seconds since the Unix epoch. The signature covers the payload
+ * **segment as written**, not the JSON it decodes to: whoever signs and whoever
+ * verifies then agree byte for byte without having to agree on how a map is
+ * serialised.
+ *
+ * Resolves true only when all four hold: the token parses, its signature checks
+ * out against `publicKey`, its `origin` is `appOrigin`, and its `exp` is still
+ * ahead of `now`. Anything else — a malformed token, a foreign origin, an
+ * expired one, one signed by another key — resolves false rather than throwing:
+ * a connection is refused the same way whatever is wrong with it, and the app
+ * carries on running.
+ *
+ * Origins are compared as scheme, host and port, so case and a trailing slash
+ * do not matter. An empty `appOrigin` matches nothing — an app that names no
+ * address of its own is not deciding here whether to accept the connection; see
+ * {@link studioSignedAccessValidator}, which is where that decision lives.
+ *
+ * **Requires Ed25519 in the platform's WebCrypto** (Chrome 137+, Safari 17+,
+ * Firefox 130+, Node 18.4+) and a secure context — https or localhost. Where it
+ * is missing, verification fails closed: the app refuses the connection instead
+ * of trusting an unchecked token.
+ */
+export async function verifyStudioBridgeToken(
+  accessToken: string,
+  { appOrigin, publicKey = studioSigningPublicKey, now }: VerifyStudioBridgeTokenOptions,
+): Promise<boolean> {
+  const expectedOrigin = normalizedOrigin(appOrigin);
+  if (expectedOrigin === '') return false;
+
+  const segments = accessToken.split(tokenSegmentSeparator);
+  if (segments.length !== 2) return false;
+  const [payloadSegment, signatureSegment] = segments as [string, string];
+
+  let claims: Record<string, unknown>;
+  let signature: Uint8Array<ArrayBuffer>;
+  let publicKeyBytes: Uint8Array<ArrayBuffer>;
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(decodeSegment(payloadSegment)));
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return false;
+    claims = parsed as Record<string, unknown>;
+    signature = decodeSegment(signatureSegment);
+    publicKeyBytes = decodeBase64(publicKey);
+  } catch {
+    return false;
+  }
+
+  if (normalizedOrigin(claims.origin) !== expectedOrigin) return false;
+
+  const expiresAtSeconds = claims.exp;
+  if (typeof expiresAtSeconds !== 'number' || !Number.isInteger(expiresAtSeconds)) return false;
+  if (expiresAtSeconds * 1000 <= (now ?? new Date()).getTime()) return false;
+
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle === undefined) return false;
+  try {
+    const key = await subtle.importKey('raw', publicKeyBytes, { name: 'Ed25519' }, false, [
+      'verify',
+    ]);
+    return await subtle.verify(
+      { name: 'Ed25519' },
+      key,
+      signature,
+      new TextEncoder().encode(payloadSegment),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export interface StudioSignedAccessOptions {
+  /**
+   * Exists for tests and for the day an app has to trust a Studio running on
+   * someone else's servers; a normal build leaves it alone.
+   */
+  publicKey?: string | undefined;
+}
+
+/**
+ * The access-token check the bridge host runs: accept a connecting Studio only
+ * when it presents a token issued for `appOrigin` — this app's own public
+ * address — and signed by Studio's key.
+ *
+ * A stolen token is therefore worthless anywhere but here, which is the
+ * property the whole scheme exists for.
+ *
+ * **An empty `appOrigin` accepts any connection.** That is the zero-config
+ * local-dev mode: a build that was never told what address it answers at lets a
+ * Studio on the same machine drive it without anyone issuing keys. A deployed
+ * build names its address and from then on only a signed token gets in.
+ */
+export function studioSignedAccessValidator(
+  appOrigin: string,
+  { publicKey = studioSigningPublicKey }: StudioSignedAccessOptions = {},
+): (accessToken: string) => Promise<boolean> {
+  return async (accessToken) =>
+    appOrigin.trim() === '' ||
+    (await verifyStudioBridgeToken(accessToken, { appOrigin, publicKey }));
+}
+
+/** Decodes one unpadded base64url segment, restoring the padding `atob` wants. */
+function decodeSegment(segment: string): Uint8Array<ArrayBuffer> {
+  return decodeBase64(segment.replaceAll('-', '+').replaceAll('_', '/'));
+}
+
+function decodeBase64(value: string): Uint8Array<ArrayBuffer> {
+  const padded = value.padEnd(Math.ceil(value.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Scheme, host and port of an address, so that `https://App.Example/` and
+ * `https://app.example` are the same origin. Anything that is not an http(s)
+ * URL with a host compares as itself — which is what makes a garbage `origin`
+ * claim fail against a real `appOrigin` rather than parse into something.
+ */
+function normalizedOrigin(address: unknown): string {
+  if (typeof address !== 'string') return '';
+  const trimmed = address.trim();
+  if (trimmed === '') return '';
+  try {
+    const url = new URL(trimmed);
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.host === '') {
+      return trimmed;
+    }
+    return url.origin;
+  } catch {
+    return trimmed;
+  }
+}

--- a/js/studio-bridge/src/features.ts
+++ b/js/studio-bridge/src/features.ts
@@ -1,0 +1,185 @@
+import type { StudioFeatureInfo } from './models.ts';
+
+/**
+ * The bit of a DOM element the registry needs. Any real `Element` satisfies it;
+ * so does a plain object, which is what lets the hit test be tested without a
+ * browser.
+ */
+export interface StudioFeatureElement {
+  getBoundingClientRect(): { left: number; top: number; right: number; bottom: number };
+  readonly parentElement: StudioFeatureElement | null;
+}
+
+/** A live declaration. Keep it for as long as the feature is on screen. */
+export interface StudioFeatureHandle {
+  /** Replaces the passport — the new text is reported on the next flush. */
+  update(feature: StudioFeatureInfo): void;
+  /** Binds (or unbinds) the element the feature paints into, for tap-to-inspect. */
+  attach(element: StudioFeatureElement | null): void;
+  /** Withdraws the declaration. Safe to call twice. */
+  release(): void;
+}
+
+/**
+ * Where the app currently paints. Defaults to the browser window; passed
+ * explicitly by tests and by anything rendering outside a plain document.
+ */
+export interface StudioFeatureViewport {
+  width: number;
+  height: number;
+  elementFromPoint?: ((x: number, y: number) => StudioFeatureElement | null) | undefined;
+}
+
+interface Entry {
+  feature: StudioFeatureInfo;
+  element: StudioFeatureElement | null;
+}
+
+/**
+ * What the app has declared about the screen it is showing right now.
+ *
+ * The registry is deliberately independent of the bridge host: components
+ * declare their features whether or not the app is being previewed, and whether
+ * or not the host has attached yet. Declaring therefore costs one call that
+ * cannot fail and cannot depend on load order — which is the whole point, since
+ * a feature nobody declared is a feature Studio cannot show.
+ */
+export class StudioFeatureRegistry {
+  #entries = new Map<number, Entry>();
+  #listeners = new Set<() => void>();
+  #nextKey = 0;
+
+  /** Declares a feature as present on the current screen. */
+  declare(feature: StudioFeatureInfo, element: StudioFeatureElement | null = null): StudioFeatureHandle {
+    const key = this.#nextKey++;
+    this.#entries.set(key, { feature, element });
+    this.#notify();
+
+    return {
+      update: (next) => {
+        const entry = this.#entries.get(key);
+        if (entry === undefined) return;
+        entry.feature = next;
+        this.#notify();
+      },
+      attach: (next) => {
+        const entry = this.#entries.get(key);
+        // No notification: where a feature sits changes nothing that travels
+        // over the wire, and a report per mounted element would be a flood.
+        if (entry !== undefined) entry.element = next;
+      },
+      release: () => {
+        if (this.#entries.delete(key)) this.#notify();
+      },
+    };
+  }
+
+  /**
+   * The features on screen, in declaration order, one entry per id: the same
+   * feature declared by several components is one feature.
+   */
+  list(): StudioFeatureInfo[] {
+    const byId = new Map<string, StudioFeatureInfo>();
+    for (const entry of this.#entries.values()) {
+      if (!byId.has(entry.feature.id)) byId.set(entry.feature.id, entry.feature);
+    }
+    return [...byId.values()];
+  }
+
+  /**
+   * The feature declared at a point given as fractions of the viewport (0.0
+   * top/left, 1.0 bottom/right) — the "pencil" tap-to-inspect flow.
+   *
+   * The innermost declaration wins: `elementFromPoint` finds what is actually
+   * painted there (so something scrolled out of view or covered does not answer
+   * for a point where the user sees nothing), then the ancestor chain is walked
+   * outwards to the nearest declared element. Where there is no document to ask
+   * — tests, exotic renderers — the smallest declared box containing the point
+   * is used instead.
+   */
+  featureAt(
+    horizontalFraction: number,
+    verticalFraction: number,
+    viewport?: StudioFeatureViewport,
+  ): StudioFeatureInfo | null {
+    const resolved = viewport ?? defaultViewport();
+    if (resolved === null) return null;
+
+    const x = horizontalFraction * resolved.width;
+    const y = verticalFraction * resolved.height;
+
+    const declared = new Map<StudioFeatureElement, StudioFeatureInfo>();
+    for (const entry of this.#entries.values()) {
+      if (entry.element !== null && !declared.has(entry.element)) {
+        declared.set(entry.element, entry.feature);
+      }
+    }
+    if (declared.size === 0) return null;
+
+    const painted = resolved.elementFromPoint?.(x, y) ?? null;
+    if (painted !== null) {
+      for (let node: StudioFeatureElement | null = painted; node !== null; node = node.parentElement) {
+        const feature = declared.get(node);
+        if (feature !== undefined) return feature;
+      }
+      return null;
+    }
+
+    let best: StudioFeatureInfo | null = null;
+    let bestArea = Number.POSITIVE_INFINITY;
+    for (const [element, feature] of declared) {
+      const rect = element.getBoundingClientRect();
+      if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) continue;
+      const area = (rect.right - rect.left) * (rect.bottom - rect.top);
+      if (area < bestArea) {
+        best = feature;
+        bestArea = area;
+      }
+    }
+    return best;
+  }
+
+  /** Notified whenever the declared set or any passport text changes. */
+  subscribe(listener: () => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  #notify(): void {
+    for (const listener of this.#listeners) listener();
+  }
+}
+
+function defaultViewport(): StudioFeatureViewport | null {
+  if (typeof window === 'undefined') return null;
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+    elementFromPoint:
+      typeof document === 'undefined' ? undefined : (x, y) => document.elementFromPoint(x, y),
+  };
+}
+
+/**
+ * The registry the framework wrappers and the bridge host share. One per page:
+ * a feature belongs to the screen the user is looking at, not to whichever
+ * module happened to import the bridge.
+ */
+export const studioFeatures = new StudioFeatureRegistry();
+
+/**
+ * Declares a feature as present on the current screen, and returns the handle
+ * that withdraws it.
+ *
+ * Framework wrappers (`@dartway/studio-bridge/react`, `/vue`) call this for
+ * you; reach for it directly in plain JS, or in a framework this package does
+ * not wrap yet.
+ */
+export function declareStudioFeature(
+  feature: StudioFeatureInfo,
+  element: StudioFeatureElement | null = null,
+): StudioFeatureHandle {
+  return studioFeatures.declare(feature, element);
+}

--- a/js/studio-bridge/src/host.ts
+++ b/js/studio-bridge/src/host.ts
@@ -1,0 +1,363 @@
+import {
+  studioFeatures,
+  type StudioFeatureElement,
+  type StudioFeatureHandle,
+  type StudioFeatureRegistry,
+} from './features.ts';
+import {
+  signedOutSession,
+  type StudioFeatureInfo,
+  type StudioProjectManifest,
+  type StudioSessionState,
+} from './models.ts';
+import { studioBridgeProtocol } from './protocol/protocol.ts';
+import type { StudioBridgeMessage } from './protocol/messages.ts';
+import { studioSignedAccessValidator } from './access/token.ts';
+import { createStudioHostChannel, type StudioMessageChannel } from './transport.ts';
+
+export interface StudioBridgeConfig {
+  /** What the app declares about itself: zones, screen passports, locales. */
+  manifest: StudioProjectManifest;
+
+  /**
+   * This app's own public address, e.g. `https://preview.example.com`. Studio
+   * is let in only when it presents a token signed for exactly this origin.
+   *
+   * **Left out (or empty) the app accepts any connection** — the zero-config
+   * local-dev mode, so that Studio on your laptop previews your dev server
+   * without anyone issuing keys. Name the origin on every deployed build.
+   */
+  appOrigin?: string | undefined;
+
+  /**
+   * The key that checks Studio's signature. Defaults to the one shipped in this
+   * package; override for tests, or for a Studio on someone else's servers.
+   */
+  publicKey?: string | undefined;
+
+  /** Defaults to the browser location (hash included, for hash routers). */
+  currentPath?: (() => string) | undefined;
+
+  /** Defaults to a signed-out session. */
+  currentSession?: (() => StudioSessionState) | undefined;
+
+  /** Active UI locale; omit when the app is not localized. */
+  currentLocale?: (() => string) | undefined;
+
+  /** Studio asks the app to navigate — run it through your own router. */
+  onNavigate?: ((path: string) => void) | undefined;
+
+  /**
+   * Studio asks the app to sign in with test credentials from its project
+   * config. Run them through your **regular** auth flow, exactly as if the user
+   * had typed them: `secret` is a test verification code for OTP flows, a
+   * password for password flows. The app ships no test users of its own.
+   */
+  onSignIn?: ((identifier: string, secret: string) => void | Promise<void>) | undefined;
+
+  onSignOut?: (() => void | Promise<void>) | undefined;
+
+  /** Studio asks for a locale from the manifest's `supportedLocales`. */
+  onLocale?: ((locale: string) => void) | undefined;
+
+  /**
+   * Report route changes by watching `history` and `popstate` (default true).
+   * Turn it off to call `reportRoute` from your router instead — which is what
+   * you want if your routes have stable names worth sending.
+   */
+  autoTrackRoute?: boolean | undefined;
+
+  /** Defaults to the shared registry the framework wrappers declare into. */
+  features?: StudioFeatureRegistry | undefined;
+
+  /**
+   * The message pipe. Defaults to `postMessage` towards the embedding window;
+   * supply one to test the handshake, or to embed the app some other way.
+   */
+  transport?: StudioMessageChannel | undefined;
+}
+
+export interface StudioBridgeHost {
+  /** True once Studio has presented an accepted token. */
+  readonly isConnected: boolean;
+
+  /**
+   * The app moved to a new location. `routeName` is the stable route identity
+   * (`adDetail`) where the path (`/ad/123`) is the instance context.
+   */
+  reportRoute(path: string, routeName?: string): void;
+
+  reportSession(session: StudioSessionState): void;
+
+  reportLocale(locale: string): void;
+
+  /**
+   * Sends the current screen's features now. Called for you whenever a
+   * declaration changes; reach for it after rendering something the registry
+   * cannot see change.
+   */
+  reportFeatures(): void;
+
+  /**
+   * Declares a feature on the current screen — the same as
+   * `declareStudioFeature`, reachable from the host for code that already holds
+   * one.
+   */
+  declareFeature(
+    feature: StudioFeatureInfo,
+    element?: StudioFeatureElement | null,
+  ): StudioFeatureHandle;
+
+  detach(): void;
+}
+
+let activeHost: StudioBridgeHost | null = null;
+
+/**
+ * Attaches the app side of the Studio bridge, or returns null when there is
+ * nothing to attach to — the app is not running inside an iframe. Callers keep
+ * the app fully functional on null: outside Studio the bridge simply is not
+ * there, and declaring features stays free.
+ *
+ * Call it once, as early as your app starts. Attaching again replaces the
+ * previous host (a module reload during development does exactly that).
+ */
+export function attachStudioBridge(config: StudioBridgeConfig): StudioBridgeHost | null {
+  const transport = config.transport ?? createStudioHostChannel();
+  if (transport === null) return null;
+
+  activeHost?.detach();
+  activeHost = new StudioBridgeHostImpl(config, transport);
+  return activeHost;
+}
+
+/** The attached host, or null outside Studio. */
+export function getStudioBridge(): StudioBridgeHost | null {
+  return activeHost;
+}
+
+class StudioBridgeHostImpl implements StudioBridgeHost {
+  #config: StudioBridgeConfig;
+  #channel: StudioMessageChannel;
+  #features: StudioFeatureRegistry;
+  #validateAccessToken: (accessToken: string) => Promise<boolean>;
+  #unsubscribe: (() => void)[] = [];
+  #connected = false;
+  #detached = false;
+  #featureReportScheduled = false;
+  #lastFeatureReport: string | null = null;
+  #lastTrackedPath: string | null = null;
+
+  constructor(config: StudioBridgeConfig, channel: StudioMessageChannel) {
+    this.#config = config;
+    this.#channel = channel;
+    this.#features = config.features ?? studioFeatures;
+    this.#validateAccessToken = studioSignedAccessValidator(config.appOrigin ?? '', {
+      publicKey: config.publicKey,
+    });
+
+    this.#unsubscribe.push(channel.subscribe((message) => this.#onMessage(message)));
+    this.#unsubscribe.push(this.#features.subscribe(() => this.#scheduleFeatureReport()));
+    if (config.autoTrackRoute ?? true) {
+      this.#lastTrackedPath = this.#currentPath();
+      this.#unsubscribe.push(trackBrowserRoute(() => this.#onBrowserRoute()));
+    }
+
+    channel.send({ type: studioBridgeProtocol.appReady });
+  }
+
+  get isConnected(): boolean {
+    return this.#connected;
+  }
+
+  #onMessage(message: StudioBridgeMessage): void {
+    if (message.type === studioBridgeProtocol.studioConnect) {
+      // Answer the handshake only if the token is accepted; on refusal stay
+      // silent — the app keeps running, Studio shows "not connected".
+      void this.#validateAccessToken(message.accessToken).then((accepted) => {
+        if (!accepted || this.#detached) return;
+        this.#connected = true;
+        this.#channel.send({
+          type: studioBridgeProtocol.manifest,
+          manifest: this.#config.manifest,
+          currentPath: this.#currentPath(),
+          session: this.#currentSession(),
+          features: this.#features.list(),
+          currentLocale: this.#config.currentLocale?.() ?? '',
+        });
+      });
+      return;
+    }
+
+    // Every command is gated on the handshake, not just the manifest —
+    // otherwise an embedding page could walk the app through its screens, or
+    // sign it in, without presenting anything.
+    if (!this.#connected) return;
+
+    switch (message.type) {
+      case studioBridgeProtocol.navigateRequest:
+        this.#config.onNavigate?.(message.path);
+        return;
+      case studioBridgeProtocol.signInRequest:
+        void this.#config.onSignIn?.(message.identifier, message.secret);
+        return;
+      case studioBridgeProtocol.signOutRequest:
+        void this.#config.onSignOut?.();
+        return;
+      case studioBridgeProtocol.localeRequest:
+        this.#config.onLocale?.(message.locale);
+        return;
+      case studioBridgeProtocol.inspectPointRequest:
+        this.#answerInspectPoint(
+          message.requestId,
+          message.horizontalFraction,
+          message.verticalFraction,
+        );
+        return;
+      default:
+        return; // App → Studio messages echoed back are ignored.
+    }
+  }
+
+  /**
+   * Answers an inspect request — and answers it even when the hit test throws.
+   * Staying silent is indistinguishable from an app that predates the message,
+   * so Studio would sit out its whole timeout and report a crash as "nothing
+   * declared here".
+   */
+  #answerInspectPoint(
+    requestId: string,
+    horizontalFraction: number,
+    verticalFraction: number,
+  ): void {
+    let feature: StudioFeatureInfo | null = null;
+    try {
+      feature = this.#features.featureAt(horizontalFraction, verticalFraction);
+    } catch (error) {
+      console.error('[dartway/studio-bridge] inspect-point request failed', error);
+    }
+    this.#channel.send(
+      feature === null
+        ? { type: studioBridgeProtocol.inspectPointResult, requestId }
+        : { type: studioBridgeProtocol.inspectPointResult, requestId, feature },
+    );
+  }
+
+  reportRoute(path: string, routeName?: string): void {
+    this.#lastTrackedPath = path;
+    if (!this.#connected) return;
+    this.#channel.send(
+      routeName === undefined
+        ? { type: studioBridgeProtocol.routeChanged, path }
+        : { type: studioBridgeProtocol.routeChanged, path, routeName },
+    );
+    this.#scheduleFeatureReport();
+  }
+
+  reportSession(session: StudioSessionState): void {
+    if (!this.#connected) return;
+    this.#channel.send({ type: studioBridgeProtocol.sessionChanged, session });
+  }
+
+  reportLocale(locale: string): void {
+    if (!this.#connected) return;
+    this.#channel.send({ type: studioBridgeProtocol.localeChanged, locale });
+  }
+
+  reportFeatures(): void {
+    this.#featureReportScheduled = false;
+    if (!this.#connected) return;
+    const path = this.#currentPath();
+    const features = this.#features.list();
+    // The same list for the same screen twice says nothing new; a re-render
+    // that touches every declaration would otherwise flood the channel.
+    const signature = JSON.stringify([path, features]);
+    if (signature === this.#lastFeatureReport) return;
+    this.#lastFeatureReport = signature;
+    this.#channel.send({ type: studioBridgeProtocol.featuresChanged, path, features });
+  }
+
+  declareFeature(
+    feature: StudioFeatureInfo,
+    element: StudioFeatureElement | null = null,
+  ): StudioFeatureHandle {
+    return this.#features.declare(feature, element);
+  }
+
+  detach(): void {
+    this.#detached = true;
+    this.#connected = false;
+    for (const unsubscribe of this.#unsubscribe) unsubscribe();
+    this.#unsubscribe = [];
+    this.#channel.dispose();
+    if (activeHost === this) activeHost = null;
+  }
+
+  #currentPath(): string {
+    return this.#config.currentPath?.() ?? defaultCurrentPath();
+  }
+
+  #currentSession(): StudioSessionState {
+    return this.#config.currentSession?.() ?? signedOutSession;
+  }
+
+  #onBrowserRoute(): void {
+    const path = this.#currentPath();
+    if (path === this.#lastTrackedPath) return;
+    this.reportRoute(path);
+  }
+
+  /**
+   * Features are reported one frame later on purpose: a route change fires
+   * before the new screen's components mount, so reporting in the same turn
+   * would describe the screen just left.
+   */
+  #scheduleFeatureReport(): void {
+    if (this.#featureReportScheduled || this.#detached) return;
+    this.#featureReportScheduled = true;
+    const flush = (): void => {
+      if (!this.#featureReportScheduled || this.#detached) return;
+      this.reportFeatures();
+    };
+    if (typeof requestAnimationFrame === 'function') requestAnimationFrame(flush);
+    else queueMicrotask(flush);
+  }
+}
+
+/** The location as a route path — the hash for hash routers, the path otherwise. */
+function defaultCurrentPath(): string {
+  if (typeof window === 'undefined') return '/';
+  const { hash, pathname } = window.location;
+  return hash.startsWith('#/') ? hash.slice(1) : pathname;
+}
+
+/**
+ * Watches the browser's own navigation, whatever router sits on top of it:
+ * `pushState`/`replaceState` are wrapped (routers call them and fire no event
+ * of their own) and back/forward and hash changes are listened for.
+ *
+ * Only ever installed inside a Studio frame — a standalone build of the app
+ * never has its history touched.
+ */
+function trackBrowserRoute(onChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof history === 'undefined') return () => {};
+
+  const original = { pushState: history.pushState, replaceState: history.replaceState };
+  for (const name of ['pushState', 'replaceState'] as const) {
+    const wrapped = original[name];
+    history[name] = function (this: History, ...args: Parameters<History['pushState']>) {
+      const result = wrapped.apply(this, args);
+      onChange();
+      return result;
+    };
+  }
+  window.addEventListener('popstate', onChange);
+  window.addEventListener('hashchange', onChange);
+
+  return () => {
+    history.pushState = original.pushState;
+    history.replaceState = original.replaceState;
+    window.removeEventListener('popstate', onChange);
+    window.removeEventListener('hashchange', onChange);
+  };
+}

--- a/js/studio-bridge/src/index.ts
+++ b/js/studio-bridge/src/index.ts
@@ -1,0 +1,70 @@
+/**
+ * The app side of the DartWay Studio bridge, for JavaScript apps.
+ *
+ * One core, two thin wrappers: `@dartway/studio-bridge/react` and
+ * `@dartway/studio-bridge/vue` only make declaring a feature idiomatic — the
+ * protocol, the handshake and the access check live here, in one place, so the
+ * two framework wrappers cannot drift apart from each other or from the Dart
+ * implementation of the same protocol.
+ */
+
+export {
+  signedOutSession,
+  type StudioFeatureInfo,
+  type StudioProjectManifest,
+  type StudioScreenSpec,
+  type StudioSessionState,
+  type StudioZoneAccess,
+  type StudioZoneSpec,
+} from './models.ts';
+
+export { studioBridgeProtocol } from './protocol/protocol.ts';
+
+export {
+  decodeStudioBridgeMessage,
+  encodeStudioBridgeMessage,
+  type AppReadyMessage,
+  type FeaturesChangedMessage,
+  type InspectPointRequestMessage,
+  type InspectPointResultMessage,
+  type LocaleChangedMessage,
+  type LocaleRequestMessage,
+  type ManifestMessage,
+  type NavigateRequestMessage,
+  type RouteChangedMessage,
+  type SessionChangedMessage,
+  type SignInRequestMessage,
+  type SignOutRequestMessage,
+  type StudioBridgeMessage,
+  type StudioConnectMessage,
+} from './protocol/messages.ts';
+
+export {
+  studioSignedAccessValidator,
+  studioSigningPublicKey,
+  verifyStudioBridgeToken,
+  type StudioSignedAccessOptions,
+  type VerifyStudioBridgeTokenOptions,
+} from './access/token.ts';
+
+export {
+  declareStudioFeature,
+  studioFeatures,
+  StudioFeatureRegistry,
+  type StudioFeatureElement,
+  type StudioFeatureHandle,
+  type StudioFeatureViewport,
+} from './features.ts';
+
+export {
+  createStudioHostChannel,
+  isEmbeddedInStudioFrame,
+  type StudioMessageChannel,
+} from './transport.ts';
+
+export {
+  attachStudioBridge,
+  getStudioBridge,
+  type StudioBridgeConfig,
+  type StudioBridgeHost,
+} from './host.ts';

--- a/js/studio-bridge/src/models.ts
+++ b/js/studio-bridge/src/models.ts
@@ -1,0 +1,290 @@
+/**
+ * The models an app declares about itself, and their wire encoding.
+ *
+ * Every `...ToJson` here mirrors the Dart package field for field, *including
+ * which fields are omitted when empty*: Studio parses leniently, but a format
+ * that drifts silently is exactly what the golden-string tests exist to catch.
+ */
+
+/** Who can enter a navigation zone. */
+export type StudioZoneAccess =
+  /** Reachable only when a user is signed in. */
+  | 'signedIn'
+  /**
+   * Reachable only when signed out; activating it while signed in means
+   * "sign out" (e.g. an auth zone).
+   */
+  | 'signedOut'
+  /** Reachable regardless of the session. */
+  | 'any';
+
+/**
+ * The screen passport declared in the app's code: functional specification
+ * plus product context, keyed by the screen's route path.
+ *
+ * Screens are identified by plain path strings so the bridge stays independent
+ * of any router — convert your typed routes to paths when declaring specs.
+ *
+ * Passport texts are plain single-language strings: whatever language the
+ * project team writes its specs in is what Studio shows.
+ */
+export interface StudioScreenSpec {
+  /** Full route path of the screen, e.g. `/schedule/profile`. */
+  path: string;
+  /** Full path of the parent screen (breadcrumb chain), omitted for roots. */
+  parentPath?: string | undefined;
+  title: string;
+  /** CJM / business context: why this screen exists. */
+  purpose: string;
+  discussionQuestions?: string[] | undefined;
+}
+
+/**
+ * A navigation zone of the app: a labelled group of screens with a root route.
+ * Zones have no display metadata in routers — it lives here.
+ */
+export interface StudioZoneSpec {
+  label: string;
+  /** Full path of the zone's root screen. */
+  rootPath: string;
+  /** Defaults to `any`. */
+  access?: StudioZoneAccess | undefined;
+  screens: StudioScreenSpec[];
+}
+
+/**
+ * A product feature — both as the app declares it next to the code and as it
+ * travels over the wire.
+ *
+ * The fields split by audience, and Studio shows them accordingly: `title`,
+ * `purpose` and `behaviors` are what a client reads, while `requirements`,
+ * `implementationNotes` and `knownIssues` are written for the team.
+ */
+export interface StudioFeatureInfo {
+  /**
+   * Stable id — deduplicates a feature declared by several components, and the
+   * name feedback and tracker items refer it by. A contract: never renamed in
+   * place.
+   */
+  id: string;
+  title: string;
+  /**
+   * Why the feature exists for the user; omitted for parts that serve a screen
+   * rather than carrying a purpose of their own.
+   */
+  purpose?: string | undefined;
+  /** What the feature observably does — one checkable statement per entry. */
+  behaviors?: string[] | undefined;
+  /** What it must honour, imposed from outside the feature. */
+  requirements?: string[] | undefined;
+  /** Decisions the team should not have to re-open. Technical side only. */
+  implementationNotes?: string[] | undefined;
+  /**
+   * What is wrong in the feature and worth taking into work. Studio filters on
+   * this to show which features carry open questions.
+   */
+  knownIssues?: string[] | undefined;
+}
+
+/**
+ * Everything an app declares about itself for Studio: navigation zones with
+ * screen passports, the feature catalog and the UI locales it can switch
+ * between.
+ *
+ * Demo personas are deliberately NOT part of the manifest: test users and
+ * their codes are configured in Studio, so a public web build never ships a
+ * list of privileged test accounts.
+ */
+export interface StudioProjectManifest {
+  projectName: string;
+  zones: StudioZoneSpec[];
+  /**
+   * The app's complete feature catalog. Studio diffs it against its own
+   * records on every connect — new features surface immediately, and a feature
+   * that vanished while carrying open work is flagged instead of silently
+   * unlinking. The live per-screen subset is reported separately, as the app
+   * navigates.
+   */
+  features?: StudioFeatureInfo[] | undefined;
+  /**
+   * Language tags of the app's UI locales (e.g. `['en', 'ru']`), first one is
+   * the default. Zero or one locale means the app is not switchable and Studio
+   * hides its locale control.
+   */
+  supportedLocales?: string[] | undefined;
+}
+
+/**
+ * The app's current session as far as Studio needs to know: whether someone is
+ * signed in, who it is (by the app's own identifier), and whether a requested
+ * sign-in is still in flight.
+ */
+export interface StudioSessionState {
+  isSignedIn: boolean;
+  /**
+   * The signed-in user's identifier in the form the app's auth uses (phone,
+   * email). Studio matches it against its own configured demo personas — the
+   * app knows nothing about personas.
+   */
+  userIdentifier?: string | undefined;
+  /** Label to show for the current user (e.g. profile name). */
+  displayLabel?: string | undefined;
+  /** True while the app is executing a requested sign-in or sign-out. */
+  isBusy?: boolean | undefined;
+}
+
+export const signedOutSession: StudioSessionState = { isSignedIn: false };
+
+// --- encoding ---------------------------------------------------------------
+
+type Json = Record<string, unknown>;
+
+export function featureToJson(feature: StudioFeatureInfo): Json {
+  const json: Json = { id: feature.id, title: feature.title };
+  if (feature.purpose != null) json.purpose = feature.purpose;
+  if (feature.behaviors?.length) json.behaviors = feature.behaviors;
+  if (feature.requirements?.length) json.requirements = feature.requirements;
+  if (feature.implementationNotes?.length) {
+    json.implementationNotes = feature.implementationNotes;
+  }
+  if (feature.knownIssues?.length) json.knownIssues = feature.knownIssues;
+  return json;
+}
+
+export function screenToJson(screen: StudioScreenSpec): Json {
+  const json: Json = { path: screen.path };
+  if (screen.parentPath != null) json.parentPath = screen.parentPath;
+  json.title = screen.title;
+  json.purpose = screen.purpose;
+  json.discussionQuestions = screen.discussionQuestions ?? [];
+  return json;
+}
+
+export function zoneToJson(zone: StudioZoneSpec): Json {
+  return {
+    label: zone.label,
+    rootPath: zone.rootPath,
+    access: zone.access ?? 'any',
+    screens: zone.screens.map(screenToJson),
+  };
+}
+
+export function manifestToJson(manifest: StudioProjectManifest): Json {
+  return {
+    projectName: manifest.projectName,
+    zones: manifest.zones.map(zoneToJson),
+    features: (manifest.features ?? []).map(featureToJson),
+    supportedLocales: manifest.supportedLocales ?? [],
+  };
+}
+
+export function sessionToJson(session: StudioSessionState): Json {
+  const json: Json = { isSignedIn: session.isSignedIn };
+  if (session.userIdentifier != null) json.userIdentifier = session.userIdentifier;
+  if (session.displayLabel != null) json.displayLabel = session.displayLabel;
+  json.isBusy = session.isBusy ?? false;
+  return json;
+}
+
+// --- decoding ---------------------------------------------------------------
+//
+// Lenient throughout, exactly as on the Dart side: an app built against an
+// older bridge sends neither the new lists nor `purpose`, and one built against
+// a newer bridge may send fields this version has never heard of. Both keep
+// working.
+
+export function asJson(value: unknown): Json {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Json)
+    : {};
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function stringListFromJson(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item) => typeof item === 'string') : [];
+}
+
+export function featureFromJson(json: Json): StudioFeatureInfo {
+  const feature: StudioFeatureInfo = {
+    id: asString(json.id),
+    title: asString(json.title),
+  };
+  const purpose = asOptionalString(json.purpose);
+  if (purpose !== undefined) feature.purpose = purpose;
+  const behaviors = stringListFromJson(json.behaviors);
+  if (behaviors.length) feature.behaviors = behaviors;
+  const requirements = stringListFromJson(json.requirements);
+  if (requirements.length) feature.requirements = requirements;
+  const implementationNotes = stringListFromJson(json.implementationNotes);
+  if (implementationNotes.length) feature.implementationNotes = implementationNotes;
+  const knownIssues = stringListFromJson(json.knownIssues);
+  if (knownIssues.length) feature.knownIssues = knownIssues;
+  return feature;
+}
+
+export function featureListFromJson(value: unknown): StudioFeatureInfo[] {
+  return Array.isArray(value)
+    ? value
+        .filter((item) => typeof item === 'object' && item !== null && !Array.isArray(item))
+        .map((item) => featureFromJson(item as Json))
+    : [];
+}
+
+export function screenFromJson(json: Json): StudioScreenSpec {
+  const screen: StudioScreenSpec = {
+    path: asString(json.path),
+    title: asString(json.title),
+    purpose: asString(json.purpose),
+    discussionQuestions: stringListFromJson(json.discussionQuestions),
+  };
+  const parentPath = asOptionalString(json.parentPath);
+  if (parentPath !== undefined) screen.parentPath = parentPath;
+  return screen;
+}
+
+export function zoneFromJson(json: Json): StudioZoneSpec {
+  const access = asString(json.access);
+  return {
+    label: asString(json.label),
+    rootPath: asString(json.rootPath, '/'),
+    access:
+      access === 'signedIn' || access === 'signedOut' || access === 'any' ? access : 'any',
+    screens: Array.isArray(json.screens)
+      ? json.screens
+          .filter((item) => typeof item === 'object' && item !== null && !Array.isArray(item))
+          .map((item) => screenFromJson(item as Json))
+      : [],
+  };
+}
+
+export function manifestFromJson(json: Json): StudioProjectManifest {
+  return {
+    projectName: asString(json.projectName),
+    zones: Array.isArray(json.zones)
+      ? json.zones
+          .filter((item) => typeof item === 'object' && item !== null && !Array.isArray(item))
+          .map((item) => zoneFromJson(item as Json))
+      : [],
+    features: featureListFromJson(json.features),
+    supportedLocales: stringListFromJson(json.supportedLocales),
+  };
+}
+
+export function sessionFromJson(json: Json): StudioSessionState {
+  const session: StudioSessionState = {
+    isSignedIn: json.isSignedIn === true,
+    isBusy: json.isBusy === true,
+  };
+  const userIdentifier = asOptionalString(json.userIdentifier);
+  if (userIdentifier !== undefined) session.userIdentifier = userIdentifier;
+  const displayLabel = asOptionalString(json.displayLabel);
+  if (displayLabel !== undefined) session.displayLabel = displayLabel;
+  return session;
+}

--- a/js/studio-bridge/src/protocol/messages.ts
+++ b/js/studio-bridge/src/protocol/messages.ts
@@ -1,0 +1,306 @@
+import {
+  asJson,
+  featureFromJson,
+  featureListFromJson,
+  featureToJson,
+  manifestFromJson,
+  manifestToJson,
+  sessionFromJson,
+  sessionToJson,
+  type StudioFeatureInfo,
+  type StudioProjectManifest,
+  type StudioSessionState,
+} from '../models.ts';
+import { studioBridgeProtocol } from './protocol.ts';
+
+// --- app → Studio -----------------------------------------------------------
+
+/** Announced on host attach (page load, reload). */
+export interface AppReadyMessage {
+  type: typeof studioBridgeProtocol.appReady;
+}
+
+/**
+ * The handshake response — the full manifest plus the current route, session,
+ * features and locale, so Studio renders correctly right away.
+ */
+export interface ManifestMessage {
+  type: typeof studioBridgeProtocol.manifest;
+  manifest: StudioProjectManifest;
+  currentPath: string;
+  session: StudioSessionState;
+  /** Features mounted on the current screen at connect time. */
+  features: StudioFeatureInfo[];
+  /** Active UI locale, empty when the app is not localized. */
+  currentLocale: string;
+}
+
+/**
+ * The app's router moved to a new location. `path` is the concrete location
+ * (`/ad/123`); `routeName` is the stable route identity (`adDetail`) — screen
+ * attribution binds to the name, the path is the instance context.
+ */
+export interface RouteChangedMessage {
+  type: typeof studioBridgeProtocol.routeChanged;
+  path: string;
+  routeName?: string;
+}
+
+/** The session changed (sign-in, sign-out, switch in progress). */
+export interface SessionChangedMessage {
+  type: typeof studioBridgeProtocol.sessionChanged;
+  session: StudioSessionState;
+}
+
+/** The features declared on the current screen changed. */
+export interface FeaturesChangedMessage {
+  type: typeof studioBridgeProtocol.featuresChanged;
+  path: string;
+  features: StudioFeatureInfo[];
+}
+
+/** The app's UI locale changed. */
+export interface LocaleChangedMessage {
+  type: typeof studioBridgeProtocol.localeChanged;
+  locale: string;
+}
+
+/**
+ * The answer to an inspect-point request — the feature at that point, or none
+ * when nothing declared covers it.
+ */
+export interface InspectPointResultMessage {
+  type: typeof studioBridgeProtocol.inspectPointResult;
+  /** Echoed back untouched, so a late answer cannot resolve a newer request. */
+  requestId: string;
+  feature?: StudioFeatureInfo;
+}
+
+// --- Studio → app -----------------------------------------------------------
+
+/**
+ * Connection request; the app answers with a manifest message only if it
+ * accepts `accessToken`. Sent on Studio start, retried while unconnected, and
+ * re-sent whenever an app-ready message arrives.
+ */
+export interface StudioConnectMessage {
+  type: typeof studioBridgeProtocol.studioConnect;
+  accessToken: string;
+}
+
+/** Navigate the live app to the given route path. */
+export interface NavigateRequestMessage {
+  type: typeof studioBridgeProtocol.navigateRequest;
+  path: string;
+}
+
+/**
+ * Sign in with the given test credentials through the app's regular auth flow.
+ * The credentials belong to Studio's project config — the app itself ships no
+ * test users and no special sign-in path.
+ */
+export interface SignInRequestMessage {
+  type: typeof studioBridgeProtocol.signInRequest;
+  /** The user identifier in the form the app's auth expects (phone, email). */
+  identifier: string;
+  /** A test verification code for OTP flows, a password for password flows. */
+  secret: string;
+}
+
+/** Sign the current user out. */
+export interface SignOutRequestMessage {
+  type: typeof studioBridgeProtocol.signOutRequest;
+}
+
+/** Switch the app UI to a language tag from the manifest's supportedLocales. */
+export interface LocaleRequestMessage {
+  type: typeof studioBridgeProtocol.localeRequest;
+  locale: string;
+}
+
+/**
+ * What feature, if any, is at this point on screen — the "pencil" flow's
+ * tap-to-inspect. The point is given as *fractions* of the app's own viewport
+ * (0.0 top/left, 1.0 bottom/right), not pixels: Studio may be showing the
+ * preview scaled or letterboxed, but a fraction of the viewport means the same
+ * point regardless of how it is currently displayed.
+ */
+export interface InspectPointRequestMessage {
+  type: typeof studioBridgeProtocol.inspectPointRequest;
+  /** Ties this request to the one answer that belongs to it; opaque to the app. */
+  requestId: string;
+  horizontalFraction: number;
+  verticalFraction: number;
+}
+
+export type StudioBridgeMessage =
+  | AppReadyMessage
+  | ManifestMessage
+  | RouteChangedMessage
+  | SessionChangedMessage
+  | FeaturesChangedMessage
+  | LocaleChangedMessage
+  | InspectPointResultMessage
+  | StudioConnectMessage
+  | NavigateRequestMessage
+  | SignInRequestMessage
+  | SignOutRequestMessage
+  | LocaleRequestMessage
+  | InspectPointRequestMessage;
+
+/**
+ * The payload of a message, with keys in the same order the Dart
+ * implementation writes them — so two encoders of one protocol produce the
+ * same string, and a golden-string test means something.
+ */
+function payloadToJson(message: StudioBridgeMessage): Record<string, unknown> {
+  switch (message.type) {
+    case studioBridgeProtocol.appReady:
+    case studioBridgeProtocol.signOutRequest:
+      return {};
+    case studioBridgeProtocol.manifest:
+      return {
+        manifest: manifestToJson(message.manifest),
+        currentPath: message.currentPath,
+        session: sessionToJson(message.session),
+        features: message.features.map(featureToJson),
+        currentLocale: message.currentLocale,
+      };
+    case studioBridgeProtocol.routeChanged:
+      return message.routeName != null
+        ? { path: message.path, routeName: message.routeName }
+        : { path: message.path };
+    case studioBridgeProtocol.sessionChanged:
+      return { session: sessionToJson(message.session) };
+    case studioBridgeProtocol.featuresChanged:
+      return { path: message.path, features: message.features.map(featureToJson) };
+    case studioBridgeProtocol.localeChanged:
+    case studioBridgeProtocol.localeRequest:
+      return { locale: message.locale };
+    case studioBridgeProtocol.inspectPointResult:
+      return message.feature != null
+        ? { requestId: message.requestId, feature: featureToJson(message.feature) }
+        : { requestId: message.requestId };
+    case studioBridgeProtocol.studioConnect:
+      return { accessToken: message.accessToken };
+    case studioBridgeProtocol.navigateRequest:
+      return { path: message.path };
+    case studioBridgeProtocol.signInRequest:
+      return { identifier: message.identifier, secret: message.secret };
+    case studioBridgeProtocol.inspectPointRequest:
+      return {
+        requestId: message.requestId,
+        horizontalFraction: message.horizontalFraction,
+        verticalFraction: message.verticalFraction,
+      };
+  }
+}
+
+/** Encodes a message into the string that travels over `postMessage`. */
+export function encodeStudioBridgeMessage(message: StudioBridgeMessage): string {
+  return JSON.stringify({
+    [studioBridgeProtocol.envelopeKey]: studioBridgeProtocol.version,
+    [studioBridgeProtocol.typeKey]: message.type,
+    [studioBridgeProtocol.payloadKey]: payloadToJson(message),
+  });
+}
+
+/**
+ * Parses raw `postMessage` data; null for anything that is not a valid message
+ * of the supported protocol version — foreign messages are common on `window`
+ * (dev tooling, browser extensions, other frames) and must be ignored
+ * silently.
+ */
+export function decodeStudioBridgeMessage(data: unknown): StudioBridgeMessage | null {
+  if (typeof data !== 'string') return null;
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) return null;
+
+  const envelope = decoded as Record<string, unknown>;
+  if (envelope[studioBridgeProtocol.envelopeKey] !== studioBridgeProtocol.version) return null;
+
+  const payload = asJson(envelope[studioBridgeProtocol.payloadKey]);
+  const string = (value: unknown, fallback = ''): string =>
+    typeof value === 'string' ? value : fallback;
+  const fraction = (value: unknown): number => (typeof value === 'number' ? value : 0);
+
+  switch (envelope[studioBridgeProtocol.typeKey]) {
+    case studioBridgeProtocol.appReady:
+      return { type: studioBridgeProtocol.appReady };
+    case studioBridgeProtocol.manifest:
+      return {
+        type: studioBridgeProtocol.manifest,
+        manifest: manifestFromJson(asJson(payload.manifest)),
+        currentPath: string(payload.currentPath, '/'),
+        session: sessionFromJson(asJson(payload.session)),
+        features: featureListFromJson(payload.features),
+        currentLocale: string(payload.currentLocale),
+      };
+    case studioBridgeProtocol.routeChanged: {
+      const message: RouteChangedMessage = {
+        type: studioBridgeProtocol.routeChanged,
+        path: string(payload.path, '/'),
+      };
+      if (typeof payload.routeName === 'string') message.routeName = payload.routeName;
+      return message;
+    }
+    case studioBridgeProtocol.sessionChanged:
+      return {
+        type: studioBridgeProtocol.sessionChanged,
+        session: sessionFromJson(asJson(payload.session)),
+      };
+    case studioBridgeProtocol.featuresChanged:
+      return {
+        type: studioBridgeProtocol.featuresChanged,
+        path: string(payload.path, '/'),
+        features: featureListFromJson(payload.features),
+      };
+    case studioBridgeProtocol.localeChanged:
+      return { type: studioBridgeProtocol.localeChanged, locale: string(payload.locale) };
+    case studioBridgeProtocol.inspectPointResult: {
+      const message: InspectPointResultMessage = {
+        type: studioBridgeProtocol.inspectPointResult,
+        requestId: string(payload.requestId),
+      };
+      if (
+        typeof payload.feature === 'object' &&
+        payload.feature !== null &&
+        !Array.isArray(payload.feature)
+      ) {
+        message.feature = featureFromJson(payload.feature as Record<string, unknown>);
+      }
+      return message;
+    }
+    case studioBridgeProtocol.studioConnect:
+      return {
+        type: studioBridgeProtocol.studioConnect,
+        accessToken: string(payload.accessToken),
+      };
+    case studioBridgeProtocol.navigateRequest:
+      return { type: studioBridgeProtocol.navigateRequest, path: string(payload.path, '/') };
+    case studioBridgeProtocol.signInRequest:
+      return {
+        type: studioBridgeProtocol.signInRequest,
+        identifier: string(payload.identifier),
+        secret: string(payload.secret),
+      };
+    case studioBridgeProtocol.signOutRequest:
+      return { type: studioBridgeProtocol.signOutRequest };
+    case studioBridgeProtocol.localeRequest:
+      return { type: studioBridgeProtocol.localeRequest, locale: string(payload.locale) };
+    case studioBridgeProtocol.inspectPointRequest:
+      return {
+        type: studioBridgeProtocol.inspectPointRequest,
+        requestId: string(payload.requestId),
+        horizontalFraction: fraction(payload.horizontalFraction),
+        verticalFraction: fraction(payload.verticalFraction),
+      };
+    default:
+      return null;
+  }
+}

--- a/js/studio-bridge/src/protocol/protocol.ts
+++ b/js/studio-bridge/src/protocol/protocol.ts
@@ -1,0 +1,44 @@
+/**
+ * Wire-level constants of the Studio bridge protocol.
+ *
+ * Every message is a JSON object encoded as a string:
+ * `{"dartwayStudioBridge": 4, "type": "<messageType>", "payload": {...}}`.
+ *
+ * This is a second implementation of one protocol — the first lives in the
+ * Dart package `dartway_studio_bridge`. The two are not generated from a
+ * shared schema, so the constants below are copied deliberately and the
+ * golden-string tests are what keeps them honest: change one side and the
+ * tests here fail rather than the pilot team's preview.
+ */
+export const studioBridgeProtocol = {
+  /**
+   * Bumped on breaking schema changes; both sides ignore other versions.
+   * See the Dart package for the history of versions 1-3.
+   * v4: `studioConnect` presents a short-lived `accessToken` — signed by
+   * Studio, issued for the app's own origin — instead of a shared secret.
+   */
+  version: 4,
+
+  /** Envelope marker key carrying the version. */
+  envelopeKey: 'dartwayStudioBridge',
+
+  typeKey: 'type',
+  payloadKey: 'payload',
+
+  // App → Studio.
+  appReady: 'appReady',
+  manifest: 'manifest',
+  routeChanged: 'routeChanged',
+  sessionChanged: 'sessionChanged',
+  featuresChanged: 'featuresChanged',
+  localeChanged: 'localeChanged',
+  inspectPointResult: 'inspectPointResult',
+
+  // Studio → app.
+  studioConnect: 'studioConnect',
+  navigateRequest: 'navigateRequest',
+  signInRequest: 'signInRequest',
+  signOutRequest: 'signOutRequest',
+  localeRequest: 'localeRequest',
+  inspectPointRequest: 'inspectPointRequest',
+} as const;

--- a/js/studio-bridge/src/react/index.ts
+++ b/js/studio-bridge/src/react/index.ts
@@ -1,0 +1,84 @@
+/**
+ * React binding: declaring a feature is one hook, or one component.
+ *
+ * Nothing here talks to Studio — declarations go into the shared registry, and
+ * the host (attached once, in your entry point) reports them. A build running
+ * outside Studio therefore pays a `Map` insert per declared feature and nothing
+ * else: there is no reason to make declaring conditional.
+ */
+import { createElement, useCallback, useEffect, useRef, type ReactNode } from 'react';
+
+import {
+  declareStudioFeature,
+  type StudioFeatureElement,
+  type StudioFeatureHandle,
+  type StudioFeatureInfo,
+} from '../index.ts';
+
+/**
+ * Declares a feature for as long as the component is mounted, and returns a ref
+ * to put on the element it paints into:
+ *
+ * ```tsx
+ * const feature = useStudioFeature({
+ *   id: 'schedule/session-list',
+ *   title: 'Session list',
+ *   purpose: 'Lets a client find a class and book it',
+ *   behaviors: ['Shows the coming week', 'A full session is marked as such'],
+ * });
+ * return <section ref={feature}>…</section>;
+ * ```
+ *
+ * The ref is optional — a feature declared without one still reaches Studio; it
+ * just cannot be found by tapping the preview.
+ */
+export function useStudioFeature(feature: StudioFeatureInfo): (element: Element | null) => void {
+  const handle = useRef<StudioFeatureHandle | null>(null);
+  const element = useRef<StudioFeatureElement | null>(null);
+
+  // The passport itself is the identity: written inline, it is a new object on
+  // every render, and a new object every render would re-declare on every
+  // render. Its text is what actually changed or did not.
+  const passport = JSON.stringify(feature);
+
+  useEffect(() => {
+    const declared = declareStudioFeature(
+      JSON.parse(passport) as StudioFeatureInfo,
+      element.current,
+    );
+    handle.current = declared;
+    return () => {
+      declared.release();
+      handle.current = null;
+    };
+  }, [passport]);
+
+  return useCallback((node: Element | null) => {
+    element.current = node;
+    handle.current?.attach(node);
+  }, []);
+}
+
+export interface StudioFeatureProps extends StudioFeatureInfo {
+  children?: ReactNode;
+}
+
+/**
+ * The same declaration as a wrapper, for when you have no element of your own
+ * to hang the ref on:
+ *
+ * ```tsx
+ * <StudioFeature id="schedule/session-list" title="Session list">
+ *   <SessionList />
+ * </StudioFeature>
+ * ```
+ *
+ * The wrapper renders a `display: contents` box, so it adds a node to the DOM
+ * (which is what tap-to-inspect finds) without adding a box to the layout.
+ */
+export function StudioFeature({ children, ...feature }: StudioFeatureProps): ReactNode {
+  const ref = useStudioFeature(feature);
+  return createElement('div', { ref, style: featureBoxStyle }, children);
+}
+
+const featureBoxStyle = { display: 'contents' } as const;

--- a/js/studio-bridge/src/transport.ts
+++ b/js/studio-bridge/src/transport.ts
@@ -1,0 +1,76 @@
+import {
+  decodeStudioBridgeMessage,
+  encodeStudioBridgeMessage,
+  type StudioBridgeMessage,
+} from './protocol/messages.ts';
+
+/**
+ * A two-way message pipe between an app and Studio. The shipped implementation
+ * wraps `window.postMessage`; the host accepts any implementation, which is how
+ * the handshake is tested without a browser.
+ */
+export interface StudioMessageChannel {
+  /** Decoded messages from the other side. Returns an unsubscribe function. */
+  subscribe(listener: (message: StudioBridgeMessage) => void): () => void;
+  send(message: StudioBridgeMessage): void;
+  dispose(): void;
+}
+
+/**
+ * True when this page runs inside an iframe — the only context where attaching
+ * can succeed. False during server-side rendering, where there is no window at
+ * all.
+ */
+export function isEmbeddedInStudioFrame(): boolean {
+  return typeof window !== 'undefined' && window.parent !== window;
+}
+
+/**
+ * The app-side transport, or null when there is nothing to attach to.
+ *
+ * Origin note: the channel accepts the first valid bridge message from the
+ * embedding window and pins that origin for its replies. There is no origin
+ * allowlist — an embedding page can only drive what the bridge exposes, and
+ * what it may drive at all is decided by the access token, not by the frame it
+ * sits in.
+ */
+export function createStudioHostChannel(): StudioMessageChannel | null {
+  if (!isEmbeddedInStudioFrame()) return null;
+  return new StudioHostWindowChannel();
+}
+
+class StudioHostWindowChannel implements StudioMessageChannel {
+  #listeners = new Set<(message: StudioBridgeMessage) => void>();
+
+  /** Studio's origin once the first valid bridge message arrives; targeted
+   * replies go there instead of `*`. */
+  #peerOrigin: string | null = null;
+
+  #onWindowMessage = (event: MessageEvent): void => {
+    if (typeof event.data !== 'string') return;
+    const message = decodeStudioBridgeMessage(event.data);
+    if (message === null) return;
+    this.#peerOrigin = event.origin;
+    for (const listener of this.#listeners) listener(message);
+  };
+
+  constructor() {
+    window.addEventListener('message', this.#onWindowMessage);
+  }
+
+  subscribe(listener: (message: StudioBridgeMessage) => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  send(message: StudioBridgeMessage): void {
+    window.parent.postMessage(encodeStudioBridgeMessage(message), this.#peerOrigin ?? '*');
+  }
+
+  dispose(): void {
+    window.removeEventListener('message', this.#onWindowMessage);
+    this.#listeners.clear();
+  }
+}

--- a/js/studio-bridge/src/vue/index.ts
+++ b/js/studio-bridge/src/vue/index.ts
@@ -1,0 +1,118 @@
+/**
+ * Vue binding: declaring a feature is one composable, or one component.
+ *
+ * Nothing here talks to Studio — declarations go into the shared registry, and
+ * the host (attached once, in your entry point) reports them. A build running
+ * outside Studio therefore pays a `Map` insert per declared feature and nothing
+ * else: there is no reason to make declaring conditional.
+ */
+import {
+  defineComponent,
+  h,
+  onScopeDispose,
+  ref,
+  toValue,
+  watch,
+  type MaybeRefOrGetter,
+  type PropType,
+  type Ref,
+  type VNode,
+} from 'vue';
+
+import {
+  declareStudioFeature,
+  type StudioFeatureHandle,
+  type StudioFeatureInfo,
+} from '../index.ts';
+
+/**
+ * Declares a feature for as long as the component is mounted, and returns the
+ * template ref to bind to the element it paints into:
+ *
+ * ```vue
+ * <script setup lang="ts">
+ * const feature = useStudioFeature({
+ *   id: 'schedule/session-list',
+ *   title: 'Session list',
+ *   purpose: 'Lets a client find a class and book it',
+ *   behaviors: ['Shows the coming week', 'A full session is marked as such'],
+ * })
+ * </script>
+ *
+ * <template>
+ *   <section :ref="feature">…</section>
+ * </template>
+ * ```
+ *
+ * The ref is optional — a feature declared without one still reaches Studio; it
+ * just cannot be found by tapping the preview. Pass a getter or a ref when the
+ * passport itself changes with the state.
+ */
+export function useStudioFeature(
+  feature: MaybeRefOrGetter<StudioFeatureInfo>,
+): Ref<Element | null> {
+  const element = ref<Element | null>(null);
+  let handle: StudioFeatureHandle | null = null;
+
+  watch(
+    [() => toValue(feature), element],
+    ([passport, node]) => {
+      if (handle === null) {
+        handle = declareStudioFeature(passport, node);
+      } else {
+        handle.update(passport);
+        handle.attach(node);
+      }
+    },
+    // Deep, because the passport is normally written inline and is a new object
+    // every time it is read; what matters is whether its text changed.
+    { immediate: true, deep: true },
+  );
+
+  onScopeDispose(() => {
+    handle?.release();
+    handle = null;
+  });
+
+  return element;
+}
+
+/**
+ * The same declaration as a wrapper, for when you have no element of your own
+ * to bind the ref to:
+ *
+ * ```vue
+ * <StudioFeature id="schedule/session-list" title="Session list">
+ *   <SessionList />
+ * </StudioFeature>
+ * ```
+ *
+ * The wrapper renders a `display: contents` box, so it adds a node to the DOM
+ * (which is what tap-to-inspect finds) without adding a box to the layout.
+ */
+export const StudioFeature = defineComponent({
+  name: 'StudioFeature',
+  props: {
+    id: { type: String, required: true },
+    title: { type: String, required: true },
+    purpose: { type: String, default: undefined },
+    behaviors: { type: Array as PropType<string[]>, default: undefined },
+    requirements: { type: Array as PropType<string[]>, default: undefined },
+    implementationNotes: { type: Array as PropType<string[]>, default: undefined },
+    knownIssues: { type: Array as PropType<string[]>, default: undefined },
+  },
+  setup(props, { slots }) {
+    const element = useStudioFeature(() => ({
+      id: props.id,
+      title: props.title,
+      purpose: props.purpose,
+      behaviors: props.behaviors,
+      requirements: props.requirements,
+      implementationNotes: props.implementationNotes,
+      knownIssues: props.knownIssues,
+    }));
+
+    return (): VNode =>
+      h('div', { ref: element, style: { display: 'contents' } }, slots.default?.());
+  },
+});

--- a/js/studio-bridge/test/features.test.ts
+++ b/js/studio-bridge/test/features.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { StudioFeatureRegistry, type StudioFeatureElement } from '../src/index.ts';
+
+interface Rect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+class FakeElement implements StudioFeatureElement {
+  readonly parentElement: StudioFeatureElement | null;
+  #rect: Rect;
+
+  constructor(rect: Rect, parentElement: StudioFeatureElement | null = null) {
+    this.#rect = rect;
+    this.parentElement = parentElement;
+  }
+
+  getBoundingClientRect(): Rect {
+    return this.#rect;
+  }
+}
+
+/** A 400×800 phone-shaped viewport, so fractions turn into round numbers. */
+const viewport = (elementFromPoint?: (x: number, y: number) => StudioFeatureElement | null) => ({
+  width: 400,
+  height: 800,
+  ...(elementFromPoint === undefined ? {} : { elementFromPoint }),
+});
+
+describe('what is on screen', () => {
+  test('features are listed in declaration order', () => {
+    const registry = new StudioFeatureRegistry();
+    registry.declare({ id: 'a', title: 'A' });
+    registry.declare({ id: 'b', title: 'B' });
+
+    assert.deepEqual(
+      registry.list().map((feature) => feature.id),
+      ['a', 'b'],
+    );
+  });
+
+  test('one feature declared by several components is one feature', () => {
+    const registry = new StudioFeatureRegistry();
+    registry.declare({ id: 'card', title: 'Card' });
+    registry.declare({ id: 'card', title: 'Card' });
+    registry.declare({ id: 'card', title: 'Card' });
+
+    assert.equal(registry.list().length, 1);
+  });
+
+  test('a released feature leaves the screen', () => {
+    const registry = new StudioFeatureRegistry();
+    const handle = registry.declare({ id: 'a', title: 'A' });
+    handle.release();
+    handle.release(); // idempotent
+
+    assert.deepEqual(registry.list(), []);
+  });
+
+  test('an updated passport replaces the old text', () => {
+    const registry = new StudioFeatureRegistry();
+    const handle = registry.declare({ id: 'a', title: 'A' });
+    handle.update({ id: 'a', title: 'A', knownIssues: ['the empty state is missing'] });
+
+    assert.deepEqual(registry.list()[0]?.knownIssues, ['the empty state is missing']);
+  });
+
+  test('subscribers hear a change of declarations, but not a change of position', () => {
+    const registry = new StudioFeatureRegistry();
+    let changes = 0;
+    const unsubscribe = registry.subscribe(() => {
+      changes++;
+    });
+
+    const handle = registry.declare({ id: 'a', title: 'A' });
+    handle.update({ id: 'a', title: 'A2' });
+    handle.attach(new FakeElement({ left: 0, top: 0, right: 10, bottom: 10 }));
+    handle.release();
+    assert.equal(changes, 3);
+
+    unsubscribe();
+    registry.declare({ id: 'b', title: 'B' });
+    assert.equal(changes, 3);
+  });
+});
+
+describe('the point Studio taps', () => {
+  test('the innermost declaration around what is painted there wins', () => {
+    const registry = new StudioFeatureRegistry();
+    const screen = new FakeElement({ left: 0, top: 0, right: 400, bottom: 800 });
+    const card = new FakeElement({ left: 0, top: 100, right: 400, bottom: 300 }, screen);
+    const painted = new FakeElement({ left: 10, top: 110, right: 100, bottom: 140 }, card);
+
+    registry.declare({ id: 'schedule', title: 'Schedule' }, screen);
+    registry.declare({ id: 'schedule/card', title: 'Session card' }, card);
+
+    assert.equal(
+      registry.featureAt(0.5, 0.25, viewport(() => painted))?.id,
+      'schedule/card',
+    );
+  });
+
+  test('nothing is answered for a point outside every declaration', () => {
+    const registry = new StudioFeatureRegistry();
+    const card = new FakeElement({ left: 0, top: 100, right: 400, bottom: 300 });
+    const elsewhere = new FakeElement({ left: 0, top: 700, right: 400, bottom: 800 });
+    registry.declare({ id: 'schedule/card', title: 'Session card' }, card);
+
+    assert.equal(registry.featureAt(0.5, 0.95, viewport(() => elsewhere)), null);
+  });
+
+  test('a feature declared without an element cannot be tapped', () => {
+    const registry = new StudioFeatureRegistry();
+    registry.declare({ id: 'a', title: 'A' });
+
+    assert.equal(registry.featureAt(0.5, 0.5, viewport(() => null)), null);
+  });
+
+  test('with no document to ask, the smallest box containing the point answers', () => {
+    const registry = new StudioFeatureRegistry();
+    registry.declare(
+      { id: 'schedule', title: 'Schedule' },
+      new FakeElement({ left: 0, top: 0, right: 400, bottom: 800 }),
+    );
+    registry.declare(
+      { id: 'schedule/card', title: 'Session card' },
+      new FakeElement({ left: 0, top: 100, right: 400, bottom: 300 }),
+    );
+
+    assert.equal(registry.featureAt(0.5, 0.25, viewport())?.id, 'schedule/card');
+    assert.equal(registry.featureAt(0.5, 0.75, viewport())?.id, 'schedule');
+  });
+});

--- a/js/studio-bridge/test/host.test.ts
+++ b/js/studio-bridge/test/host.test.ts
@@ -1,0 +1,444 @@
+import assert from 'node:assert/strict';
+import { before, describe, test } from 'node:test';
+
+import {
+  attachStudioBridge,
+  decodeStudioBridgeMessage,
+  encodeStudioBridgeMessage,
+  StudioFeatureRegistry,
+  type StudioBridgeMessage,
+  type StudioMessageChannel,
+  type StudioProjectManifest,
+} from '../src/index.ts';
+
+/**
+ * Studio, as far as the app can tell: everything crosses this channel as the
+ * same wire string `postMessage` would carry, so the tests exercise the real
+ * encoder and decoder rather than a shortcut around them.
+ */
+class FakeStudio implements StudioMessageChannel {
+  readonly wire: string[] = [];
+  disposed = false;
+  #listeners = new Set<(message: StudioBridgeMessage) => void>();
+
+  subscribe(listener: (message: StudioBridgeMessage) => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  send(message: StudioBridgeMessage): void {
+    this.wire.push(encodeStudioBridgeMessage(message));
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.#listeners.clear();
+  }
+
+  /** Studio speaks. */
+  say(message: StudioBridgeMessage): void {
+    const delivered = decodeStudioBridgeMessage(encodeStudioBridgeMessage(message));
+    assert.notEqual(delivered, null);
+    for (const listener of [...this.#listeners]) listener(delivered as StudioBridgeMessage);
+  }
+
+  get heard(): StudioBridgeMessage[] {
+    return this.wire.map((raw) => decodeStudioBridgeMessage(raw) as StudioBridgeMessage);
+  }
+
+  of<T extends StudioBridgeMessage['type']>(
+    type: T,
+  ): Extract<StudioBridgeMessage, { type: T }>[] {
+    return this.heard.filter((message) => message.type === type) as Extract<
+      StudioBridgeMessage,
+      { type: T }
+    >[];
+  }
+}
+
+const manifest: StudioProjectManifest = {
+  projectName: 'Demo',
+  zones: [
+    {
+      label: 'Client app',
+      rootPath: '/schedule',
+      access: 'signedIn',
+      screens: [{ path: '/schedule', title: 'Schedule', purpose: 'The week ahead' }],
+    },
+  ],
+  supportedLocales: ['en', 'ru'],
+};
+
+const appOrigin = 'https://app.example.com';
+
+async function waitFor(condition: () => boolean, what: string): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+/** Long enough for anything the host was going to do to have happened. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+}
+
+// --- Studio's half of the token contract, as in token.test.ts ---------------
+
+let studioKeyPair: CryptoKeyPair;
+let studioPublicKey: string;
+
+before(async () => {
+  studioKeyPair = (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  studioPublicKey = base64(
+    new Uint8Array(await crypto.subtle.exportKey('raw', studioKeyPair.publicKey)),
+  );
+});
+
+async function tokenFor(origin: string, expiresAt: Date): Promise<string> {
+  const payload = base64(
+    new TextEncoder().encode(
+      JSON.stringify({ origin, exp: Math.floor(expiresAt.getTime() / 1000) }),
+    ),
+  )
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+  const signature = await crypto.subtle.sign(
+    { name: 'Ed25519' },
+    studioKeyPair.privateKey,
+    new TextEncoder().encode(payload),
+  );
+  return `${payload}.${base64(new Uint8Array(signature))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '')}`;
+}
+
+function base64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+describe('the handshake', () => {
+  test('the app announces itself the moment it attaches', () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({ manifest, transport: studio });
+    assert.notEqual(host, null);
+    assert.deepEqual(studio.heard, [{ type: 'appReady' }]);
+    host?.detach();
+  });
+
+  test('a token signed for this origin gets the manifest', async () => {
+    const studio = new FakeStudio();
+    const features = new StudioFeatureRegistry();
+    features.declare({ id: 'schedule/session-list', title: 'Session list' });
+
+    const host = attachStudioBridge({
+      manifest,
+      appOrigin,
+      publicKey: studioPublicKey,
+      features,
+      transport: studio,
+      currentPath: () => '/schedule',
+      currentSession: () => ({ isSignedIn: true, userIdentifier: '79990000002' }),
+      currentLocale: () => 'ru',
+    });
+
+    studio.say({
+      type: 'studioConnect',
+      accessToken: await tokenFor(appOrigin, new Date(Date.now() + 600_000)),
+    });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+    const answer = studio.of('manifest')[0];
+    assert.equal(answer?.manifest.projectName, 'Demo');
+    assert.equal(answer?.currentPath, '/schedule');
+    assert.equal(answer?.session.userIdentifier, '79990000002');
+    assert.equal(answer?.currentLocale, 'ru');
+    assert.deepEqual(answer?.features.map((feature) => feature.id), ['schedule/session-list']);
+    assert.equal(host?.isConnected, true);
+    host?.detach();
+  });
+
+  test('a token issued for someone else gets nothing at all', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({
+      manifest,
+      appOrigin,
+      publicKey: studioPublicKey,
+      transport: studio,
+    });
+
+    studio.say({
+      type: 'studioConnect',
+      accessToken: await tokenFor('https://someone-else.example.com', new Date(Date.now() + 600_000)),
+    });
+    await settle();
+
+    assert.deepEqual(studio.of('manifest'), []);
+    assert.equal(host?.isConnected, false);
+    host?.detach();
+  });
+
+  test('an expired token gets nothing at all', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({
+      manifest,
+      appOrigin,
+      publicKey: studioPublicKey,
+      transport: studio,
+    });
+
+    studio.say({
+      type: 'studioConnect',
+      accessToken: await tokenFor(appOrigin, new Date(Date.now() - 1000)),
+    });
+    await settle();
+
+    assert.deepEqual(studio.of('manifest'), []);
+    assert.equal(host?.isConnected, false);
+    host?.detach();
+  });
+
+  test('a build that names no origin connects without a token (local dev)', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({ manifest, transport: studio });
+
+    studio.say({ type: 'studioConnect', accessToken: '' });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+    assert.equal(host?.isConnected, true);
+    host?.detach();
+  });
+});
+
+describe('commands', () => {
+  test('are refused until the handshake has been accepted', async () => {
+    const studio = new FakeStudio();
+    const navigated: string[] = [];
+    const host = attachStudioBridge({
+      manifest,
+      appOrigin,
+      publicKey: studioPublicKey,
+      transport: studio,
+      onNavigate: (path) => navigated.push(path),
+    });
+
+    studio.say({ type: 'navigateRequest', path: '/admin' });
+    await settle();
+    assert.deepEqual(navigated, [], 'drove the app without presenting a token');
+
+    studio.say({
+      type: 'studioConnect',
+      accessToken: await tokenFor(appOrigin, new Date(Date.now() + 600_000)),
+    });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+    studio.say({ type: 'navigateRequest', path: '/schedule' });
+    assert.deepEqual(navigated, ['/schedule']);
+    host?.detach();
+  });
+
+  test('reach the app once it is connected', async () => {
+    const studio = new FakeStudio();
+    const done: string[] = [];
+    const host = attachStudioBridge({
+      manifest,
+      transport: studio,
+      onSignIn: (identifier, secret) => {
+        done.push(`signIn:${identifier}:${secret}`);
+      },
+      onSignOut: () => {
+        done.push('signOut');
+      },
+      onLocale: (locale) => done.push(`locale:${locale}`),
+    });
+
+    studio.say({ type: 'studioConnect', accessToken: '' });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+    studio.say({ type: 'signInRequest', identifier: '79990000002', secret: '123456' });
+    studio.say({ type: 'signOutRequest' });
+    studio.say({ type: 'localeRequest', locale: 'ru' });
+
+    assert.deepEqual(done, ['signIn:79990000002:123456', 'signOut', 'locale:ru']);
+    host?.detach();
+  });
+
+  test('an inspect request is always answered, with the id it came with', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({ manifest, transport: studio });
+
+    studio.say({ type: 'studioConnect', accessToken: '' });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+    // Nothing is declared with an element here, and there is no document to hit
+    // test against — the point is that silence is never the answer, since
+    // Studio cannot tell it apart from an app that predates the message.
+    studio.say({
+      type: 'inspectPointRequest',
+      requestId: 'inspect-7',
+      horizontalFraction: 0.5,
+      verticalFraction: 0.5,
+    });
+
+    assert.deepEqual(studio.of('inspectPointResult'), [
+      { type: 'inspectPointResult', requestId: 'inspect-7' },
+    ]);
+    host?.detach();
+  });
+});
+
+describe('reporting the current screen', () => {
+  test('a feature declared after connecting is reported for the current path', async () => {
+    const studio = new FakeStudio();
+    const features = new StudioFeatureRegistry();
+    let path = '/schedule';
+    const host = attachStudioBridge({
+      manifest,
+      features,
+      transport: studio,
+      currentPath: () => path,
+    });
+
+    studio.say({ type: 'studioConnect', accessToken: '' });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+    assert.deepEqual(studio.of('manifest')[0]?.features, []);
+
+    const listed = features.declare({
+      id: 'schedule/session-list',
+      title: 'Session list',
+      purpose: 'Lets a client find a class and book it',
+      behaviors: ['Shows the coming week'],
+      knownIssues: ['Cancelled sessions still take a slot'],
+    });
+    const booking = features.declare({ id: 'schedule/booking', title: 'Booking' });
+
+    await waitFor(() => studio.of('featuresChanged').length === 1, 'the feature report');
+    const report = studio.of('featuresChanged')[0];
+    assert.equal(report?.path, '/schedule');
+    assert.deepEqual(
+      report?.features.map((feature) => feature.id),
+      ['schedule/session-list', 'schedule/booking'],
+    );
+    assert.deepEqual(report?.features[0]?.knownIssues, ['Cancelled sessions still take a slot']);
+
+    // Leaving the screen withdraws what it declared.
+    path = '/admin';
+    listed.release();
+    booking.release();
+    await waitFor(() => studio.of('featuresChanged').length === 2, 'the second feature report');
+    assert.deepEqual(studio.of('featuresChanged')[1], {
+      type: 'featuresChanged',
+      path: '/admin',
+      features: [],
+    });
+
+    host?.detach();
+  });
+
+  test('the same screen is not reported twice over', async () => {
+    const studio = new FakeStudio();
+    const features = new StudioFeatureRegistry();
+    const host = attachStudioBridge({
+      manifest,
+      features,
+      transport: studio,
+      currentPath: () => '/schedule',
+    });
+
+    studio.say({ type: 'studioConnect', accessToken: '' });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+    const handle = features.declare({ id: 'a', title: 'A' });
+    await waitFor(() => studio.of('featuresChanged').length === 1, 'the feature report');
+
+    // A re-render that re-declares the very same passport says nothing new.
+    handle.update({ id: 'a', title: 'A' });
+    host?.reportFeatures();
+    await settle();
+    assert.equal(studio.of('featuresChanged').length, 1);
+
+    handle.update({ id: 'a', title: 'A', purpose: 'why it exists' });
+    await waitFor(() => studio.of('featuresChanged').length === 2, 'the updated passport');
+
+    host?.detach();
+  });
+
+  test('route, session and locale changes reach a connected Studio', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({
+      manifest,
+      transport: studio,
+      currentPath: () => '/schedule',
+    });
+
+    studio.say({ type: 'studioConnect', accessToken: '' });
+    await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+    host?.reportRoute('/ad/123', 'adDetail');
+    host?.reportSession({ isSignedIn: true, displayLabel: 'Anna' });
+    host?.reportLocale('ru');
+
+    assert.deepEqual(studio.of('routeChanged'), [
+      { type: 'routeChanged', path: '/ad/123', routeName: 'adDetail' },
+    ]);
+    assert.equal(studio.of('sessionChanged')[0]?.session.displayLabel, 'Anna');
+    assert.deepEqual(studio.of('localeChanged'), [{ type: 'localeChanged', locale: 'ru' }]);
+
+    host?.detach();
+  });
+
+  test('nothing is reported before a Studio has been let in', async () => {
+    const studio = new FakeStudio();
+    const features = new StudioFeatureRegistry();
+    const host = attachStudioBridge({
+      manifest,
+      appOrigin,
+      publicKey: studioPublicKey,
+      features,
+      transport: studio,
+      currentPath: () => '/schedule',
+    });
+
+    features.declare({ id: 'a', title: 'A' });
+    host?.reportRoute('/ad/123');
+    host?.reportSession({ isSignedIn: true });
+    host?.reportLocale('ru');
+    await settle();
+
+    assert.deepEqual(studio.heard, [{ type: 'appReady' }]);
+    host?.detach();
+  });
+});
+
+test('detaching ends it', async () => {
+  const studio = new FakeStudio();
+  const features = new StudioFeatureRegistry();
+  const host = attachStudioBridge({
+    manifest,
+    features,
+    transport: studio,
+    currentPath: () => '/schedule',
+  });
+
+  studio.say({ type: 'studioConnect', accessToken: '' });
+  await waitFor(() => studio.of('manifest').length === 1, 'the manifest');
+
+  host?.detach();
+  assert.equal(studio.disposed, true);
+  assert.equal(host?.isConnected, false);
+
+  const before = studio.wire.length;
+  features.declare({ id: 'a', title: 'A' });
+  await settle();
+  assert.equal(studio.wire.length, before, 'kept talking after detaching');
+});

--- a/js/studio-bridge/test/protocol.test.ts
+++ b/js/studio-bridge/test/protocol.test.ts
@@ -1,0 +1,294 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  decodeStudioBridgeMessage,
+  encodeStudioBridgeMessage,
+  studioBridgeProtocol,
+  type StudioBridgeMessage,
+} from '../src/index.ts';
+
+/**
+ * The strings below are the wire format as the Dart implementation writes it —
+ * key order included. They are the whole point of this file: an app on this
+ * package has to connect to a Studio that was never told it exists, so drift is
+ * only cheap while it is caught here.
+ */
+describe('the wire format matches the Dart implementation byte for byte', () => {
+  test('appReady', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({ type: 'appReady' }),
+      '{"dartwayStudioBridge":4,"type":"appReady","payload":{}}',
+    );
+  });
+
+  test('manifest — the handshake response', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({
+        type: 'manifest',
+        manifest: { projectName: 'Demo', zones: [] },
+        currentPath: '/schedule',
+        session: { isSignedIn: false },
+        features: [],
+        currentLocale: 'en',
+      }),
+      '{"dartwayStudioBridge":4,"type":"manifest","payload":{' +
+        '"manifest":{"projectName":"Demo","zones":[],"features":[],"supportedLocales":[]},' +
+        '"currentPath":"/schedule",' +
+        '"session":{"isSignedIn":false,"isBusy":false},' +
+        '"features":[],' +
+        '"currentLocale":"en"}}',
+    );
+  });
+
+  test('manifest — a zone with a screen passport', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({
+        type: 'manifest',
+        manifest: {
+          projectName: 'Demo',
+          zones: [
+            {
+              label: 'Client app',
+              rootPath: '/schedule',
+              access: 'signedIn',
+              screens: [
+                {
+                  path: '/schedule/profile',
+                  parentPath: '/schedule',
+                  title: 'Profile',
+                  purpose: 'Everything about the person',
+                  discussionQuestions: ['Should the phone be editable?'],
+                },
+              ],
+            },
+          ],
+          supportedLocales: ['en', 'ru'],
+        },
+        currentPath: '/schedule',
+        session: { isSignedIn: true, userIdentifier: '79990000002', isBusy: false },
+        features: [],
+        currentLocale: 'en',
+      }),
+      '{"dartwayStudioBridge":4,"type":"manifest","payload":{' +
+        '"manifest":{"projectName":"Demo","zones":[{"label":"Client app","rootPath":"/schedule",' +
+        '"access":"signedIn","screens":[{"path":"/schedule/profile","parentPath":"/schedule",' +
+        '"title":"Profile","purpose":"Everything about the person",' +
+        '"discussionQuestions":["Should the phone be editable?"]}]}],' +
+        '"features":[],"supportedLocales":["en","ru"]},' +
+        '"currentPath":"/schedule",' +
+        '"session":{"isSignedIn":true,"userIdentifier":"79990000002","isBusy":false},' +
+        '"features":[],"currentLocale":"en"}}',
+    );
+  });
+
+  test('featuresChanged — empty passport lists are left out, as in Dart', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({
+        type: 'featuresChanged',
+        path: '/schedule',
+        features: [
+          { id: 'schedule-list', title: 'List', behaviors: ['does a thing'], knownIssues: [] },
+        ],
+      }),
+      '{"dartwayStudioBridge":4,"type":"featuresChanged","payload":{"path":"/schedule",' +
+        '"features":[{"id":"schedule-list","title":"List","behaviors":["does a thing"]}]}}',
+    );
+  });
+
+  test('routeChanged carries the route name only when there is one', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({ type: 'routeChanged', path: '/auth' }),
+      '{"dartwayStudioBridge":4,"type":"routeChanged","payload":{"path":"/auth"}}',
+    );
+    assert.equal(
+      encodeStudioBridgeMessage({ type: 'routeChanged', path: '/ad/123', routeName: 'adDetail' }),
+      '{"dartwayStudioBridge":4,"type":"routeChanged","payload":' +
+        '{"path":"/ad/123","routeName":"adDetail"}}',
+    );
+  });
+
+  test('sessionChanged', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({
+        type: 'sessionChanged',
+        session: { isSignedIn: true, userIdentifier: '1', displayLabel: 'Anna', isBusy: true },
+      }),
+      '{"dartwayStudioBridge":4,"type":"sessionChanged","payload":{"session":' +
+        '{"isSignedIn":true,"userIdentifier":"1","displayLabel":"Anna","isBusy":true}}}',
+    );
+  });
+
+  test('localeChanged', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({ type: 'localeChanged', locale: 'ru' }),
+      '{"dartwayStudioBridge":4,"type":"localeChanged","payload":{"locale":"ru"}}',
+    );
+  });
+
+  test('inspectPointResult, with a feature and without', () => {
+    assert.equal(
+      encodeStudioBridgeMessage({
+        type: 'inspectPointResult',
+        requestId: 'inspect-7',
+        feature: { id: 'ad/card', title: 'Ad card' },
+      }),
+      '{"dartwayStudioBridge":4,"type":"inspectPointResult","payload":{"requestId":"inspect-7",' +
+        '"feature":{"id":"ad/card","title":"Ad card"}}}',
+    );
+    assert.equal(
+      encodeStudioBridgeMessage({ type: 'inspectPointResult', requestId: 'inspect-7' }),
+      '{"dartwayStudioBridge":4,"type":"inspectPointResult","payload":{"requestId":"inspect-7"}}',
+    );
+  });
+});
+
+describe('decoding what Studio sends', () => {
+  test('studioConnect carries the access token', () => {
+    assert.deepEqual(
+      decodeStudioBridgeMessage(
+        '{"dartwayStudioBridge":4,"type":"studioConnect","payload":{"accessToken":"abc"}}',
+      ),
+      { type: 'studioConnect', accessToken: 'abc' },
+    );
+  });
+
+  test('a connect with no token decodes to an empty one', () => {
+    // Which only a build in its zero-config local-dev mode accepts.
+    assert.deepEqual(
+      decodeStudioBridgeMessage('{"dartwayStudioBridge":4,"type":"studioConnect","payload":{}}'),
+      { type: 'studioConnect', accessToken: '' },
+    );
+  });
+
+  test('navigateRequest', () => {
+    assert.deepEqual(
+      decodeStudioBridgeMessage(
+        '{"dartwayStudioBridge":4,"type":"navigateRequest","payload":{"path":"/schedule"}}',
+      ),
+      { type: 'navigateRequest', path: '/schedule' },
+    );
+  });
+
+  test('signInRequest carries the credentials', () => {
+    assert.deepEqual(
+      decodeStudioBridgeMessage(
+        '{"dartwayStudioBridge":4,"type":"signInRequest","payload":' +
+          '{"identifier":"79990000002","secret":"123456"}}',
+      ),
+      { type: 'signInRequest', identifier: '79990000002', secret: '123456' },
+    );
+  });
+
+  test('signOutRequest', () => {
+    assert.deepEqual(
+      decodeStudioBridgeMessage('{"dartwayStudioBridge":4,"type":"signOutRequest","payload":{}}'),
+      { type: 'signOutRequest' },
+    );
+  });
+
+  test('localeRequest', () => {
+    assert.deepEqual(
+      decodeStudioBridgeMessage(
+        '{"dartwayStudioBridge":4,"type":"localeRequest","payload":{"locale":"ru"}}',
+      ),
+      { type: 'localeRequest', locale: 'ru' },
+    );
+  });
+
+  test('inspectPointRequest carries the fractional point and the request id', () => {
+    assert.deepEqual(
+      decodeStudioBridgeMessage(
+        '{"dartwayStudioBridge":4,"type":"inspectPointRequest","payload":' +
+          '{"requestId":"inspect-7","horizontalFraction":0.25,"verticalFraction":0.75}}',
+      ),
+      {
+        type: 'inspectPointRequest',
+        requestId: 'inspect-7',
+        horizontalFraction: 0.25,
+        verticalFraction: 0.75,
+      },
+    );
+  });
+
+  test('a whole-number fraction written as an int, the way Dart may send it', () => {
+    const message = decodeStudioBridgeMessage(
+      '{"dartwayStudioBridge":4,"type":"inspectPointRequest","payload":' +
+        '{"requestId":"i","horizontalFraction":1,"verticalFraction":0}}',
+    );
+    assert.equal(message?.type, 'inspectPointRequest');
+    assert.deepEqual(message, {
+      type: 'inspectPointRequest',
+      requestId: 'i',
+      horizontalFraction: 1,
+      verticalFraction: 0,
+    });
+  });
+});
+
+describe('decoding rejects foreign and malformed input', () => {
+  test('non-string data', () => {
+    assert.equal(decodeStudioBridgeMessage(42), null);
+    assert.equal(decodeStudioBridgeMessage(null), null);
+    assert.equal(decodeStudioBridgeMessage({ type: 'appReady' }), null);
+  });
+
+  test('invalid json', () => {
+    assert.equal(decodeStudioBridgeMessage('not json'), null);
+  });
+
+  test('json that is not an object', () => {
+    assert.equal(decodeStudioBridgeMessage('[1,2,3]'), null);
+    assert.equal(decodeStudioBridgeMessage('"hello"'), null);
+  });
+
+  test('missing or wrong envelope version', () => {
+    assert.equal(decodeStudioBridgeMessage('{"type":"appReady"}'), null);
+    assert.equal(decodeStudioBridgeMessage('{"dartwayStudioBridge":999,"type":"appReady"}'), null);
+    // v1 (bilingual passports) is a different schema — must be ignored.
+    assert.equal(decodeStudioBridgeMessage('{"dartwayStudioBridge":1,"type":"appReady"}'), null);
+  });
+
+  test('unknown message type', () => {
+    assert.equal(
+      decodeStudioBridgeMessage(
+        `{"dartwayStudioBridge":${studioBridgeProtocol.version},"type":"bogus","payload":{}}`,
+      ),
+      null,
+    );
+  });
+
+  test('a foreign postMessage is ignored', () => {
+    // e.g. dev-server or browser-extension chatter on the same window.
+    assert.equal(decodeStudioBridgeMessage('{"source":"react-devtools"}'), null);
+  });
+});
+
+test('every message type survives a round trip', () => {
+  const messages: StudioBridgeMessage[] = [
+    { type: 'appReady' },
+    { type: 'routeChanged', path: '/ad/1', routeName: 'adDetail' },
+    { type: 'sessionChanged', session: { isSignedIn: true, userIdentifier: '1', isBusy: false } },
+    {
+      type: 'featuresChanged',
+      path: '/schedule',
+      features: [{ id: 'a', title: 'A', purpose: 'why', behaviors: ['b'] }],
+    },
+    { type: 'localeChanged', locale: 'ru' },
+    { type: 'inspectPointResult', requestId: 'i', feature: { id: 'a', title: 'A' } },
+    { type: 'studioConnect', accessToken: 'token' },
+    { type: 'navigateRequest', path: '/x' },
+    { type: 'signInRequest', identifier: 'a', secret: 'b' },
+    { type: 'signOutRequest' },
+    { type: 'localeRequest', locale: 'en' },
+    { type: 'inspectPointRequest', requestId: 'i', horizontalFraction: 0.5, verticalFraction: 0.5 },
+  ];
+
+  for (const message of messages) {
+    assert.deepEqual(
+      decodeStudioBridgeMessage(encodeStudioBridgeMessage(message)),
+      message,
+      `round trip failed for ${message.type}`,
+    );
+  }
+});

--- a/js/studio-bridge/test/token.test.ts
+++ b/js/studio-bridge/test/token.test.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { before, describe, test } from 'node:test';
+
+import {
+  studioSignedAccessValidator,
+  studioSigningPublicKey,
+  verifyStudioBridgeToken,
+} from '../src/index.ts';
+
+/**
+ * Studio's half of the contract, written out here rather than imported: the app
+ * never signs, so the package ships no signer, and the issuer lives in another
+ * repository. Keeping an independent implementation of the format in the test
+ * is what makes the test worth having — it fails when the verifier drifts from
+ * the format the docs promise, instead of drifting along with it.
+ */
+async function signToken({
+  signingKey,
+  origin,
+  expiresAt,
+}: {
+  signingKey: CryptoKey;
+  origin: string;
+  expiresAt: Date;
+}): Promise<string> {
+  const payload = base64UrlSegment(
+    new TextEncoder().encode(
+      JSON.stringify({ origin, exp: Math.floor(expiresAt.getTime() / 1000) }),
+    ),
+  );
+  const signature = await crypto.subtle.sign(
+    { name: 'Ed25519' },
+    signingKey,
+    new TextEncoder().encode(payload),
+  );
+  return `${payload}.${base64UrlSegment(new Uint8Array(signature))}`;
+}
+
+function base64UrlSegment(bytes: Uint8Array): string {
+  return base64(bytes).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function base64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+async function newStudioKeyPair(): Promise<CryptoKeyPair> {
+  return (await crypto.subtle.generateKey({ name: 'Ed25519' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+}
+
+async function publicKeyOf(pair: CryptoKeyPair): Promise<string> {
+  return base64(new Uint8Array(await crypto.subtle.exportKey('raw', pair.publicKey)));
+}
+
+const appOrigin = 'https://app.example.com';
+const inTenMinutes = (): Date => new Date(Date.now() + 10 * 60 * 1000);
+
+let studioKeyPair: CryptoKeyPair;
+let studioPublicKey: string;
+let validToken: string;
+
+before(async () => {
+  studioKeyPair = await newStudioKeyPair();
+  studioPublicKey = await publicKeyOf(studioKeyPair);
+  validToken = await signToken({
+    signingKey: studioKeyPair.privateKey,
+    origin: appOrigin,
+    expiresAt: inTenMinutes(),
+  });
+});
+
+test('the shipped signing key is a 32-byte Ed25519 public key', () => {
+  assert.equal(atob(studioSigningPublicKey).length, 32);
+});
+
+describe('verifyStudioBridgeToken', () => {
+  test('accepts a live token signed for this origin', async () => {
+    assert.equal(
+      await verifyStudioBridgeToken(validToken, { appOrigin, publicKey: studioPublicKey }),
+      true,
+    );
+  });
+
+  test('accepts the same origin written differently', async () => {
+    assert.equal(
+      await verifyStudioBridgeToken(validToken, {
+        appOrigin: 'https://App.Example.com/',
+        publicKey: studioPublicKey,
+      }),
+      true,
+    );
+  });
+
+  test('rejects a token issued for another origin', async () => {
+    const foreignToken = await signToken({
+      signingKey: studioKeyPair.privateKey,
+      origin: 'https://someone-else.example.com',
+      expiresAt: inTenMinutes(),
+    });
+    assert.equal(
+      await verifyStudioBridgeToken(foreignToken, { appOrigin, publicKey: studioPublicKey }),
+      false,
+    );
+  });
+
+  test('rejects an expired token', async () => {
+    const expiredToken = await signToken({
+      signingKey: studioKeyPair.privateKey,
+      origin: appOrigin,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    assert.equal(
+      await verifyStudioBridgeToken(expiredToken, { appOrigin, publicKey: studioPublicKey }),
+      false,
+    );
+  });
+
+  test('rejects a token that expires exactly now', async () => {
+    const now = new Date();
+    const token = await signToken({
+      signingKey: studioKeyPair.privateKey,
+      origin: appOrigin,
+      expiresAt: now,
+    });
+    assert.equal(
+      await verifyStudioBridgeToken(token, { appOrigin, publicKey: studioPublicKey, now }),
+      false,
+    );
+  });
+
+  test('rejects a token whose claims were edited after signing', async () => {
+    const forgedPayload = base64UrlSegment(
+      new TextEncoder().encode(
+        JSON.stringify({
+          origin: appOrigin,
+          exp: Math.floor(Date.now() / 1000) + 365 * 24 * 3600,
+        }),
+      ),
+    );
+    const forgedToken = `${forgedPayload}.${validToken.split('.')[1]}`;
+    assert.equal(
+      await verifyStudioBridgeToken(forgedToken, { appOrigin, publicKey: studioPublicKey }),
+      false,
+    );
+  });
+
+  test('rejects a token signed by another key', async () => {
+    const impostorToken = await signToken({
+      signingKey: (await newStudioKeyPair()).privateKey,
+      origin: appOrigin,
+      expiresAt: inTenMinutes(),
+    });
+    assert.equal(
+      await verifyStudioBridgeToken(impostorToken, { appOrigin, publicKey: studioPublicKey }),
+      false,
+    );
+  });
+
+  test('rejects garbage instead of throwing', async () => {
+    for (const malformed of ['', 'not-a-token', 'a.b.c', 'aGk=.###', '.', 'eyJ9.']) {
+      assert.equal(
+        await verifyStudioBridgeToken(malformed, { appOrigin, publicKey: studioPublicKey }),
+        false,
+        `accepted ${malformed}`,
+      );
+    }
+  });
+
+  test('a build that names no origin verifies nothing', async () => {
+    assert.equal(
+      await verifyStudioBridgeToken(validToken, { appOrigin: '', publicKey: studioPublicKey }),
+      false,
+    );
+  });
+});
+
+describe('studioSignedAccessValidator', () => {
+  test('lets a valid token in and keeps everything else out', async () => {
+    const validator = studioSignedAccessValidator(appOrigin, { publicKey: studioPublicKey });
+    assert.equal(await validator(validToken), true);
+    assert.equal(await validator('forged'), false);
+    assert.equal(await validator(''), false);
+  });
+
+  test("rejects a token not signed by the key this build trusts", async () => {
+    const validator = studioSignedAccessValidator(appOrigin);
+    assert.equal(await validator(validToken), false);
+  });
+
+  test('a build with no origin named accepts any connection (local dev)', async () => {
+    const validator = studioSignedAccessValidator('');
+    assert.equal(await validator(''), true);
+    assert.equal(await validator('anything at all'), true);
+  });
+});

--- a/js/studio-bridge/tsconfig.build.json
+++ b/js/studio-bridge/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/js/studio-bridge/tsconfig.json
+++ b/js/studio-bridge/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+
+    // Imports carry the `.ts` extension they are written with, so the sources
+    // run as they are under `node --test` (Node strips the types) and still
+    // emit as `.js` — one set of files, no transpiler in the test path.
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
The pilot teams write React and Vue, and until now they could not connect their app to Studio at all: the bridge existed only in Dart. This adds the same bridge's **app half**, written a second time, as `js/studio-bridge` — `@dartway/studio-bridge` on npm, one core plus two thin bindings (`/react`, `/vue`) as subpaths rather than separate packages, so their protocol version cannot diverge.

No Dart code changes. The Studio side needs nothing: the wire format is identical.

## Where it sits

Outside `packages/`, which is the pub workspace. Worth recording what was actually measured rather than assumed: a folder without a `pubspec.yaml` under `packages/*` does **not** break resolution — `dart pub workspace list` and `dart pub get` are byte-identical with and without one. The placement is still right, because a JS package has no business inside a Dart resolution; `dart analyze js` is clean and `node_modules`/`dist` are ignored from the repository root, so the next JS package cannot commit its build.

## What keeps it compatible

There is no shared schema between the two implementations, so the tests carry **golden wire strings** — the Dart encoder's exact output, key order and omitted-when-empty fields included:

```
{"dartwayStudioBridge":4,"type":"manifest","payload":{"manifest":{...},"currentPath":"/schedule","session":{"isSignedIn":false,"isBusy":false},"features":[],"currentLocale":"en"}}
```

Change the format on either side and these fail, instead of a pilot team's preview failing.

## Two deliberate differences from the Dart host

Neither is visible on the wire, and Studio behaves the same against both.

1. **Every command is gated on the handshake**, not just the manifest. The Dart host dispatches `navigateRequest` / `signInRequest` / `signOutRequest` / `localeRequest` before any token is accepted — its README says the gate covers every command, and the code does not. Reported separately; the new implementation does what the docs promise.
2. **Nothing is reported before a Studio has been let in**, so passports are not posted to a frame that never proved who it was.

## Declaring a feature

The centrepiece: in DartWay the framework collects passports, in React and Vue nobody does, so the declaration had to be cheaper than skipping it.

```tsx
<StudioFeature id="schedule/session-list" title="Session list"
  purpose="Lets a client find a class and book it"
  behaviors={['Shows the coming week', 'A full session is marked as such']}>
  <SessionList />
</StudioFeature>
```

Declarations go into a registry that is independent of the bridge, so they cannot fail, cannot depend on load order, and cost one map entry in a build that never meets Studio. `useStudioFeature` returns a ref for an element you already render. A bound element also answers tap-to-inspect: the innermost declaration around what is painted at the point wins.

Route changes are picked up from `history` and `popstate` — any router reports itself with no wiring, and the patch is installed only inside a Studio frame.

## Access

Unchanged in substance: the shipped Ed25519 public key, a token that must be live and issued for this build's own origin, and a build naming no origin accepting anything — the zero-config local-dev mode is preserved. Verification runs on WebCrypto and fails closed where Ed25519 is unavailable (documented in the README, since the local mode verifies nothing and is unaffected).

## Tests and toolchain

58 tests, all green: the handshake, refusal on a foreign origin, refusal on an expired token, refusal of commands before the handshake, feature reports for the current screen, hit testing, and the golden wire format. The token tests sign with an independently written implementation of the format, mirroring the Dart test, so the verifier cannot drift along with them.

Toolchain is deliberately thin — `tsc` for the build, `node --test` straight over the TypeScript sources (Node strips the types), no runtime dependencies, React and Vue as optional peers.

## Synchronisation law

No public Dart API changed, so `example/`, `template/` and `toolkit/skills/` are untouched and still compile. `docs/6-studio/studio-bridge.md` and the monorepo map in `CLAUDE.md` record that the package exists; the new package carries its own `CHANGELOG.md` at 0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
