### PR TITLE
feat(prefs): a stored value can belong to an entity, not just to the app

### DIFF
--- a/docs/3-flutter/data-layer.md
+++ b/docs/3-flutter/data-layer.md
@@ -229,6 +229,46 @@ final workspaceStateProvider =
 (`scoped_providers_should_specify_dependencies`) which cannot help you here: it only reasons about
 providers written with code generation, and DartWay writes them by hand.
 
+## State that is not server data
+
+"How this list is sorted", "is this panel collapsed", "which tab was open" is state too, and it never
+goes near `dw.repo`. Two questions place it, in this order.
+
+**Does it survive a restart?** No — an ordinary `Notifier`, in memory like anything else. Yes — the
+[`dartway_shared_preferences`](plugins.md) plugin, `dw.plugins.prefs`. It hands back a riverpod
+provider, so persisting a value costs no reactivity: the same `ref.watch`, and every reader on the
+screen sees one value.
+
+**Does it belong to an entity?** No, it is one setting for the whole app — a constant key:
+
+```dart
+final darkModeProvider =
+    dw.plugins.prefs.provider<bool>(key: 'darkMode', defaultValue: false);
+```
+
+Yes, there is one per project, per chat, per section — the family form, where `keyFor` builds the key
+from the argument:
+
+```dart
+final projectSortProvider = dw.plugins.prefs.providerFamily<String, int>(
+  keyFor: (projectId) => 'project.$projectId.sort',
+  defaultValue: 'name',
+);
+
+final sort = ref.watch(projectSortProvider(project.id));
+ref.read(projectSortProvider(project.id).notifier).update('createdAt');
+```
+
+The family is what makes this safe, not just short. `provider` takes a constant key and must be
+declared once, like any riverpod provider: call it per id and each call builds a *new* provider, so
+two of them over one key never see each other's writes. A family is declared once and riverpod keeps
+one provider per argument value, which is exactly the guarantee the loop cannot give.
+
+`mappedProvider`/`mappedProviderFamily` are the same pair for enums and custom types, stored as a
+`String`. `dw.plugins.prefs.raw` is the underlying store, for a genuine one-off imperative read — a
+store class of your own built on it has no subscribers, and the state ends up trapped in one widget's
+`State`.
+
 ## Writing
 
 ```dart

--- a/packages/dartway_shared_preferences/CHANGELOG.md
+++ b/packages/dartway_shared_preferences/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.4.0
+
+- **`providerFamily(keyFor:, defaultValue:)` and `mappedProviderFamily(keyFor:, mapFrom:, mapTo:)`
+  — a stored value whose key comes from an entity.** `provider`/`mappedProvider` take a constant
+  key, so state that belongs to a project, a chat or a section had nowhere to go: they cannot be
+  called per id, and the class doc says why — a second call with the same key builds a *second*
+  provider, and the two are blind to each other's writes.
+
+  The family is exactly the answer to that warning. Riverpod holds one provider per argument value,
+  so `family(id)` resolved in one widget and `family(id)` resolved in another are the same state.
+  Declare the family as the top-level `final`; calling it with an argument inside `build` is the
+  intended use. `DwPrefProviderFamily<T, Arg>` and `DwMappedPrefProviderFamily<T, Arg>` name the
+  return types, so a consumer still imports nothing but this package — and here that matters more
+  than before: the underlying `NotifierProviderFamily` is not even exported from
+  `flutter_riverpod.dart`, it lives in `flutter_riverpod/misc.dart`.
+
+  What this replaces, twice over on one real project: a store class with injected read/write over
+  `dw.plugins.prefs.raw`, plus a `StatefulWidget` reading in `initState`, re-reading in
+  `didUpdateWidget` when the entity changed, and writing back on every change. The thirty lines were
+  not the cost — the lost reactivity was. A pair of functions has no subscribers, so the value lived
+  in one widget's `State` and every second reader had to be handed it through a constructor.
+
+  Both forms ship together on purpose: `provider` and `mappedProvider` are documented as a pair, and
+  a family for only one of them is a splinter somebody has to ask about.
+
+- The `dartway-data-layer` skill gains a section on local screen state, which said nothing about
+  `dw.plugins.prefs` before. Two questions draw the border: does the value survive a restart (no — an
+  ordinary `Notifier`; yes — this plugin), and does it belong to an entity (yes — a family with the
+  key built from the argument; no — a constant key). Without a rule the choice was made by copying
+  the neighbouring file, which is how one app ends up storing the same kind of thing three ways.
+
 ## 0.3.0
 
 Follows `dartway_flutter` 0.5.0, where `DwPlugin.init()` gained the core as an argument:

--- a/packages/dartway_shared_preferences/README.md
+++ b/packages/dartway_shared_preferences/README.md
@@ -64,6 +64,41 @@ ref.read(darkModeProvider.notifier).update(true);
 compiles but throws `UnsupportedError` on the first write; reach for `mappedProvider` (enums, custom
 types) or `raw` instead.
 
+## Per-entity values — the family form
+
+When the key depends on an entity — a sort order per project, a collapsed flag per section, a draft
+per chat — `keyFor` builds the key from an argument:
+
+```dart
+final DwPrefProviderFamily<String, int> projectSortProvider =
+    dw.plugins.prefs.providerFamily<String, int>(
+      keyFor: (projectId) => 'project.$projectId.sort',
+      defaultValue: 'name',
+    );
+
+// in a widget
+final sort = ref.watch(projectSortProvider(project.id));
+ref.read(projectSortProvider(project.id).notifier).update('createdAt');
+```
+
+`mappedProviderFamily(keyFor:, mapFrom:, mapTo:)` is the same for enums and custom types, exactly as
+`mappedProvider` is to `provider`.
+
+**A family is the safe way to do per-entity state, not merely the short one.** Calling `provider`
+once per id is the thing "define each provider once" forbids: every call builds a *new* provider, and
+two providers over one key never see each other's writes. A family is declared once and riverpod
+keeps a single provider per argument value — so `family(id)` read in one widget and `family(id)` read
+in another are the same state. Declare the *family* as the top-level `final`; calling it with an
+argument inside `build` is the intended use.
+
+The argument must be a value riverpod can compare: a `String`, an `int`, or any type with `==` and
+`hashCode` (a record, if you need several fields). Keys are namespaced by hand — `keyFor` returns the
+whole key, so a prefix naming the feature that owns it costs one string.
+
+Reaching for `raw` and a store of your own instead is the trade to avoid: two functions have no
+subscribers, so the value ends up living in one widget's `State` and every other reader on the screen
+has to be handed it through a constructor. `raw` is for a genuine one-off read.
+
 ## Why a plugin
 
 `dw.` is the framework's closed core; `dw.plugins.` is what a project plugs in. Preferences live

--- a/packages/dartway_shared_preferences/example/README.md
+++ b/packages/dartway_shared_preferences/example/README.md
@@ -35,3 +35,44 @@ class DarkModeSwitch extends ConsumerWidget {
 The switch reflects storage and writes to it; no manual read/write, no reload. For a value that
 isn't a primitive, `mappedProvider` maps it to and from a `String`; for a one-off read, reach the
 underlying store with `dw.plugins.prefs.raw`.
+
+## A value per entity
+
+`darkMode` is one setting for the whole app. A sort order belongs to *this* project, so the key has
+to carry its id — that is `providerFamily`, and the family (not the provider it returns) is the
+top-level `final`:
+
+```dart
+final projectSortProvider = dw.plugins.prefs.providerFamily<String, int>(
+  keyFor: (projectId) => 'project.$projectId.sort',
+  defaultValue: 'name',
+);
+
+class ProjectSortButton extends ConsumerWidget {
+  const ProjectSortButton({required this.projectId, super.key});
+
+  final int projectId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sort = ref.watch(projectSortProvider(projectId));
+    return DropdownButton<String>(
+      value: sort,
+      items: const [
+        DropdownMenuItem(value: 'name', child: Text('Name')),
+        DropdownMenuItem(value: 'createdAt', child: Text('Newest')),
+      ],
+      onChanged: (value) => value == null
+          ? null
+          : ref.read(projectSortProvider(projectId).notifier).update(value),
+    );
+  }
+}
+```
+
+Riverpod holds one provider per argument value, so anything else on the screen that watches
+`projectSortProvider(projectId)` — the list itself, a "reset" button in another panel — rebuilds on
+that write, and a different project keeps its own stored order. Calling `provider` per id instead
+would give each of those readers a provider of its own, blind to the others' writes.
+
+For an enum or a custom type, `mappedProviderFamily(keyFor:, mapFrom:, mapTo:)`.

--- a/packages/dartway_shared_preferences/lib/src/dw_shared_preferences.dart
+++ b/packages/dartway_shared_preferences/lib/src/dw_shared_preferences.dart
@@ -1,5 +1,6 @@
 import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'logic/mapped_pref_notifier.dart';
@@ -28,6 +29,17 @@ typedef DwPrefProvider<T> = NotifierProvider<PrefNotifier<T>, T>;
 typedef DwMappedPrefProvider<T> =
     NotifierProvider<MappedPrefNotifier<T>, T>;
 
+/// What [DwSharedPreferences.providerFamily] returns — see [DwPrefProvider] for
+/// why the plugin names its own return types. Call it with an [Arg] to get a
+/// [DwPrefProvider] over the key that argument maps to.
+typedef DwPrefProviderFamily<T, Arg> =
+    NotifierProviderFamily<PrefNotifier<T>, T, Arg>;
+
+/// What [DwSharedPreferences.mappedProviderFamily] returns — see
+/// [DwPrefProviderFamily].
+typedef DwMappedPrefProviderFamily<T, Arg> =
+    NotifierProviderFamily<MappedPrefNotifier<T>, T, Arg>;
+
 /// The shared-preferences plugin: a reactive wrapper over [SharedPreferences].
 /// Declare it at startup, then reach it as `dw.plugins.prefs`:
 ///
@@ -50,6 +62,21 @@ typedef DwMappedPrefProvider<T> =
 ///
 /// // one-off imperative read, no provider:
 /// final token = dw.plugins.prefs.raw.getString('token');
+/// ```
+///
+/// When the key depends on an entity — one value per project, per chat, per
+/// user — reach for [providerFamily] / [mappedProviderFamily] instead of
+/// calling [provider] per id. The family is the top-level `final`; riverpod
+/// then holds one provider per argument value, which is exactly the guarantee
+/// a loop over [provider] cannot give you.
+///
+/// ```dart
+/// final projectSortProvider = dw.plugins.prefs.providerFamily<String, int>(
+///   keyFor: (projectId) => 'project.$projectId.sort',
+///   defaultValue: 'name',
+/// );
+///
+/// ref.watch(projectSortProvider(project.id));
 /// ```
 class DwSharedPreferences extends DwPlugin {
   DwSharedPreferences();
@@ -92,6 +119,66 @@ class DwSharedPreferences extends DwPlugin {
   }) {
     return NotifierProvider<MappedPrefNotifier<T>, T>(() {
       return MappedPrefNotifier<T>(raw, key, mapFrom, mapTo);
+    });
+  }
+
+  /// [provider], but the key is built per argument — for a value that belongs
+  /// to an entity rather than to the app: a sort order per project, a collapsed
+  /// flag per section, a draft per chat.
+  ///
+  /// [keyFor] turns the argument into the storage key; everything else matches
+  /// [provider], including the natively-stored types and the [UnsupportedError]
+  /// any other `T` throws on the first write.
+  ///
+  /// **This is what makes per-entity state safe.** Calling [provider] once per
+  /// id hits the hazard the class doc warns about — two providers over one key,
+  /// blind to each other's writes. A family is declared once and riverpod keeps
+  /// a single provider per argument value, so every reader of `family(id)` sees
+  /// the same state. Declare the *family* as a top-level `final`; calling it
+  /// with an argument inside `build` is the intended use.
+  ///
+  /// ```dart
+  /// final projectSortProvider = dw.plugins.prefs.providerFamily<String, int>(
+  ///   keyFor: (projectId) => 'project.$projectId.sort',
+  ///   defaultValue: 'name',
+  /// );
+  ///
+  /// final sort = ref.watch(projectSortProvider(project.id));
+  /// ref.read(projectSortProvider(project.id).notifier).update('createdAt');
+  /// ```
+  ///
+  /// [Arg] must be a value riverpod can compare — a `String`, an `int`, or any
+  /// type with `==` and `hashCode`. Two arguments that are `==` share one
+  /// provider; two that are not get one each, and their keys must differ too,
+  /// which is [keyFor]'s job.
+  DwPrefProviderFamily<T, Arg> providerFamily<T, Arg>({
+    required String Function(Arg arg) keyFor,
+    required T defaultValue,
+  }) {
+    return NotifierProvider.family<PrefNotifier<T>, T, Arg>((arg) {
+      return PrefNotifier<T>(raw, keyFor(arg), defaultValue);
+    });
+  }
+
+  /// [mappedProvider], but the key is built per argument — the enum-and-custom-
+  /// type half of [providerFamily], whose doc explains why a family is the
+  /// right tool for per-entity state.
+  ///
+  /// ```dart
+  /// final projectViewProvider =
+  ///     dw.plugins.prefs.mappedProviderFamily<ProjectView, int>(
+  ///       keyFor: (projectId) => 'project.$projectId.view',
+  ///       mapFrom: (raw) => ProjectView.values.byName(raw ?? 'list'),
+  ///       mapTo: (view) => view.name,
+  ///     );
+  /// ```
+  DwMappedPrefProviderFamily<T, Arg> mappedProviderFamily<T, Arg>({
+    required String Function(Arg arg) keyFor,
+    required T Function(String?) mapFrom,
+    required String Function(T) mapTo,
+  }) {
+    return NotifierProvider.family<MappedPrefNotifier<T>, T, Arg>((arg) {
+      return MappedPrefNotifier<T>(raw, keyFor(arg), mapFrom, mapTo);
     });
   }
 }

