### PR TITLE
fix(studio-bridge): a token that cannot be checked now says so instead of failing mute

### DIFF
--- a/docs/6-studio/studio-bridge.md
+++ b/docs/6-studio/studio-bridge.md
@@ -80,11 +80,10 @@ Studio, unmodified. The app half of the bridge exists a second time as
 bindings (`/react`, `/vue`), speaking the same protocol version, checking the
 same signature against the same shipped public key.
 
-Two things differ, and neither of them on the wire. A JS app **can** enumerate
-its features, because a declaration is a component and components are what a
-framework already tracks — where a Flutter app reports what is mounted, a React
-or Vue app declares `<StudioFeature>` and the registry does the rest. And every
-Studio command is gated on the handshake there, not just the manifest.
+One thing differs, and not on the wire: a JS app **can** enumerate its features,
+because a declaration is a component and components are what a framework already
+tracks — where a Flutter app reports what is mounted, a React or Vue app
+declares `<StudioFeature>` and the registry does the rest.
 
 The two implementations are kept honest by golden wire strings in the JS
 package's tests: the Dart encoder's exact output, key order included. Change the

--- a/js/studio-bridge/CHANGELOG.md
+++ b/js/studio-bridge/CHANGELOG.md
@@ -22,12 +22,13 @@ Studio; nothing on the Studio side knows which implementation it is talking to.
   bound to an element also answers Studio's tap-to-inspect.
 - Route changes are picked up from `history` and `popstate`, so any router
   reports itself without wiring.
+- A token that cannot be **checked** — no WebCrypto (the page is not a secure
+  context), a browser without Ed25519, a misconfigured `publicKey` — is refused
+  like any other, and the reason is written to the console once. A token that is
+  checked and found wanting stays silent: refusing it is the check working.
 
-Two deliberate differences from the Dart implementation, neither of them visible
-on the wire:
-
-- **Every command is gated on the handshake**, not just the manifest — an
-  embedding page that presents no accepted token cannot navigate the app or sign
-  it in.
-- **Nothing is reported before a Studio has been let in**, so passports do not
-  travel to a frame that never proved who it was.
+Two things this implementation did from the start and the Dart one did not:
+**every command is gated on the handshake**, not just the manifest, and
+**nothing is reported before a Studio has been let in**. Writing them here is
+what surfaced the same gap in the Dart host, fixed in `dartway_studio_bridge`
+0.7.1 — the two now agree.

--- a/js/studio-bridge/README.md
+++ b/js/studio-bridge/README.md
@@ -167,8 +167,11 @@ all — and it is why a deployed build should always name its address.
 
 Signature checking uses Ed25519 in WebCrypto (Chrome 137+, Safari 17+, Firefox
 130+) in a secure context. Where it is unavailable the app refuses the
-connection rather than trusting an unchecked token; the local-dev mode above is
-unaffected, since it verifies nothing.
+connection rather than trusting an unchecked token — and writes one line to the
+console saying which of the two is missing. Without it the preview would just
+sit at "not connected" with nothing anywhere pointing at the reason, since a
+refusal is silence by design. The local-dev mode above is unaffected: it
+verifies nothing and needs neither.
 
 ## Licence
 

--- a/js/studio-bridge/src/access/token.ts
+++ b/js/studio-bridge/src/access/token.ts
@@ -56,7 +56,9 @@ export interface VerifyStudioBridgeTokenOptions {
  * **Requires Ed25519 in the platform's WebCrypto** (Chrome 137+, Safari 17+,
  * Firefox 130+, Node 18.4+) and a secure context — https or localhost. Where it
  * is missing, verification fails closed: the app refuses the connection instead
