### PR TITLE
fix(feature-spec): implementationNotes asked for the one thing guaranteed to go stale

### DIFF
--- a/docs/3-flutter/features-and-specs.md
+++ b/docs/3-flutter/features-and-specs.md
@@ -70,8 +70,8 @@ class MyBookingsPage extends ConsumerWidget implements DwFeature {
           'decision is the server access filter, not this screen.',
     ],
     implementationNotes: [
-      'Two watches, joined locally: the bookings themselves and the reviews, '
-          'intersected by bookingId.',
+      'A review count on the booking model would remove the second read; it is '
+          'kept separate to show the local join is cheap.',
     ],
   );
 ```
@@ -95,7 +95,7 @@ from `dartway check`. A feature whose entry point is an extension or a function
 | `purpose` | why the user needs it — optional |
 | `behaviors` | verifiable statements about what it observably does |
 | `requirements` | what it must honour, imposed from outside |
-| `implementationNotes` | decisions a reader would otherwise re-open |
+| `implementationNotes` | what the code cannot say about itself — reasons, traps, decisions |
 | `knownIssues` | what is wrong here and worth taking into work |
 
 **`id` is a contract.** Studio passports, feedback and tracker items refer to the feature by it, and
@@ -113,6 +113,20 @@ turned back into prose and stops being worth reading.
 
 **`requirements` is what is imposed from outside** — signed-in users only, no price before
 confirmation, works offline. If you can phrase it as an observable action, it is a behavior.
+
+**`implementationNotes` is what the code cannot say about itself** — why it is done this way, a trap
+invisible from the outside, a decision someone would otherwise re-open. The name invites a wider
+reading than it should, so it comes with a test: **would this still be worth reading after the
+feature is rewritten?**
+
+- A reason survives — *"the list is not cached: it changes more often than it is read."*
+- A trap survives — *"the server sends the date in UTC, the screen shows it local."*
+- A map of the code does not — *"the list comes from `dw.repo.modelList` and is drawn by a
+  `ListView`."* That is what the code already says, and unlike the code it starts lying the moment
+  someone moves the widget. Nothing checks it: not the compiler, not `dartway check`.
+
+Which is the whole point of the field. Everything a reader can get by opening the file belongs in
+the file; this list is for what they would otherwise have to re-derive — or get wrong.
 
 A side effect worth knowing about: writing behaviors as verifiable statements is how you discover
 things nobody claimed. Phrasing them for the events block on a home screen is what surfaced that the

--- a/example/dartway_example_flutter/lib/admin/dashboard/admin_dashboard_page.dart
+++ b/example/dartway_example_flutter/lib/admin/dashboard/admin_dashboard_page.dart
@@ -19,9 +19,9 @@ class AdminDashboardPage extends StatelessWidget implements DwFeature {
     purpose: 'The landing screen of the panel: how big the club is right now.',
     behaviors: ['A line under the counters explains that they are live.'],
     implementationNotes: [
-      'The counters themselves are admin/live-counters. This screen is their '
-          'frame, and the future home of event analytics — visits, conversion, '
-          'retention — which needs an analytics milestone, not another watch.',
+      'Event analytics — visits, conversion, retention — belongs here and is '
+          'deliberately absent: it needs an analytics milestone, not another '
+          'watch over existing models.',
     ],
   );
 

--- a/example/dartway_example_flutter/lib/admin/users/admin_users_page.dart
+++ b/example/dartway_example_flutter/lib/admin/users/admin_users_page.dart
@@ -33,9 +33,8 @@ class AdminUsersPage extends HookConsumerWidget implements DwFeature {
           'request comes from somewhere other than this table.',
     ],
     implementationNotes: [
-      'Search and role filter are local hook state handed to the table — the '
-          'narrowing happens client-side over a list the server already '
-          'restricted.',
+      'Search and role narrowing happen client-side: the server has already '
+          'restricted the list, so a backend filter would buy nothing.',
     ],
   );
 

--- a/example/dartway_example_flutter/lib/app/bookings/my_bookings_page.dart
+++ b/example/dartway_example_flutter/lib/app/bookings/my_bookings_page.dart
@@ -30,9 +30,8 @@ class MyBookingsPage extends ConsumerWidget implements DwFeature {
           'decision is the server access filter, not this screen.',
     ],
     implementationNotes: [
-      'Two watches, joined locally: the bookings themselves and the reviews, '
-          'intersected by bookingId. A review count on the booking model would '
-          'remove the second watch — it is kept to show the join is cheap.',
+      'A review count on the booking model would remove the second read; the '
+          'local join is kept to show it costs little.',
     ],
   );
 

--- a/example/dartway_example_flutter/lib/app/chat/widgets/chat_message_composer.dart
+++ b/example/dartway_example_flutter/lib/app/chat/widgets/chat_message_composer.dart
@@ -21,10 +21,6 @@ class ChatMessageComposer extends HookConsumerWidget implements DwFeature {
       'Sending clears the input.',
       'An empty or whitespace-only message is not sent.',
     ],
-    implementationNotes: [
-      'Sending is a single dw.repo.saveModel(ChatMessage) — the list above '
-          'updates in realtime, with no extra wiring.',
-    ],
   );
 
   @override

--- a/example/dartway_example_flutter/lib/app/chat/widgets/chat_message_list.dart
+++ b/example/dartway_example_flutter/lib/app/chat/widgets/chat_message_list.dart
@@ -28,10 +28,6 @@ class ChatMessageList extends ConsumerWidget implements DwFeature {
       'Clients never receive staff messages — the access filter is the '
           'enforcement, not the UI.',
     ],
-    implementationNotes: [
-      'A realtime chat is ~40 lines of DwCrudConfig, secure-by-default: '
-          'the staff-only access filter means the data never reaches a client.',
-    ],
   );
 
   @override

--- a/example/dartway_example_flutter/lib/app/schedule/schedule_page.dart
+++ b/example/dartway_example_flutter/lib/app/schedule/schedule_page.dart
@@ -13,8 +13,8 @@ class SchedulePage extends ConsumerWidget implements DwFeature {
     id: 'schedule/page',
     title: 'Schedule screen',
     implementationNotes: [
-      'A composition and nothing else: the app bar plus ScheduleSessionList, '
-          'which carries the feature itself — see schedule/session-list.',
+      'This screen carries no feature of its own — schedule/session-list '
+          'does, and that is the passport worth reading.',
     ],
   );
 

--- a/example/dartway_example_flutter/lib/app/schedule/widgets/schedule_session_list.dart
+++ b/example/dartway_example_flutter/lib/app/schedule/widgets/schedule_session_list.dart
@@ -35,8 +35,6 @@ class ScheduleSessionList extends ConsumerWidget implements DwFeature {
       'A member sees only their own bookings on the cards.',
     ],
     implementationNotes: [
-      'ref.watch(dw.repo.modelList<ClubSession>()) with a backend filter: '
-          'realtime sync, pagination and loading states come with it.',
       'Live to your own writes only. Another member booking the last seat '
           'shows on the next fetch — pushing it to everyone needs a named '
           'channel, which this screen deliberately does not set up.',

--- a/example/dartway_example_flutter/lib/app/services/services_page.dart
+++ b/example/dartway_example_flutter/lib/app/services/services_page.dart
@@ -23,8 +23,8 @@ class ServicesPage extends ConsumerWidget implements DwFeature {
       'While the list loads, four placeholder cards are shown.',
     ],
     implementationNotes: [
-      'An unfiltered dw.repo.modelList<ClubService> — the price list is '
-          'readable by anyone signed in, so there is nothing to narrow.',
+      'Nothing is narrowed here: the price list is readable by anyone signed '
+          'in, so there is no filter to write.',
     ],
   );
 

--- a/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
+++ b/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
@@ -44,11 +44,20 @@ class DwFeatureSpec {
   /// phrased as an observable action belongs in [behaviors] instead.
   final List<String> requirements;
 
-  /// Decisions a reader would otherwise re-open: why the preview image in the
-  /// row and the full one in the list, why the height lives in the kit.
+  /// What the code cannot say about itself: why it is done this way, a trap
+  /// invisible from the outside, a decision someone would otherwise re-open.
   ///
   /// Written for the team, not for the client — Studio shows it on the
   /// technical side, away from the product panel.
+  ///
+  /// The name invites a wider reading than it should, so it comes with a test:
+  /// *would this still be worth reading after the feature is rewritten?* A
+  /// reason survives ("the list is not cached: it changes more often than it is
+  /// read"); a trap survives ("the server sends the date in UTC, the screen
+  /// shows it local"). A map of the code does not — "the list comes from
+  /// `dw.repo.modelList` and is drawn by a `ListView`" is what the file already
+  /// says, and unlike the file it starts lying the moment someone moves the
+  /// widget. Nothing checks it: not the compiler, not `dartway check`.
   final List<String> implementationNotes;
 
   /// What is wrong here and worth taking into work: a setting nothing reads,

--- a/packages/dartway_studio_bridge/lib/src/models/studio_feature_info.dart
+++ b/packages/dartway_studio_bridge/lib/src/models/studio_feature_info.dart
@@ -36,7 +36,12 @@ class StudioFeatureInfo {
   /// What it must honour, imposed from outside the feature.
   final List<String> requirements;
 
-  /// Decisions the team should not have to re-open. Technical side only.
+  /// What the code cannot say about itself: reasons, traps, decisions the team
+  /// should not have to re-open. Technical side only.
+  ///
+  /// The test the app side applies when filling this in — *would it still be
+  /// worth reading after the feature is rewritten?* — keeps out descriptions of
+  /// how the code is put together, which go stale silently.
   final List<String> implementationNotes;
 
   /// What is wrong in the feature and worth taking into work. Studio filters

--- a/template/dartway_starter_flutter/lib/admin/dashboard/admin_dashboard_page.dart
+++ b/template/dartway_starter_flutter/lib/admin/dashboard/admin_dashboard_page.dart
@@ -20,8 +20,8 @@ class AdminDashboardPage extends StatelessWidget implements DwFeature {
         'The landing screen of the panel: how big the system is right now.',
     behaviors: ['A line under the counters explains that they are live.'],
     implementationNotes: [
-      'The counters themselves are admin/live-counters; this screen is their '
-          'frame, and the place to put analytics when you have any.',
+      'Analytics belongs here when there is any — this screen is the frame, '
+          'and the counters are their own feature (admin/live-counters).',
     ],
   );
 

--- a/template/dartway_starter_flutter/lib/admin/dashboard/widgets/admin_counters.dart
+++ b/template/dartway_starter_flutter/lib/admin/dashboard/widgets/admin_counters.dart
@@ -27,8 +27,8 @@ class AdminCounters extends ConsumerWidget implements DwFeature {
           'enforce it, not this widget.',
     ],
     implementationNotes: [
-      'Plain watchModelList calls: the same realtime CRUD the client app '
-          'uses, with no separate admin API.',
+      'No separate admin API: the panel reads through the same CRUD the '
+          'client app does, so an access rule is written once.',
     ],
   );
 

--- a/template/dartway_starter_flutter/lib/admin/users/admin_users_page.dart
+++ b/template/dartway_starter_flutter/lib/admin/users/admin_users_page.dart
@@ -32,9 +32,8 @@ class AdminUsersPage extends HookConsumerWidget implements DwFeature {
           'request comes from somewhere other than this table.',
     ],
     implementationNotes: [
-      'Search and role filter are local hook state handed to the table — the '
-          'narrowing happens client-side over a list the server already '
-          'restricted.',
+      'Search and role narrowing happen client-side: the server has already '
+          'restricted the list, so a backend filter would buy nothing.',
     ],
   );
 

--- a/template/dartway_starter_flutter/lib/app/home/home_page.dart
+++ b/template/dartway_starter_flutter/lib/app/home/home_page.dart
@@ -31,10 +31,6 @@ class HomePage extends ConsumerWidget implements DwFeature {
       'The app name comes from the database, not from a constant.',
       'Changing it in the admin panel updates this screen with no reload.',
     ],
-    implementationNotes: [
-      'A watchModelList over AppSetting — the same realtime read any other '
-          'screen uses.',
-    ],
   );
 
   @override

--- a/toolkit/skills/dartway-feature-scaffold/SKILL.md
+++ b/toolkit/skills/dartway-feature-scaffold/SKILL.md
@@ -214,7 +214,7 @@ class BookingListPage extends ConsumerWidget implements DwFeature {
       'A client sees only their own bookings — decided by accessFilter on the backend, not by the widget.',
     ],
     implementationNotes: [
-      'One watch on dw.repo.modelList<Booking> with a backendFilter — realtime and pagination come included.',
+      'The list is not cached: a booking changes more often than the screen is opened.',
     ],
     knownIssues: [
       'Sorting by date is commented out in the list even though the field is still in the form —'
@@ -230,7 +230,7 @@ Rules per field:
 - **`purpose`** — why the user needs it. **Optional and often unnecessary:** a card or a list row has no purpose of its own, it serves the screen; repeating the screen's purpose on every one of its parts is noise.
 - **`behaviors`** — what the feature observably does, one verifiable statement per item. **The criterion that keeps this field alive: every item can be verified by looking at the running app.** The moment "works well with long titles" shows up, the field has turned back into an essay.
 - **`requirements`** — what the feature is obliged to honor, imposed **from the outside** (authorized users only, the price is not shown before confirmation, works offline). If it is phrased as an observable action, it belongs in `behaviors`.
-- **`implementationNotes`** — decisions that would otherwise be rediscovered ("why the preview is in the row and the full image in the list"). Written for the team, not for the client: Studio shows them on the technical side.
+- **`implementationNotes`** — what the code cannot say about itself: why it is done this way, a trap that is not visible from the outside, a decision that would otherwise be re-opened. Written for the team, not for the client: Studio shows them on the technical side. **The test: would this still be worth reading after the feature is rewritten?** A reason survives ("the list is not cached — it changes more often than it is read"); a trap survives ("the server sends the date in UTC, the screen shows it local"). A map of the code does not: "the list comes from `dw.repo.modelList` and is drawn by a `ListView`" is what the code already says, and it starts lying the moment someone moves the widget.
 - **`knownIssues`** — what is **wrong** in the feature and worth picking up: a setting nobody reads; a screen still sitting on mocks; sorting commented out while the field is still live in the form.
 
 **The line between `implementationNotes` and `knownIssues` is what the reader is supposed to do about it.** A note says "this is intentional, don't touch it", a finding says "this is wrong, fix it". The agent needs that distinction **before** it changes anything: otherwise it either "fixes" a deliberate decision or carefully preserves a bug. One question settles it: **if this gets fixed, does the entry disappear?** It disappears — `knownIssues`. It stays as an explanation — `implementationNotes`.


### PR DESCRIPTION
## What this fixes

`DwFeatureSpec.implementationNotes` is named for notes and documented for decisions, and nothing in the framework drew the line between *why* and *how*. That gap was found while writing passports on a real project: the first reading of the name gave "nuances and explanations", and it took opening the doc comment to discover the opposite.

Worse than the missing rule: **the framework demonstrated the wrong side of it.** The example in `dartway-feature-scaffold`, the one in `docs/3-flutter/features-and-specs.md`, and half the passports in `example/` and `template/` described how the code is put together — `'One watch on dw.repo.modelList<Booking> with a backendFilter'`, `'A watchModelList over AppSetting'`, `'Sending is a single dw.repo.saveModel(ChatMessage)'`. That is what the code already says, and unlike the code it starts lying on the first refactor; nothing checks it — not the compiler, not `dartway check`. `template/` is what every new project receives, so the shipped example taught the anti-pattern.

## The boundary

The field keeps its wide meaning — reasons, traps, decisions — and gains a test, phrased to match the one `knownIssues` already carries:

> **Would this still be worth reading after the feature is rewritten?**
>
> A reason survives — *"the list is not cached: it changes more often than it is read."*
> A trap survives — *"the server sends the date in UTC, the screen shows it local."*
> A map of the code does not — *"the list comes from `dw.repo.modelList` and is drawn by a `ListView`."*

## Changes

- the rule and its example in `dartway-feature-scaffold` and `docs/3-flutter/features-and-specs.md`
- the doc comments on `DwFeatureSpec.implementationNotes` and `StudioFeatureInfo.implementationNotes`
- twelve passports in `example/` and `template/`: four entries deleted for carrying no reason at all, eight rewritten to state one

## Notes for review

- **No public API moves** — signatures and behaviour are untouched, so no `CHANGELOG` entry.
- **No protocol change.** `dartway_studio_bridge` appears in the diff through a doc comment only; no field added, removed or renamed, so the Studio side is unaffected.
- **Renaming to `implementationDecisions`** is the right name and is deliberately not done here: it is a bridge protocol field, and a breaking change there lands teams on mismatched builds. Parked until the next breaking version of the protocol.

`dart analyze` clean across the four touched packages; `dartway_flutter` 28 tests, `dartway_studio_bridge` 68, `template` 4 — all green. `framework-finish` reports no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