--- a/packages/dartway_shared_preferences/pubspec.yaml
+++ b/packages/dartway_shared_preferences/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_shared_preferences
 description: "Shared-preferences plugin for DartWay: typed riverpod providers over local storage, reached as dw.plugins.prefs. Optional by design."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_shared_preferences/test/consumer_needs_only_this_package_test.dart
+++ b/packages/dartway_shared_preferences/test/consumer_needs_only_this_package_test.dart
@@ -35,10 +35,28 @@ late final DwMappedPrefProvider<_Theme> themeProvider = _prefs
       mapTo: (theme) => theme.name,
     );
 
+/// The family typedefs carry the same burden and then some: they alias
+/// `NotifierProviderFamily`, which is not even exported from
+/// `flutter_riverpod.dart` — it lives in `flutter_riverpod/misc.dart`. A
+/// consumer who had to spell the type out would need an import they have no way
+/// to guess at.
+late final DwPrefProviderFamily<String, int> projectSortProvider = _prefs
+    .providerFamily<String, int>(
+      keyFor: (projectId) => 'project.$projectId.sort',
+      defaultValue: 'name',
+    );
+
+late final DwMappedPrefProviderFamily<_Theme, String> sectionThemeProvider =
+    _prefs.mappedProviderFamily<_Theme, String>(
+      keyFor: (section) => 'section.$section.theme',
+      mapFrom: (stored) => _Theme.values.asNameMap()[stored ?? ''] ?? _Theme.system,
+      mapTo: (theme) => theme.name,
+    );
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('a consumer declares both providers importing only this package', () {
+  test('a consumer declares every provider importing only this package', () {
     _prefs = DwSharedPreferences();
 
     // Not initialized on purpose. `init` takes the core the plugin was plugged
@@ -50,5 +68,7 @@ void main() {
     // declarations above compile at all.
     expect(darkModeProvider, isNotNull);
     expect(themeProvider, isNotNull);
+    expect(projectSortProvider, isNotNull);
+    expect(sectionThemeProvider, isNotNull);
   });
 }

--- a/packages/dartway_shared_preferences/test/dw_shared_preferences_test.dart
+++ b/packages/dartway_shared_preferences/test/dw_shared_preferences_test.dart
@@ -65,4 +65,92 @@ void main() {
     expect(container.read(theme), _Theme.dark);
     expect(prefs.raw.getString('theme'), 'dark');
   });
+
+  group('providerFamily', () {
+    test('two arguments keep separate values under separate keys', () async {
+      final sort = prefs.providerFamily<String, int>(
+        keyFor: (projectId) => 'project.$projectId.sort',
+        defaultValue: 'name',
+      );
+
+      await container.read(sort(1).notifier).update('createdAt');
+
+      expect(container.read(sort(1)), 'createdAt');
+      // The other project never heard about it — this is the whole point.
+      expect(container.read(sort(2)), 'name');
+
+      expect(prefs.raw.getString('project.1.sort'), 'createdAt');
+      expect(prefs.raw.getString('project.2.sort'), isNull);
+    });
+
+    test('the same argument resolves to one provider, shared by every reader',
+        () async {
+      final sort = prefs.providerFamily<String, int>(
+        keyFor: (projectId) => 'project.$projectId.sort',
+        defaultValue: 'name',
+      );
+
+      // Two separate calls with the same argument. Riverpod compares family
+      // providers by (family, argument), so the container holds one state
+      // behind both — the guarantee a loop over `provider` cannot give.
+      expect(sort(7), sort(7));
+      expect(container.read(sort(7).notifier), same(container.read(sort(7).notifier)));
+
+      await container.read(sort(7).notifier).update('createdAt');
+
+      // A second reader that resolved the family independently sees the write.
+      expect(container.read(sort(7)), 'createdAt');
+    });
+
+    test('reads a value already in storage instead of the default', () async {
+      SharedPreferences.setMockInitialValues({'project.3.sort': 'createdAt'});
+      prefs = DwSharedPreferences();
+      await prefs.init(dwInstance);
+
+      final sort = prefs.providerFamily<String, int>(
+        keyFor: (projectId) => 'project.$projectId.sort',
+        defaultValue: 'name',
+      );
+
+      expect(container.read(sort(3)), 'createdAt');
+      expect(container.read(sort(4)), 'name');
+    });
+  });
+
+  group('mappedProviderFamily', () {
+    test('two arguments keep separate values under separate keys', () async {
+      final theme = prefs.mappedProviderFamily<_Theme, String>(
+        keyFor: (section) => 'section.$section.theme',
+        mapFrom: (raw) => _Theme.values.byName(raw ?? 'system'),
+        mapTo: (mode) => mode.name,
+      );
+
+      await container.read(theme('billing').notifier).update(_Theme.dark);
+
+      expect(container.read(theme('billing')), _Theme.dark);
+      expect(container.read(theme('reports')), _Theme.system);
+
+      expect(prefs.raw.getString('section.billing.theme'), 'dark');
+      expect(prefs.raw.getString('section.reports.theme'), isNull);
+    });
+
+    test('the same argument resolves to one provider, shared by every reader',
+        () async {
+      final theme = prefs.mappedProviderFamily<_Theme, String>(
+        keyFor: (section) => 'section.$section.theme',
+        mapFrom: (raw) => _Theme.values.byName(raw ?? 'system'),
+        mapTo: (mode) => mode.name,
+      );
+
+      expect(theme('billing'), theme('billing'));
+      expect(
+        container.read(theme('billing').notifier),
+        same(container.read(theme('billing').notifier)),
+      );
+
+      await container.read(theme('billing').notifier).update(_Theme.dark);
+
+      expect(container.read(theme('billing')), _Theme.dark);
+    });
+  });
 }

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -8,7 +8,9 @@ description: >-
   narrowing by query via backendFilter, local filtering you do yourself with .where in the widget,
   actions from the UI via dw.action (unified error/loading handling), notifications via dw.notify.* (not SnackBar),
   the profile via ref.watchUserProfile/readUserProfile (getters, not CRUD), sign-out via
