### PR TITLE
fix(studio-bridge): the access gate guarded the manifest and nothing else

### DIFF
--- a/docs/6-studio/studio-bridge.md
+++ b/docs/6-studio/studio-bridge.md
@@ -32,6 +32,11 @@ The open `dartway_studio_bridge` package is the only integration surface:
   passes its `validateAccessToken`. A token taken off the wire is therefore
   useless anywhere else, and it expires on its own.
 
+  The gate is on **everything**, not on the manifest alone: until a token has
+  been accepted the app runs no command it is sent and reports nothing back, so
+  a page that embedded the build without presenting anything can neither drive
+  it nor read its feature passports.
+
   Your build holds no secret and copies nothing out of Studio: the public half
   of the pair ships inside the bridge package, and a public key can only check
   signatures, never make them. The build names one thing — where it answers:

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -327,7 +327,7 @@ packages:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.7.1"
   dbus:
     dependency: transitive
     description:

--- a/packages/dartway_studio_bridge/CHANGELOG.md
+++ b/packages/dartway_studio_bridge/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.7.1
+
+**The access gate now covers every command, which is what this package has been
+documenting all along.** The token was checked on the handshake alone: the
+manifest was withheld from a Studio that presented nothing, but `navigate`,
+`sign in`, `sign out`, `locale` and `inspect point` were dispatched to the
+delegate regardless. Any page that embedded a public web build in an iframe
+could therefore walk the app through its screens and sign it in with test
+credentials without presenting anything at all — while the token looked like it
+was doing its job, since the manifest never arrived.
+
+The host now holds the handshake result and drops everything else until a token
+has been accepted. `reportRoute`, `reportSession`, `reportLocale` and
+`reportFeatures` are dropped the same way: whoever connects is handed the whole
+state in the handshake response, so nothing is lost — and a page that presented
+nothing is no longer sent the app's feature passports, `implementationNotes` and
+`knownIssues` included.
+
+No protocol change: Studio sends `studioConnect` first and retries until it gets
+a manifest, so the Studio side needs nothing. An app that never had a Studio in
+front of it sees no difference either.
+
+- `StudioBridgeHost.isConnected` — true once a Studio has been let in.
+- `StudioBridgeHost.attach` takes an optional `channel`. The host used to build
+  its own and could therefore only exist inside an iframe, which is why it had
+  no tests, which is why the gate could go missing in the first place. It now
+  has a file of them.
+
 ## 0.7.0
 
 **Access is proved by a signature, not by a shared secret** (protocol version 4 — breaking). An app

--- a/packages/dartway_studio_bridge/README.md
+++ b/packages/dartway_studio_bridge/README.md
@@ -153,7 +153,10 @@ The `studioConnect` handshake carries an `accessToken`; the host answers with
 its manifest only if `validateAccessToken` accepts it, otherwise it stays
 silent (Studio shows "not connected"). The gate covers every command, not just
 the manifest — otherwise an embedding page could walk the app through its
-screens without presenting anything.
+screens without presenting anything. It covers the app's own reports too
+(`reportRoute`, `reportSession`, `reportLocale`, `reportFeatures`): they are
+dropped until a Studio is let in, since whoever connects is handed the whole
+state in the handshake response anyway.
 
 The token is short-lived, signed by Studio with an Ed25519 key, and issued for
 **one origin**: the address your build answers at. A token lifted off the wire

