### PR TITLE
feat(flutter)!: a plugin is handed the core it was plugged into

### DIFF
--- a/docs/3-flutter/plugins.md
+++ b/docs/3-flutter/plugins.md
@@ -8,7 +8,7 @@ including the ones that will never open Telegram.
 DartWay does not do that. The framework knows what a **plugin** is; it never knows what any
 particular one *does*. `dartway_flutter` contains no mention of Telegram or of `shared_preferences` —
 only [`DwPlugin`](https://github.com/dartway/dartway/blob/master/packages/dartway_flutter/lib/src/core/logic/dw_plugin.dart),
-an interface with a single `init()`.
+an interface with a single `init(core)`.
 
 The consequences are the whole point:
 
@@ -77,7 +77,7 @@ that is perfectly fine.
 
 ## When a plugin is initialized
 
-`dw.init()` runs `init()` on every declared plugin, awaited, in declaration order — and a project
+`dw.init()` runs `init(core)` on every declared plugin, awaited, in declaration order — and a project
 built by `dartway create` already calls it from the bootstrapper:
 
 ```dart
@@ -96,6 +96,50 @@ screen rather than half-booting the app.
 Declare a plugin and forget it, and the failure is loud and immediate: `dw.plugins.of<T>()` throws a
 `StateError` naming the type that was never registered. It cannot silently return null.
 
+### `init` is handed the core, and that is not a convenience
+
+A plugin cannot read `dw` while it is being declared. Look at where the declaration sits:
+
+```dart
+late final DwCore<Client, UserProfile> dw;   // the app's own variable
+
+dw = DwCore<Client, UserProfile>(
+  plugins: [MyPlugin()],                     // built as an argument to the constructor
+);                                           // that assigns dw — dw is not assigned yet
+```
+
+`plugins:` is a constructor parameter, so every plugin is constructed *before* the variable it will
+be reached through exists. Anything that touches `dw` inside that list throws
+`LateInitializationError` before the first frame — and the analyzer says nothing, because `late
+final` is exactly the promise that it will be there by the time anyone reads it. The framework does
+not export the singleton either, so there is no back door: `dw` is the app's variable, not ours.
+
+Hence the argument. `init` is the first moment the core exists, and it arrives rather than being
+looked up:
+
+```dart
+class MyPlugin extends DwPlugin {
+  ProviderListenable<int?>? _userId;
+
+  @override
+  Future<void> init(DwFlutter core) async {
+    // A plugin that needs the data layer names DwCore and casts. The cast is the
+    // honest part: it says out loud that this plugin does not work on the plain
+    // Flutter toolbox, and fails at startup rather than at the first read.
+    final dwCore = core as DwCore<Client, UserProfile>;
+    _userId = dwCore.userProfileProvider.select((profile) => profile?.id);
+  }
+}
+```
+
+The parameter is a `DwFlutter` because that is what declares `plugins:`. An app on the data layer
+passes a `DwCore`, which *is* a `DwFlutter` — so a plugin that needs nothing from the core (most of
+them) ignores the argument and works on both.
+
+What a plugin must **not** do is keep the core and read it during `init` for something the app has not
+finished setting up. Session state is the usual example: at `init` time nobody is signed in yet.
+Capture the provider, watch it from the widget tree, and react — do not read a value.
+
 ## Distribution: pub.dev, and nothing else
 
 **Plugins ship on pub.dev, versioned independently of the core.** Not as a git ref, not as a path
@@ -112,7 +156,7 @@ machine, and they cost more than they save:
   consume it;
 - a git ref pins a moving branch, so two checkouts of the same app can build different code.
 
-Each plugin states its compatibility with a caret on the framework — `dartway_flutter: ^0.4.0`. So a
+Each plugin states its compatibility with a caret on the framework — `dartway_flutter: ^0.5.0`. So a
 breaking release of `dartway_flutter` is followed by a release of each plugin, and pub refuses the
 combinations that were never tested instead of failing at runtime.
 
@@ -145,8 +189,9 @@ A plugin is one class and one extension, in your own package:
 ```dart
 class MyAnalytics extends DwPlugin {
   @override
-  Future<void> init() async {
-    // runs during dw.init(), before the first frame
+  Future<void> init(DwFlutter core) async {
+    // runs during dw.init(), before the first frame, with the core it was
+    // plugged into — ignore the argument if you have no use for it
   }
 
   void track(String event) {/* ... */}

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -277,7 +277,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -291,7 +291,7 @@ packages:
       path: "../../packages/dartway_push/dartway_push_client"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   dartway_router:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.4.0
+  dartway_flutter: ^0.5.0
 
   dartway_router: ^1.1.1
 

--- a/packages/dartway_flutter/CHANGELOG.md
+++ b/packages/dartway_flutter/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.5.0
+
+**A plugin is handed the core it was plugged into.** `DwPlugin.init()` now takes one:
+`Future<void> init(DwFlutter core)`. Until now it took nothing, and a plugin had no legal way to
+reach the framework it was part of.
+
+The gap was not theoretical. A plugin is constructed *as an argument* to the constructor that
+assigns `dw` — that is what `plugins:` being a constructor parameter means — while the app declares
+`late final DwCore<Client, UserProfile> dw`. So anything a plugin needs from the core has to be
+passed in at declaration time, and the ambient instance is not assigned yet. Writing the obvious
+thing inside the list:
+
+```dart
+plugins: [DwPush(config: DwPushConfig(
+  recipientIdProvider: dw.userProfileProvider.select((p) => p?.id),  // throws at startup
+))],
+```
+
+compiles silently and fails with `LateInitializationError` before the first frame. `dw` is also not
+exported by the framework — neither `dartway_flutter` nor `dartway_serverpod_core_flutter` hands the
+singleton out — so there was no version of that line that worked, only versions that looked like they
+might. `dartway_push_flutter`'s own README shipped one.
+
+`init` is the first moment the core exists, so that is where it arrives. The argument is a
+`DwFlutter`; an app on the data layer passes a `DwCore`, which is one — a plugin that needs the data
+layer names it and casts, and thereby says out loud that it does not work on the plain toolbox.
+
+**Breaking, mechanically.** Every `DwPlugin` implementation adds the parameter; nothing else about a
+plugin changes, and a plugin with no use for the core ignores it. `DwPlugins.initAll()` takes the core
+too, and `dw.init()` passes itself.
 
 ## 0.4.0
 

--- a/packages/dartway_flutter/example/lib/main.dart
+++ b/packages/dartway_flutter/example/lib/main.dart
@@ -56,7 +56,7 @@ class _ClockPlugin extends DwPlugin {
   late final DateTime startedAt;
 
   @override
-  Future<void> init() async => startedAt = DateTime.now();
+  Future<void> init(DwFlutter core) async => startedAt = DateTime.now();
 }
 
 class _ExampleApp extends StatelessWidget {

--- a/packages/dartway_flutter/example/pubspec.lock
+++ b/packages/dartway_flutter/example/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/dartway_flutter/lib/src/core/dw_flutter.dart
+++ b/packages/dartway_flutter/lib/src/core/dw_flutter.dart
@@ -28,7 +28,7 @@ class DwFlutter {
   final errorContext = DwErrorContext();
 
   Future<void> init() async {
-    await plugins.initAll();
+    await plugins.initAll(this);
   }
 
   /// Reports an error through the framework pipeline: captures the app-state

--- a/packages/dartway_flutter/lib/src/core/logic/dw_plugin.dart
+++ b/packages/dartway_flutter/lib/src/core/logic/dw_plugin.dart
@@ -1,3 +1,5 @@
+import '../dw_flutter.dart';
+
 /// An integration plugged into the app core at bootstrap.
 ///
 /// The framework knows what a plugin *is* — never what any particular one
@@ -17,11 +19,25 @@
 ///   DwTelegramWebApp get telegram => of<DwTelegramWebApp>();
 /// }
 /// ```
+///
+/// [init] hands the plugin the core it was plugged into, because until that
+/// moment there is nothing for it to reach: the ambient `dw` is the app's own
+/// `late final` variable, and a plugin is constructed as an argument to the
+/// constructor that assigns it. Reading `dw` from inside a `plugins: [...]`
+/// list compiles and throws `LateInitializationError` at startup.
+///
+/// The argument is a [DwFlutter]. An app built on the data layer passes a
+/// `DwCore`, which is one — a plugin that needs the data layer names it and
+/// casts, and thereby says out loud that it does not work on the plain
+/// toolbox.
 abstract class DwPlugin {
   const DwPlugin();
 
-  /// Runs once during `dw.init()`, in the order the plugins were declared.
-  Future<void> init();
+  /// Runs once during `dw.init()`, in declaration order, with the core this
+  /// plugin was plugged into. A plugin is built *before* `dw` exists — that is
+  /// what `plugins:` being a constructor argument means — so this is the first
+  /// moment it may look at anything.
+  Future<void> init(DwFlutter core);
 }
 
 /// The plugins a project has connected, reached as `dw.plugins`.
@@ -47,10 +63,11 @@ class DwPlugins {
     );
   }
 
-  /// Initializes every plugin once, in declaration order. Called by `dw.init()`.
-  Future<void> initAll() async {
+  /// Initializes every plugin once, in declaration order, handing each the
+  /// [core] it was declared on. Called by `dw.init()`, which passes itself.
+  Future<void> initAll(DwFlutter core) async {
     for (final plugin in _plugins) {
-      await plugin.init();
+      await plugin.init(core);
     }
   }
 }

--- a/packages/dartway_flutter/pubspec.yaml
+++ b/packages/dartway_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_flutter
 description: "The Flutter skeleton of a DartWay app: bootstrap runner, guarded UI actions, the AsyncValue rendering contract, notifications and error reporting. Riverpod-native."
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_flutter/test/dw_plugin_test.dart
+++ b/packages/dartway_flutter/test/dw_plugin_test.dart
@@ -3,14 +3,18 @@ import 'package:flutter_test/flutter_test.dart';
 
 class _RecordingPlugin extends DwPlugin {
   bool initialized = false;
+  DwFlutter? core;
 
   @override
-  Future<void> init() async => initialized = true;
+  Future<void> init(DwFlutter core) async {
+    this.core = core;
+    initialized = true;
+  }
 }
 
 class _UndeclaredPlugin extends DwPlugin {
   @override
-  Future<void> init() async {}
+  Future<void> init(DwFlutter core) async {}
 }
 
 /// A plugin the app declares through its interface while the object it actually
@@ -21,7 +25,7 @@ abstract class _Bridge extends DwPlugin {}
 
 class _BridgeWebImpl extends _Bridge {
   @override
-  Future<void> init() async {}
+  Future<void> init(DwFlutter core) async {}
 }
 
 void main() {
@@ -62,6 +66,17 @@ void main() {
       await dwInstance.init();
 
       expect(recording.initialized, isTrue);
+    });
+
+    // The whole reason `init` takes an argument: a plugin is constructed as an
+    // argument to the constructor that assigns `dw`, so reading the ambient
+    // instance from inside `plugins: [...]` throws LateInitializationError.
+    // `init` is the first moment the core exists, and it is handed over rather
+    // than looked up.
+    test('a plugin is handed the core it was plugged into', () async {
+      await dwInstance.init();
+
+      expect(recording.core, same(dwInstance));
     });
   });
 }

--- a/packages/dartway_push/dartway_push_flutter/lib/src/dw_push.dart
+++ b/packages/dartway_push/dartway_push_flutter/lib/src/dw_push.dart
@@ -54,7 +54,7 @@ class DwPush extends DwPlugin {
   /// permission prompt before the first frame is a prompt with no app behind
   /// it, and a notification tap has nowhere to go until the tree is up.
   @override
-  Future<void> init() async {}
+  Future<void> init(DwFlutter core) async {}
 
   // --- Driven by DwPushScope -------------------------------------------------
 

--- a/packages/dartway_push/dartway_push_flutter/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.4.0
+  dartway_flutter: ^0.5.0
 
   # The device registration request, and the CRUD action that carries it. The
   # app half talks to the server half through the generated protocol, not

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   serverpod_client: ^3.4.11
 
-  dartway_flutter: ^0.4.0
+  dartway_flutter: ^0.5.0
   dartway_serverpod_core_client: ^0.5.0
   dartway_serverpod_core_shared: ^0.5.0
 

--- a/packages/dartway_shared_preferences/CHANGELOG.md
+++ b/packages/dartway_shared_preferences/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0
+
+Follows `dartway_flutter` 0.5.0, where `DwPlugin.init()` gained the core as an argument:
+`DwSharedPreferences.init(DwFlutter core)`. Local storage needs nothing from the core — the parameter
+is the plugin contract, and behaviour is unchanged. An app that declares the plugin and reads
+`dw.plugins.prefs` never sees the difference.
+
 ## 0.2.0
 
 - **`DwPrefProvider<T>` and `DwMappedPrefProvider<T>` — the plugin names its own return types**, so a

--- a/packages/dartway_shared_preferences/lib/src/dw_shared_preferences.dart
+++ b/packages/dartway_shared_preferences/lib/src/dw_shared_preferences.dart
@@ -59,7 +59,7 @@ class DwSharedPreferences extends DwPlugin {
   late final SharedPreferences raw;
 
   @override
-  Future<void> init() async {
+  Future<void> init(DwFlutter core) async {
     raw = await SharedPreferences.getInstance();
   }
 

--- a/packages/dartway_shared_preferences/pubspec.yaml
+++ b/packages/dartway_shared_preferences/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_shared_preferences
 description: "Shared-preferences plugin for DartWay: typed riverpod providers over local storage, reached as dw.plugins.prefs. Optional by design."
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.4.0
+  dartway_flutter: ^0.5.0
   flutter_riverpod: ^3.0.0
   shared_preferences: ^2.3.0
 

--- a/packages/dartway_shared_preferences/test/consumer_needs_only_this_package_test.dart
+++ b/packages/dartway_shared_preferences/test/consumer_needs_only_this_package_test.dart
@@ -15,7 +15,6 @@
 
 import 'package:dartway_shared_preferences/dartway_shared_preferences.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 enum _Theme { system, dark }
 
@@ -39,11 +38,14 @@ late final DwMappedPrefProvider<_Theme> themeProvider = _prefs
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('a consumer declares both providers importing only this package', () async {
-    SharedPreferences.setMockInitialValues({});
+  test('a consumer declares both providers importing only this package', () {
     _prefs = DwSharedPreferences();
-    await _prefs.init();
 
+    // Not initialized on purpose. `init` takes the core the plugin was plugged
+    // into, and constructing one would put `dartway_flutter` in the import list
+    // this file exists to keep short. Nothing here reads a provider, so nothing
+    // needs the storage behind it.
+    //
     // Reading them is enough: the assertion this file makes is that the two
     // declarations above compile at all.
     expect(darkModeProvider, isNotNull);

--- a/packages/dartway_shared_preferences/test/dw_shared_preferences_test.dart
+++ b/packages/dartway_shared_preferences/test/dw_shared_preferences_test.dart
@@ -1,3 +1,4 @@
+import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:dartway_shared_preferences/dartway_shared_preferences.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,10 +12,15 @@ void main() {
   late DwSharedPreferences prefs;
   late ProviderContainer container;
 
+  // `init` takes the core the plugin was plugged into, so a test that inits the
+  // plugin by hand needs one to hand over. Built once — one DwFlutter per test
+  // process — and reused: local storage reads nothing out of it.
+  final dwInstance = DwFlutter(config: const DwConfig());
+
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     prefs = DwSharedPreferences();
-    await prefs.init();
+    await prefs.init(dwInstance);
     container = ProviderContainer();
     addTearDown(container.dispose);
   });

--- a/packages/dartway_telegram/CHANGELOG.md
+++ b/packages/dartway_telegram/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.0
+
+Follows `dartway_flutter` 0.5.0, where `DwPlugin.init()` gained the core as an argument:
+`DwTelegramWebApp.init(DwFlutter core)`. The bridge asks Telegram for everything it knows and needs
+nothing from the core — the parameter is the plugin contract, and behaviour is unchanged. Breaking
+only for a consumer that implements `DwTelegramWebApp` itself.
+
 ## 0.1.1
 
 Moves to `dartway_flutter` 0.2.0 (breaking `DwFeatureSpec`), so the two resolve together.

--- a/packages/dartway_telegram/lib/src/dw_telegram_web_app.dart
+++ b/packages/dartway_telegram/lib/src/dw_telegram_web_app.dart
@@ -47,8 +47,11 @@ abstract class DwTelegramWebApp implements DwPlugin {
 
   /// Announces the app to Telegram and applies the config. Called by the app
   /// core during bootstrap; safe outside Telegram, where it does nothing.
+  ///
+  /// The bridge asks Telegram for everything it knows and needs nothing from
+  /// [core] — the argument is the plugin contract, not a hint that it does.
   @override
-  Future<void> init();
+  Future<void> init(DwFlutter core);
 
   /// Whether the app really is running inside a Telegram Mini App — `false` on
   /// mobile, on desktop, and on plain web opened in a browser.

--- a/packages/dartway_telegram/lib/src/dw_telegram_web_app_stub.dart
+++ b/packages/dartway_telegram/lib/src/dw_telegram_web_app_stub.dart
@@ -1,3 +1,4 @@
+import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:flutter/widgets.dart';
 
 import 'dw_telegram_platform.dart';
@@ -13,7 +14,7 @@ class DwTelegramWebAppImpl extends DwTelegramWebApp {
   final DwTelegramWebAppConfig config;
 
   @override
-  Future<void> init() async {}
+  Future<void> init(DwFlutter core) async {}
 
   @override
   bool get isRunningInTelegram => false;

--- a/packages/dartway_telegram/lib/src/dw_telegram_web_app_web.dart
+++ b/packages/dartway_telegram/lib/src/dw_telegram_web_app_web.dart
@@ -1,3 +1,4 @@
+import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:flutter/widgets.dart';
 import 'package:telegram_web_app/telegram_web_app.dart';
 
@@ -36,7 +37,7 @@ class DwTelegramWebAppImpl extends DwTelegramWebApp {
   }
 
   @override
-  Future<void> init() async {
+  Future<void> init(DwFlutter core) async {
     if (!isRunningInTelegram) return;
 
     // The WebApp object can exist before Telegram has handed over the viewport,

--- a/packages/dartway_telegram/pubspec.yaml
+++ b/packages/dartway_telegram/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_telegram
 description: "Telegram Mini App integration for DartWay apps: initialize the Telegram WebApp, read its safe-area insets and the Telegram user id. Optional by design."
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.4.0
+  dartway_flutter: ^0.5.0
   telegram_web_app: ^0.3.3
 
 dev_dependencies:

--- a/packages/dartway_telegram/test/dw_telegram_test.dart
+++ b/packages/dartway_telegram/test/dw_telegram_test.dart
@@ -4,6 +4,17 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  // One DwFlutter per test process — the singleton forbids re-creation. It is
+  // built up here because `init` takes a core now, so even the group that only
+  // checks the stub is inert needs one to hand over.
+  final pluggedIn = DwTelegramWebApp.create(
+    config: const DwTelegramWebAppConfig(requestFullScreen: true),
+  );
+  final dwInstance = DwFlutter(
+    config: const DwConfig(),
+    plugins: [pluggedIn],
+  );
+
   group('DwTelegramPlatform.fromRaw', () {
     test('maps the clients Telegram reports today', () {
       expect(DwTelegramPlatform.fromRaw('ios'), DwTelegramPlatform.ios);
@@ -35,26 +46,16 @@ void main() {
     });
 
     test('init is a no-op, so an app can declare it on every platform', () {
-      expect(telegram.init(), completes);
+      expect(telegram.init(dwInstance), completes);
     });
   });
 
   group('as a plugin', () {
-    final telegram = DwTelegramWebApp.create(
-      config: const DwTelegramWebAppConfig(requestFullScreen: true),
-    );
-
-    // One DwFlutter per test process — the singleton forbids re-creation.
-    final dwInstance = DwFlutter(
-      config: const DwConfig(),
-      plugins: [telegram],
-    );
-
     test('is reachable as dw.plugins.telegram', () {
       // The bridge the app declares is an interface; the object it gets is a
       // platform impl. `dw.plugins.telegram` has to resolve the former to the latter —
       // this is the whole contract behind the extension.
-      expect(dwInstance.plugins.telegram, same(telegram));
+      expect(dwInstance.plugins.telegram, same(pluggedIn));
     });
 
     test('the framework initializes it with the app core', () {

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -270,7 +270,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.0"
   dartway_lints:
     dependency: "direct dev"
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.4.0
+  dartway_flutter: ^0.5.0
 
   dartway_router: ^1.1.1
 


### PR DESCRIPTION
`DwPlugin.init()` took nothing, so a plugin had no legal way to reach the framework it was part of. It now takes one:

```dart
abstract class DwPlugin {
  /// Runs once during `dw.init()`, in declaration order, with the core this
  /// plugin was plugged into. A plugin is built *before* `dw` exists — that is
  /// what `plugins:` being a constructor argument means — so this is the first
  /// moment it may look at anything.
  Future<void> init(DwFlutter core);
}
```

## Why

`plugins:` is a constructor argument, so every plugin is built *before* the variable it will be reached through exists. The app declares `late final DwCore<Client, UserProfile> dw` and assigns it from the same expression the plugins are listed in:

```dart
dw = DwCore<Client, UserProfile>(
  plugins: [DwPush(config: DwPushConfig(
    recipientIdProvider: dw.userProfileProvider.select((p) => p?.id),  // throws at startup
  ))],
);
```

That compiles silently and fails with `LateInitializationError` before the first frame. The analyzer cannot warn, because `late final` is exactly the promise that the value will be there by the time anyone reads it. And the framework does not export the singleton — neither `dartway_flutter` nor `dartway_serverpod_core_flutter` hands it out — so there was no version of that line that worked, only versions that looked like they might.

Two marks it already left in the repository:

- **`dartway_push_flutter`'s README ships that exact snippet.** So does `docs/3-flutter/push-notifications.md` and the `dartway-push-delivery` skill.
- the `ref.watchSignedInUserId` / `readSignedInUserId` extensions in `core_flutter` exist as a way around the same gap, and are called nowhere in the monorepo — only declared.

`init` is the first moment the core exists, so that is where it arrives, handed over rather than looked up.

## The type of the argument

A `DwFlutter`, because that is what declares `plugins:`. An app on the data layer passes a `DwCore`, which *is* a `DwFlutter` — so a plugin that needs the data layer names it and casts:

```dart
final dwCore = core as DwCore<Client, UserProfile>;
```

The cast is the honest part: it says out loud that the plugin does not work on the plain Flutter toolbox, and it fails at startup rather than at the first read. A plugin that needs nothing from the core (most of them) ignores the argument and works on both.

## Scope

Breaking, mechanically — every implementation adds the parameter and nothing else changes. All four in the repository are updated: `DwTelegramWebApp` (interface plus both platform impls), `DwSharedPreferences`, `DwPush`, and the example's toy `_ClockPlugin`. `DwPlugins.initAll()` takes the core too, and `dw.init()` passes itself.

The plugin tests now need a core to hand over, which is the one ergonomic cost of the change. `consumer_needs_only_this_package_test.dart` stops calling `init` instead of paying it: constructing a core there would put `dartway_flutter` in the import list that file exists to keep short, and nothing in it reads a provider.

A new test holds the reason for the argument — a plugin is asserted to receive the same instance it was declared on.

## Versions

`dartway_flutter` 0.4.0 → **0.5.0**, with `dartway_telegram` 0.2.0 and `dartway_shared_preferences` 0.3.0 following so the set resolves together, and every `^0.4.0` constraint moved (core_flutter, push_flutter, example, template). Lockfiles follow. `example/dartway_example_flutter/pubspec.lock` also picks up `dartway_push_client` 0.2.0, which was already the version on disk and stale in the lock.

## Synchronisation law

- **`docs/3-flutter/plugins.md`** — the `init(core)` signature throughout, and a new section explaining why `init` takes a core rather than reading `dw`. The trap is invisible in the code that falls into it, so the doc shows the declaration site and names `LateInitializationError`.
- **`example/` and `template/`** — neither declares a plugin, so nothing to port; both `flutter analyze` clean after the bump.
- **`toolkit/skills/`** — no skill mentions `DwPlugin` or its signature.
- **CHANGELOGs** — `dartway_flutter` 0.5.0, `dartway_telegram` 0.2.0, `dartway_shared_preferences` 0.3.0.

## Deliberately not in this PR

- **`dartway_push_flutter` beyond the signature.** `feat/push-app-half` was waiting for this mechanism and will sit on it, which is where the broken `recipientIdProvider` example gets fixed for real — in the README, `docs/3-flutter/push-notifications.md` and the `dartway-push-delivery` skill together, once the plugin actually reads the core in `init`. `dartway_push_flutter` keeps version 0.1.0: it is unreleased, so its `init` signature changing needs no entry of its own.
- **the `ref.watchSignedInUserId` / `readSignedInUserId` session extensions.** Now that a plugin can reach the core legitimately, the workaround has no callers left to justify it — a separate removal, after this.

`dart analyze` clean on the four affected packages; tests green in `dartway_flutter`, `dartway_telegram`, `dartway_shared_preferences` and `dartway_push_flutter`; `example/dartway_example_flutter`, `template/dartway_starter_flutter` and `packages/dartway_flutter/example` all analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