-  sessionProvider.notifier.signOut(). Use when working with data, actions, notifications,
+  sessionProvider.notifier.signOut(), local screen state that survives a restart via
+  dw.plugins.prefs (providerFamily/mappedProviderFamily when the value belongs to an entity).
+  Use when working with data, actions, notifications, local state,
   loading/saving models in Flutter features.
 ---
 
@@ -244,6 +246,53 @@ class FakeAudioControllerNotifier extends AudioControllerNotifier {
 }
 ```
 
+## 4b. Local screen state — two questions decide where it lives
+
+**Why:** "the sort order of this list", "is this panel collapsed", "which tab was open" is state
+too, and an app that answers the question differently in every feature ends up with three ways to
+store the same thing — chosen by copying the neighbouring file rather than by a rule. There are two
+questions, in this order.
+
+**1. Does the value survive a restart?** No — an ordinary `Notifier` (§4a), it is in-memory state
+like any other. Yes — `dw.plugins.prefs`, the local-storage plugin
+(`dartway_shared_preferences`, declared in `plugins:` next to the config). It gives back a riverpod
+provider, so persistence costs you no reactivity: the same `ref.watch`, and every reader on the
+screen sees the same value.
+
+**2. Does the value belong to an entity?** No (one setting for the whole app) — a constant key.
+Yes (one per project, per chat, per section) — the **family** form, where the key is built from the
+argument:
+
+```dart
+// ❌ a hand-rolled store: read in initState, re-read in didUpdateWidget, write on change
+class _SortStore { String read(int id) => ...; void write(int id, String v) => ...; }
+
+// ❌ provider() called per id: every call builds a *new* provider, and two over one key
+//    do not see each other's writes
+final p = dw.plugins.prefs.provider(key: 'project.$projectId.sort', defaultValue: 'name');
+
+// ✅ the family is the top-level `final`; riverpod holds one provider per argument value
+final projectSortProvider = dw.plugins.prefs.providerFamily<String, int>(
+  keyFor: (projectId) => 'project.$projectId.sort',
+  defaultValue: 'name',
+);
+
+// in the widget — an ordinary watch, and any other reader of the same id sees the same state
+final sort = ref.watch(projectSortProvider(project.id));
+ref.read(projectSortProvider(project.id).notifier).update('createdAt');
+```
+
+`mappedProviderFamily(keyFor:, mapFrom:, mapTo:)` is the same for enums and custom types, exactly as
+`mappedProvider` is to `provider`. Storage keys are namespaced by hand (`'project.$id.sort'`) —
+`keyFor` returns the whole key, so a prefix that says which feature owns it costs one string.
+
+**The hand-rolled store is the thing to stop writing.** A class with injected read/write over
+`dw.plugins.prefs.raw` plus a `StatefulWidget` that re-reads in `didUpdateWidget` is thirty lines
+that work — and have no subscribers. The state then lives in one widget's `State`, so a second
+reader (a counter in the header, a "reset" button in another panel) can only receive it through
+constructor arguments. `raw` is for a genuine one-off imperative read, not for state a screen
+watches.
+
 ## 5. Notifications — `dw.notify.*` (not `SnackBar`)
 
 **Why:** a single style of toasts/notifications across the whole app. Don't poke `ScaffoldMessenger`/`SnackBar`/custom popups.
@@ -399,6 +448,7 @@ Neighbouring forms: `pickAndUploadImage()` (returns a `DwCloudFile` with size an
 - [ ] Narrowing by query — `backendFilter`; local filtering you do yourself with `.where` in the widget (the framework doesn't provide it).
 - [ ] Actions from the UI — `dw.action((context) async {...})`, not a raw `onPressed`/`() async {}`.
 - [ ] Notifications — `dw.notify.success/warning/error/info`, not `SnackBar`/`ScaffoldMessenger`.
+- [ ] Local screen state — survives a restart? `dw.plugins.prefs`, not a store over `raw`. Belongs to an entity? `providerFamily(keyFor:)`, not `provider` per id.
 - [ ] Profile — `ref.watchUserProfile`/`readUserProfile` (getters), not `watchModel<UserProfile>()`. Signed out is a legal answer, or you want `.select` — `dw.userProfileProvider` / `dw.requireUserProfileProvider`. Only the id — `dw.signedInUserIdProvider`.
 - [ ] Sign-out — `ref.read(dw.sessionProvider!.notifier).signOut()`.
 - [ ] Must **another** user see the update? `dw.repo.modelList` doesn't do that by itself — `broadcastTo` in the config (public), a channel with the group id (group), `sendUpdatesToUser` (private).


### PR DESCRIPTION
## The problem

`dw.plugins.prefs.provider(key:, defaultValue:)` and `mappedProvider(key:, mapFrom:, mapTo:)` take a **constant** key. State whose key depends on an entity — a sort order per project, a collapsed flag per section, a draft per chat — therefore has nowhere to go. Calling them in a loop or per id is worse than useless, and the class doc already warns why: a second call with the same key builds a *second* provider, and two providers over one key never see each other's writes.

On a real project this produced the same home-rolled thing twice: a store class with injected read/write over `dw.plugins.prefs.raw`, a key like `'app.project.$projectId.<what>'`, and a `StatefulWidget` reading in `initState`, re-reading in `didUpdateWidget` when the entity changed, and writing back on every change.

The cost was never the thirty lines — it was the lost reactivity. `mappedProvider` is a `NotifierProvider`; anyone can subscribe. A pair of functions has none, so the state lived in one widget's `State` and every second reader (a counter in the header, a "reset" button in another panel) had to be handed it through a constructor. The plugin shipped a ready mechanism for precisely the *rarer* case: one global value per app.

## The change

Family variants on `DwSharedPreferences`, with the key built from the argument:

```dart
final projectSortProvider = dw.plugins.prefs.providerFamily<String, int>(
  keyFor: (projectId) => 'project.$projectId.sort',
  defaultValue: 'name',
);