--- a/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
+++ b/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
@@ -83,8 +83,12 @@ class StudioBridgeHost {
     // Studio's own timeout treats that exactly like an old app that doesn't
     // know the message at all.
     StudioInspectPoint? inspectPoint,
+    // The pipe to talk over. Defaults to the embedding window, which is the
+    // only thing an app ever wants; pass one to drive the host from a test, or
+    // to embed the app somewhere that is not an iframe.
+    StudioMessageChannel? channel,
   }) {
-    final channel = createStudioHostChannel();
+    channel ??= createStudioHostChannel();
     if (channel == null) return null;
     return StudioBridgeHost._(
       channel,
@@ -110,14 +114,32 @@ class StudioBridgeHost {
   final StudioInspectPoint _inspectPoint;
   late final StreamSubscription<StudioBridgeMessage> _subscription;
 
+  /// Set once a connecting Studio has presented an accepted token, and the
+  /// gate on everything that follows. Without it the token would guard the
+  /// manifest alone, and an embedding page that presented nothing could still
+  /// walk the app through its screens or sign it in — which is precisely what
+  /// this class documents that it does not allow.
+  bool _connected = false;
+
+  /// True once a Studio has been let in. Nothing crosses the bridge before it,
+  /// in either direction, beyond the app-ready announcement.
+  bool get isConnected => _connected;
+
   void _onMessage(StudioBridgeMessage message) {
+    if (message case StudioConnectMessage(:final accessToken)) {
+      // Answer the handshake only if the token is accepted; on refusal stay
+      // silent — the app keeps running, Studio shows "not connected".
+      _validateAccessToken(accessToken).then((accepted) {
+        if (!accepted) return;
+        _connected = true;
+        _sendManifest();
+      });
+      return;
+    }
+
+    if (!_connected) return;
+
     switch (message) {
-      case StudioConnectMessage(:final accessToken):
-        // Answer the handshake only if the token is accepted; on refusal stay
-        // silent — the app keeps running, Studio shows "not connected".
-        _validateAccessToken(accessToken).then((accepted) {
-          if (accepted) _sendManifest();
-        });
       case NavigateRequestMessage(:final path):
         _delegate.onNavigateRequest(path);
       case SignInRequestMessage(:final identifier, :final secret):
@@ -178,18 +200,33 @@ class StudioBridgeHost {
         currentLocale: _currentLocale(),
       ));
 
-  void reportRoute(String path, {String? routeName}) =>
-      _channel.send(RouteChangedMessage(path, routeName: routeName));
+  /// The reports below are dropped until a Studio has been let in. Nothing is
+  /// lost by that: whoever connects is handed the whole state in the handshake
+  /// response, so an unconnected app has nobody to tell anything to — while a
+  /// page that has presented nothing would otherwise be sent the app's feature
+  /// passports, `implementationNotes` and `knownIssues` included.
+  void reportRoute(String path, {String? routeName}) {
+    if (!_connected) return;
+    _channel.send(RouteChangedMessage(path, routeName: routeName));
+  }
 
-  void reportSession(StudioSessionState session) =>
-      _channel.send(SessionChangedMessage(session));
+  void reportSession(StudioSessionState session) {
+    if (!_connected) return;
+    _channel.send(SessionChangedMessage(session));
+  }
 
-  void reportFeatures(String path, List<StudioFeatureInfo> features) =>
-      _channel.send(FeaturesChangedMessage(path: path, features: features));
+  void reportFeatures(String path, List<StudioFeatureInfo> features) {
+    if (!_connected) return;
+    _channel.send(FeaturesChangedMessage(path: path, features: features));
+  }
 
-  void reportLocale(String locale) => _channel.send(LocaleChangedMessage(locale));
+  void reportLocale(String locale) {
+    if (!_connected) return;
+    _channel.send(LocaleChangedMessage(locale));
+  }
 
   void detach() {
+    _connected = false;
     _subscription.cancel();
     _channel.dispose();
   }

--- a/packages/dartway_studio_bridge/pubspec.yaml
+++ b/packages/dartway_studio_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_studio_bridge
 description: "Open bridge between a DartWay app and DartWay Studio: in-code screen spec registry models and the runtime postMessage protocol."
-version: 0.7.0
+version: 0.7.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_studio_bridge/test/studio_bridge_host_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_host_test.dart
@@ -1,0 +1,270 @@
+import 'dart:async';
+
+import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Studio, as far as the app can tell. Everything Studio says crosses the wire
+/// first — encoded and decoded exactly as the real channel would — so a message
+/// that only works because the test handed the object over cannot pass here.
+class _FakeStudio implements StudioMessageChannel {
+  final _incoming = StreamController<StudioBridgeMessage>.broadcast();
+  final heard = <StudioBridgeMessage>[];
+  bool disposed = false;
+
+  @override
+  Stream<StudioBridgeMessage> get messages => _incoming.stream;
+
+  @override
+  void send(StudioBridgeMessage message) => heard.add(message);
+
+  @override
+  void dispose() {
+    disposed = true;
+    _incoming.close();
+  }
+
+  void say(StudioBridgeMessage message) {
+    final decoded = StudioBridgeMessage.tryDecode(message.encode());
+    expect(decoded, isNotNull);
+    _incoming.add(decoded!);
+  }
+
+  Iterable<T> of<T extends StudioBridgeMessage>() => heard.whereType<T>();
+}
+
+class _RecordingDelegate implements StudioBridgeHostDelegate {
+  final done = <String>[];
+
+  @override
+  void onNavigateRequest(String path) => done.add('navigate:$path');
+
+  @override
+  Future<void> onSignInRequest(String identifier, String secret) async =>
+      done.add('signIn:$identifier:$secret');
+
+  @override
+  Future<void> onSignOutRequest() async => done.add('signOut');
+
+  @override
+  void onLocaleRequest(String locale) => done.add('locale:$locale');
+}
+
+const _manifest = StudioProjectManifest(
+  projectName: 'Demo',
+  zones: [
+    StudioZoneSpec(
+      label: 'Client app',
+      rootPath: '/schedule',
+      access: StudioZoneAccess.signedIn,
+      screens: [
+        StudioScreenSpec(
+          path: '/schedule',
+          title: 'Schedule',
+          purpose: 'The week ahead',
+        ),
+      ],
+    ),
+  ],
+);
+
+/// Accepts one token and nothing else, so the tests are about the gate rather
+/// than about signatures — those have a file of their own.
+Future<bool> _acceptsOnly(String accessToken) async => accessToken == 'good';
+
+void main() {
+  late _FakeStudio studio;
+  late _RecordingDelegate delegate;
+
+  StudioBridgeHost attach({
+    List<StudioFeatureInfo> features = const [],
+    StudioInspectPoint? inspectPoint,
+  }) {
+    final host = StudioBridgeHost.attach(
+      manifest: _manifest,
+      delegate: delegate,
+      currentPath: () => '/schedule',
+      currentSession: () => const StudioSessionState(
+        isSignedIn: true,
+        userIdentifier: '79990000002',
+      ),
+      currentFeatures: () => features,
+      currentLocale: () => 'ru',
+      validateAccessToken: _acceptsOnly,
+      inspectPoint: inspectPoint,
+      channel: studio,
+    );
+    expect(host, isNotNull, reason: 'attach refused an explicit channel');
+    return host!;
+  }
+
+  Future<void> connect() async {
+    studio.say(const StudioConnectMessage(accessToken: 'good'));
+    await pumpEventQueue();
+  }
+
+  setUp(() {
+    studio = _FakeStudio();
+    delegate = _RecordingDelegate();
+  });
+
+  test('the app announces itself the moment it attaches', () {
+    attach();
+    expect(studio.heard, [isA<AppReadyMessage>()]);
+  });
+
+  test('an accepted token is answered with the manifest', () async {
+    final host = attach(
+      features: const [StudioFeatureInfo(id: 'schedule/list', title: 'List')],
+    );
+    await connect();
+
+    final answer = studio.of<ManifestMessage>().single;
+    expect(answer.manifest.projectName, 'Demo');
+    expect(answer.currentPath, '/schedule');
+    expect(answer.session.userIdentifier, '79990000002');
+    expect(answer.currentLocale, 'ru');
+    expect(answer.features.single.id, 'schedule/list');
+    expect(host.isConnected, isTrue);
+  });
+
+  test('a refused token is answered with silence', () async {
+    final host = attach();
+    studio.say(const StudioConnectMessage(accessToken: 'forged'));
+    await pumpEventQueue();
+
+    expect(studio.of<ManifestMessage>(), isEmpty);
+    expect(host.isConnected, isFalse);
+  });
+
+  group('the gate covers every command, not just the manifest', () {
+    test('an embedding page that presented nothing cannot drive the app',
+        () async {
+      final host = attach();
+
+      studio.say(const NavigateRequestMessage('/admin'));
+      studio.say(const SignInRequestMessage(
+        identifier: '79990000002',
+        secret: '123456',
+      ));
+      studio.say(const SignOutRequestMessage());
+      studio.say(const LocaleRequestMessage('en'));
+      await pumpEventQueue();
+
+      expect(delegate.done, isEmpty);
+      expect(host.isConnected, isFalse);
+    });
+
+    test('nor read what is declared on the screen', () async {
+      attach(
+        inspectPoint: (_, _) =>
+            const StudioFeatureInfo(id: 'schedule/list', title: 'List'),
+      );
+
+      studio.say(const InspectPointRequestMessage(
+        requestId: 'inspect-1',
+        horizontalFraction: 0.5,
+        verticalFraction: 0.5,
+      ));
+      await pumpEventQueue();
+
+      expect(studio.of<InspectPointResultMessage>(), isEmpty);
+    });
+
+    test('a refused Studio stays refused for the commands that follow',
+        () async {
+      attach();
+      studio.say(const StudioConnectMessage(accessToken: 'forged'));
+      await pumpEventQueue();
+
+      studio.say(const NavigateRequestMessage('/admin'));
+      await pumpEventQueue();
+
+      expect(delegate.done, isEmpty);
+    });
+
+    test('and every command lands once it has been let in', () async {
+      attach(
+        inspectPoint: (_, _) =>
+            const StudioFeatureInfo(id: 'schedule/list', title: 'List'),
+      );
+      await connect();
+
+      studio.say(const NavigateRequestMessage('/admin'));
+      studio.say(const SignInRequestMessage(
+        identifier: '79990000002',
+        secret: '123456',
+      ));
+      studio.say(const SignOutRequestMessage());
+      studio.say(const LocaleRequestMessage('en'));
+      studio.say(const InspectPointRequestMessage(
+        requestId: 'inspect-1',
+        horizontalFraction: 0.5,
+        verticalFraction: 0.5,
+      ));
+      await pumpEventQueue();
+
+      expect(delegate.done, [
+        'navigate:/admin',
+        'signIn:79990000002:123456',
+        'signOut',
+        'locale:en',
+      ]);
+      final result = studio.of<InspectPointResultMessage>().single;
+      expect(result.requestId, 'inspect-1');
+      expect(result.feature?.id, 'schedule/list');
+    });
+  });
+
+  group('reports', () {
+    test('say nothing to a Studio that has not been let in', () async {
+      final host = attach();
+
+      host.reportRoute('/ad/123', routeName: 'adDetail');
+      host.reportSession(StudioSessionState.signedOut);
+      host.reportLocale('en');
+      host.reportFeatures('/schedule', const [
+        StudioFeatureInfo(
+          id: 'schedule/list',
+          title: 'List',
+          knownIssues: ['the empty state is missing'],
+        ),
+      ]);
+      await pumpEventQueue();
+
+      expect(studio.heard, [isA<AppReadyMessage>()]);
+    });
+
+    test('reach a connected Studio', () async {
+      final host = attach();
+      await connect();
+
+      host.reportRoute('/ad/123', routeName: 'adDetail');
+      host.reportSession(StudioSessionState.signedOut);
+      host.reportLocale('en');
+      host.reportFeatures('/schedule', const [
+        StudioFeatureInfo(id: 'schedule/list', title: 'List'),
+      ]);
+
+      expect(studio.of<RouteChangedMessage>().single.routeName, 'adDetail');
+      expect(studio.of<SessionChangedMessage>().single.session.isSignedIn,
+          isFalse);
+      expect(studio.of<LocaleChangedMessage>().single.locale, 'en');
+      expect(studio.of<FeaturesChangedMessage>().single.features.single.id,
+          'schedule/list');
+    });
+  });
+
+  test('detaching ends it', () async {
+    final host = attach();
+    await connect();
+
+    host.detach();
+    expect(studio.disposed, isTrue);
+    expect(host.isConnected, isFalse);
+
+    final before = studio.heard.length;
+    host.reportRoute('/ad/123');
+    await pumpEventQueue();
+    expect(studio.heard, hasLength(before));
+  });
+}

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -320,7 +320,7 @@ packages:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.7.1"
   dbus:
     dependency: transitive
     description:


### PR DESCRIPTION
The access token was checked on the handshake alone. A Studio that presented nothing was refused the manifest — and then had its `navigateRequest`, `signInRequest`, `signOutRequest`, `localeRequest` and `inspectPointRequest` dispatched to the delegate regardless. Any page that embedded a public web build in an iframe could walk the app through its screens and sign it in with test credentials without presenting anything, while the token looked like it was doing its job, because the manifest never arrived.

The README has claimed the opposite since the gate was introduced:

> The gate covers every command, not just the manifest — otherwise an embedding page could walk the app through its screens without presenting anything.

The code now does what the documentation promises.

## The change

`StudioBridgeHost` holds the handshake result (`isConnected`) and drops everything but `studioConnect` until a token has been accepted.

`reportRoute`, `reportSession`, `reportLocale` and `reportFeatures` are gated the same way. Nothing is lost by it — whoever connects is handed the whole state in the handshake response — and a page that presented nothing is no longer posted the app's feature passports, `implementationNotes` and `knownIssues` included. That is arguably the worse half of the leak, since those are written for the team.

**No protocol change, nothing for the Studio side to catch up with:** Studio sends `studioConnect` first and retries until a manifest arrives, so a connected preview behaves exactly as before. An app that never had a Studio in front of it sees no difference either.

## Why it could go missing

The host built its own channel, so it could only exist inside an iframe and could not be tested — the package had tests for messages, models and tokens, and none for the host. `attach` now takes an optional `channel` (documented as the escape hatch it is), and the host has a test file.

The three gate tests were verified against the bug rather than assumed: with `if (!_connected) return;` commented out, `flutter test` reports `+7 -3`.

Found while writing the JavaScript implementation of the same protocol (#44), where the documented behaviour was implemented from the start; the two hosts now agree.

## Synchronisation law

Public API changed (`isConnected`, the optional `channel`), so: `example/` and `template/` analyze clean, their `pubspec.lock`s carry the version bump, `CHANGELOG.md` has a 0.7.1 entry, and `docs/6-studio/studio-bridge.md` plus the package README say the gate is on everything. `toolkit/` mentions neither symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