- * of trusting an unchecked token.
+ * of trusting an unchecked token, and says why once in the console — a refusal
+ * is otherwise silence, and silence is what a browser too old to check looks
+ * like from Studio's side as well.
  */
 export async function verifyStudioBridgeToken(
   accessToken: string,
@@ -89,11 +91,34 @@ export async function verifyStudioBridgeToken(
   if (expiresAtSeconds * 1000 <= (now ?? new Date()).getTime()) return false;
 
   const subtle = globalThis.crypto?.subtle;
-  if (subtle === undefined) return false;
+  if (subtle === undefined) {
+    reportOnce(
+      'WebCrypto is unavailable on this page. `crypto.subtle` exists only in a ' +
+        'secure context, so serve the app over https (localhost counts).',
+    );
+    return false;
+  }
+
+  let key: CryptoKey;
   try {
-    const key = await subtle.importKey('raw', publicKeyBytes, { name: 'Ed25519' }, false, [
-      'verify',
-    ]);
+    key = await subtle.importKey('raw', publicKeyBytes, { name: 'Ed25519' }, false, ['verify']);
+  } catch (error) {
+    // A 32-byte key that the platform still refuses to import is the platform
+    // saying it does not do Ed25519; any other length is this build's own
+    // `publicKey` being wrong. Both are worth saying out loud — see below.
+    reportOnce(
+      publicKeyBytes.length === 32
+        ? 'this browser cannot verify Ed25519 signatures with WebCrypto. It needs ' +
+            'Chrome 137+, Safari 17+ or Firefox 130+.'
+        : `the configured publicKey is ${publicKeyBytes.length} bytes, not the 32 ` +
+            'an Ed25519 public key has. Leave it unset to use the key shipped with ' +
+            'this package.',
+      error,
+    );
+    return false;
+  }
+
+  try {
     return await subtle.verify(
       { name: 'Ed25519' },
       key,
@@ -101,9 +126,35 @@ export async function verifyStudioBridgeToken(
       new TextEncoder().encode(payloadSegment),
     );
   } catch {
+    // A signature of the wrong shape. Ordinary traffic, not a diagnosis:
+    // refusing it is the function working, and saying so on every retry would
+    // bury the messages above.
     return false;
   }
 }
+
+/**
+ * Said once per page, and only when the token could not be *checked* at all —
+ * as opposed to being checked and refused, which is this function's day job and
+ * says nothing about the app.
+ *
+ * The failure it describes is otherwise mute: the app simply does not answer
+ * the handshake, Studio shows "not connected", and nothing anywhere points at
+ * the cause. A refusal stays a refusal — nothing here weakens the check — but
+ * whoever is looking at the console learns why.
+ */
+function reportOnce(reason: string, error?: unknown): void {
+  if (reported.has(reason)) return;
+  reported.add(reason);
+  console.error(
+    `[dartway/studio-bridge] Studio's access token could not be checked: ${reason} ` +
+      'The connection is refused rather than trusted. For local development, leave ' +
+      '`appOrigin` unset — that mode verifies nothing and needs none of this.',
+    ...(error === undefined ? [] : [error]),
+  );
+}
+
+const reported = new Set<string>();
 
 export interface StudioSignedAccessOptions {
   /**

--- a/js/studio-bridge/test/token.test.ts
+++ b/js/studio-bridge/test/token.test.ts
@@ -179,6 +179,112 @@ describe('verifyStudioBridgeToken', () => {
   });
 });
 
+describe('when the token cannot be checked at all', () => {
+  test('no WebCrypto on the page — refuses, and says which context it needs', async () => {
+    const console = captureConsole();
+    const platform = usePlatform(undefined);
+    try {
+      assert.equal(
+        await verifyStudioBridgeToken(validToken, { appOrigin, publicKey: studioPublicKey }),
+        false,
+      );
+    } finally {
+      platform.restore();
+      console.restore();
+    }
+    assert.equal(console.messages.length, 1);
+    assert.match(console.messages[0] ?? '', /secure context/);
+  });
+
+  test('a browser without Ed25519 — refuses, and names the browsers that have it', async () => {
+    const console = captureConsole();
+    const platform = usePlatform({
+      importKey: () => {
+        throw new Error('Unrecognized algorithm name');
+      },
+    });
+    try {
+      assert.equal(
+        await verifyStudioBridgeToken(validToken, { appOrigin, publicKey: studioPublicKey }),
+        false,
+      );
+    } finally {
+      platform.restore();
+      console.restore();
+    }
+    assert.equal(console.messages.length, 1);
+    assert.match(console.messages[0] ?? '', /cannot verify Ed25519/);
+  });
+
+  test('a misconfigured public key is named as such, and named once', async () => {
+    const sixteenBytes = base64(new Uint8Array(16));
+    const console = captureConsole();
+    try {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        assert.equal(
+          await verifyStudioBridgeToken(validToken, { appOrigin, publicKey: sixteenBytes }),
+          false,
+        );
+      }
+    } finally {
+      console.restore();
+    }
+    // Studio retries its handshake every couple of seconds; a message per retry
+    // would bury itself.
+    assert.equal(console.messages.length, 1);
+    assert.match(console.messages[0] ?? '', /16 bytes, not the 32/);
+  });
+
+  test('an ordinary forged token is refused without a word', async () => {
+    const console = captureConsole();
+    try {
+      const forged = `${validToken.split('.')[0]}.${base64UrlSegment(new Uint8Array(64))}`;
+      assert.equal(
+        await verifyStudioBridgeToken(forged, { appOrigin, publicKey: studioPublicKey }),
+        false,
+      );
+      assert.equal(
+        await verifyStudioBridgeToken('not-a-token', { appOrigin, publicKey: studioPublicKey }),
+        false,
+      );
+    } finally {
+      console.restore();
+    }
+    // Refusing a bad token is the function working, not something to report.
+    assert.deepEqual(console.messages, []);
+  });
+});
+
+/** Swaps in a platform whose WebCrypto behaves as the test needs. */
+function usePlatform(subtle: unknown): { restore: () => void } {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+  Object.defineProperty(globalThis, 'crypto', {
+    value: subtle === undefined ? undefined : { subtle },
+    configurable: true,
+    writable: true,
+  });
+  return {
+    restore: () => {
+      if (original === undefined) delete (globalThis as { crypto?: unknown }).crypto;
+      else Object.defineProperty(globalThis, 'crypto', original);
+    },
+  };
+}
+
+function captureConsole(): { messages: string[]; restore: () => void } {
+  const original = globalThis.console.error;
+  const messages: string[] = [];
+  globalThis.console.error = (...args: unknown[]) => {
+    messages.push(args.map((arg) => String(arg)).join(' '));
+  };
+  return {
+    messages,
+    restore: () => {
+      globalThis.console.error = original;
+    },
+  };
+}
+
 describe('studioSignedAccessValidator', () => {
   test('lets a valid token in and keeps everything else out', async () => {
     const validator = studioSignedAccessValidator(appOrigin, { publicKey: studioPublicKey });


### PR DESCRIPTION
Option B from the discussion on #44: keep the check exactly as strict, stop it from failing silently.

## The problem

`verifyStudioBridgeToken` fails closed where the platform cannot do Ed25519 — correct, and completely mute. The app does not answer the handshake, Studio shows "not connected", and nothing anywhere points at the cause. From the outside a browser too old to verify is indistinguishable from an app that never loaded.

The blast radius is small — it needs a deployed build that names its `appOrigin` **and** a viewer on a browser without Ed25519 in WebCrypto — but when it does happen it is a support conversation with no evidence in it.

## The change

Three causes are named once in the console:

- no WebCrypto at all — the page is not a secure context, so serve it over https;
- a browser without Ed25519 — Chrome 137+, Safari 17+, Firefox 130+;
- a `publicKey` that is not 32 bytes — this build's own misconfiguration, not the viewer's browser.

Each is said **once per page**, not per handshake: Studio retries its connect every couple of seconds and a message per retry would bury itself.

A token that *is* checked and found wanting stays silent, as before. Refusing a forged or expired token is the function working; it says nothing about the app and does not belong in the console. Nothing about the check itself changed — an unverifiable token is still refused, never trusted.

## Tests

Four new ones, 62 in total. The platform is swapped for one whose WebCrypto behaves as the test needs (absent, or refusing Ed25519), `console.error` is captured, and the last test asserts the **absence** of output for an ordinary forged token — the property that makes the other three worth having.

## Two things carried along

- `docs/6-studio` still listed the command gate as a difference between the JS and Dart implementations; that stopped being true when the Dart host was fixed in 0.7.1 (#45). Corrected, along with the same claim in the package changelog.
- The package is not published to npm yet (`npm view` returns 404), so this lands in the existing `0.1.0` changelog entry rather than inventing a version nobody can install.

Not done, deliberately: a pure-JS or `@noble/ed25519` fallback for browsers without Ed25519. It buys a few percent of viewers at the price of either hand-rolled crypto in a security path or the package's first runtime dependency, and it would not help the insecure-context case at all (SHA-512 comes from the same `crypto.subtle`). Worth revisiting only if a pilot team actually hits it — at which point this console line is what will tell us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