final sort = ref.watch(projectSortProvider(project.id));
ref.read(projectSortProvider(project.id).notifier).update('createdAt');
```

plus `mappedProviderFamily(keyFor:, mapFrom:, mapTo:)` for enums and custom types.

**The family is the answer to the warning, not a way around it.** Riverpod compares family providers by `(family, argument)`, so it keeps one provider per argument value — the guarantee a loop over `provider` cannot give. The new doc comments say this outright.

Both forms ship together on purpose: `provider` and `mappedProvider` are documented as a pair, and a family for only one of them is a splinter somebody has to ask about.

Written by hand, no `riverpod_generator`, as everything in this repository is: `NotifierProvider.family` is declared as `NotifierT Function(ArgT arg)` and the existing `PrefNotifier`/`MappedPrefNotifier` already take the key through their constructors — neither needed a change.

`DwPrefProviderFamily<T, Arg>` and `DwMappedPrefProviderFamily<T, Arg>` name the return types, so a consumer still imports nothing but this package. That matters more here than for the orphan providers: `NotifierProviderFamily` is not exported from `flutter_riverpod.dart` at all — it lives in `flutter_riverpod/misc.dart`, an import nobody would guess at.

## Tests

`flutter test` — 9 passing. The two the change turns on, for each of the two families:

- two different arguments keep separate values under separate keys, and neither sees the other's write;
- the same argument resolves to one provider — `family(7) == family(7)`, the notifier is `same`, and a reader that resolved the family independently sees the write.

Plus: a family reads a value already in storage instead of the default, and `consumer_needs_only_this_package_test.dart` now declares both family typedefs — a compile-time assertion that the misc.dart import stayed inside the package.

## Synchronisation

- `toolkit/skills/dartway-data-layer/SKILL.md` — a new §4b on local screen state, which said **nothing** about `dw.plugins.prefs` before. Two questions draw the border: does the value survive a restart (no — an ordinary `Notifier`; yes — this plugin), and does it belong to an entity (yes — a family; no — a constant key). Without a rule the choice was made by copying the neighbouring file, which is how one app ends up storing the same kind of thing three ways.
- `docs/3-flutter/data-layer.md` — the same border, for the docs reader.
- README and the package `example/` show the family form; `CHANGELOG` + `pubspec` → 0.4.0 (the package versions independently of the core).
- `example/` and `template/` do not depend on this plugin, so neither is affected. `framework-finish` reports no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
