### PR TITLE
fix(flutter): the list skeleton is built only when a skeleton is shown

### DIFF
--- a/docs/3-flutter/data-layer.md
+++ b/docs/3-flutter/data-layer.md
@@ -137,9 +137,14 @@ speak. So:
   model of type X` while building the skeleton — during `build`, so it is a red screen, not an
   error state.
 
-`dwBuildListAsync` asserts up front that a placeholder is obtainable, but the assert only checks
-that `DwConfig.defaultModelGetter` is wired at all (the app passes `dwGetDefault`), not that your
+`dwBuildListAsync` asserts that a placeholder is obtainable, but the assert only checks that
+`DwConfig.defaultModelGetter` is wired at all (the app passes `dwGetDefault`), not that your
 particular model is registered. A new model means a new `setupRepository` call, always.
+
+Both the assert and the placeholder itself belong to the loading branch and run nowhere else — a
+widget test that hands the builder a ready `AsyncData` never touches the registry, and so does not
+have to stand it up. A list test that *does* fail on a missing placeholder is a test of the loading
+state, whether or not it was written as one.
 
 ## Narrowing the list: `backendFilter`
 

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -277,7 +277,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.5.1"
   dartway_lints:
     dependency: "direct dev"
     description:

--- a/packages/dartway_flutter/CHANGELOG.md
+++ b/packages/dartway_flutter/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.5.1
+
+**`dwBuildListAsync` builds its skeleton only when it is showing one.** The placeholder list — and
+the assert that a placeholder is obtainable at all — used to be computed before `dwBuildAsync` was
+even asked which branch to render, so `dw.getDefaultModel<T>()` ran on the data and error frames
+too. In an app that is invisible, because `DefaultModels.initRepository()` runs at startup. In a
+widget test it is a wall: a screen handed a ready `AsyncData<List<X>>([])`, with no loading state
+anywhere in the test, still died on `UnimplementedError: Default Objects Repository doesn't contain
+a model of type X` — a message naming neither the screen nor the test.
+
+Both builders now delegate to one implementation that takes the placeholder as a factory and calls
+it inside the loading branch, where the single-value `dwBuildAsync` already computed its own. The
+public API is unchanged; a widget test of a list screen no longer has to stand up the default-model
+registry unless it is genuinely testing the loading state.
+
 ## 0.5.0
 
 **A plugin is handed the core it was plugged into.** `DwPlugin.init()` now takes one:

--- a/packages/dartway_flutter/example/pubspec.lock
+++ b/packages/dartway_flutter/example/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.5.1"
   fake_async:
     dependency: transitive
     description:

--- a/packages/dartway_flutter/lib/src/ui/async_ui/dw_async_ui.dart
+++ b/packages/dartway_flutter/lib/src/ui/async_ui/dw_async_ui.dart
@@ -17,43 +17,22 @@ extension DwAsyncValueX<T> on AsyncValue<T> {
     bool skipLoadingOnReload = false,
     bool skipLoadingOnRefresh = true,
   }) {
-    return when(
+    final placeholder = loadingValue;
+
+    return _dwBuildAsync<T>(
+      this,
+      childBuilder: childBuilder,
+      errorWidget: errorWidget,
+      loadingValueBuilder: placeholder == null ? null : () => placeholder,
+      loadingWidget: loadingWidget,
       skipLoadingOnReload: skipLoadingOnReload,
       skipLoadingOnRefresh: skipLoadingOnRefresh,
-      data: (data) => childBuilder(data),
-      error: (error, stackTrace) {
-        dw.handleError(error, stackTrace, source: DwErrorSource.asyncBuild);
-        return errorWidget;
-      },
-      loading: () {
-        if (loadingWidget != null) return loadingWidget;
-
-        if (loadingValue == null && !dw.isDefaultModelsGetterSetUp) {
-          return const SizedBox.shrink();
-        }
-
-        final fakeData =
-            loadingValue ?? (null is T ? null as T : dw.getDefaultModel<T>());
-
-        final built = childBuilder(fakeData);
-
-        // A sliver child needs the sliver-flavoured skeletonizer: the box one
-        // would be an invalid child for the enclosing CustomScrollView.
-        if (built is SliverList ||
-            built is SliverGrid ||
-            built is SliverToBoxAdapter ||
-            built is SliverPadding) {
-          return SliverSkeletonizer(enabled: true, child: built);
-        }
-
-        return Skeletonizer(child: built);
-      },
     );
   }
 }
 
-/// The list variant of [dwBuildAsync]: generates [loadingItemsCount] skeleton
-/// items from a placeholder model, then delegates to [dwBuildAsync].
+/// The list variant of [DwAsyncValueX.dwBuildAsync]: the loading branch renders
+/// [loadingItemsCount] skeleton items built from a placeholder model.
 extension DwAsyncValueListX<T> on AsyncValue<List<T>> {
   Widget dwBuildListAsync({
     required Widget Function(List<T> value) childBuilder,
@@ -64,24 +43,78 @@ extension DwAsyncValueListX<T> on AsyncValue<List<T>> {
     bool skipLoadingOnReload = false,
     bool skipLoadingOnRefresh = true,
   }) {
-    assert(
-      loadingItem != null || dw.isDefaultModelsGetterSetUp,
-      'Cannot build a loading value for dwBuildListAsync: either pass '
-      'loadingItem, or set DwConfig.defaultModelGetter.',
-    );
-
-    final items = List.generate(
-      loadingItemsCount,
-      (_) => loadingItem ?? (null is T ? null as T : dw.getDefaultModel<T>()),
-    );
-
-    return dwBuildAsync(
+    return _dwBuildAsync<List<T>>(
+      this,
       childBuilder: childBuilder,
-      loadingValue: items,
-      loadingWidget: loadingWidget,
       errorWidget: errorWidget,
+      // A factory, not a value: the placeholder list — and the assert that it
+      // can be built at all — must not run on the data and error branches. A
+      // widget test of a list screen would otherwise need the app's model
+      // registry standing up to render an AsyncData it already holds.
+      loadingValueBuilder: () {
+        assert(
+          loadingItem != null || dw.isDefaultModelsGetterSetUp,
+          'Cannot build a loading value for dwBuildListAsync: either pass '
+          'loadingItem, or set DwConfig.defaultModelGetter.',
+        );
+
+        return List.generate(
+          loadingItemsCount,
+          (_) =>
+              loadingItem ?? (null is T ? null as T : dw.getDefaultModel<T>()),
+        );
+      },
+      loadingWidget: loadingWidget,
       skipLoadingOnReload: skipLoadingOnReload,
       skipLoadingOnRefresh: skipLoadingOnRefresh,
     );
   }
+}
+
+/// The single implementation both public builders delegate to. The loading
+/// placeholder arrives as a factory so that nothing it needs — the default-model
+/// registry above all — is touched unless the loading branch actually renders.
+/// A null [loadingValueBuilder] means the caller supplied no placeholder.
+Widget _dwBuildAsync<T>(
+  AsyncValue<T> value, {
+  required Widget Function(T value) childBuilder,
+  required Widget errorWidget,
+  required T Function()? loadingValueBuilder,
+  required Widget? loadingWidget,
+  required bool skipLoadingOnReload,
+  required bool skipLoadingOnRefresh,
+}) {
+  return value.when(
+    skipLoadingOnReload: skipLoadingOnReload,
+    skipLoadingOnRefresh: skipLoadingOnRefresh,
+    data: (data) => childBuilder(data),
+    error: (error, stackTrace) {
+      dw.handleError(error, stackTrace, source: DwErrorSource.asyncBuild);
+      return errorWidget;
+    },
+    loading: () {
+      if (loadingWidget != null) return loadingWidget;
+
+      if (loadingValueBuilder == null && !dw.isDefaultModelsGetterSetUp) {
+        return const SizedBox.shrink();
+      }
+
+      final fakeData = loadingValueBuilder != null
+          ? loadingValueBuilder()
+          : (null is T ? null as T : dw.getDefaultModel<T>());
+
+      final built = childBuilder(fakeData);
+
+      // A sliver child needs the sliver-flavoured skeletonizer: the box one
+      // would be an invalid child for the enclosing CustomScrollView.
+      if (built is SliverList ||
+          built is SliverGrid ||
+          built is SliverToBoxAdapter ||
+          built is SliverPadding) {
+        return SliverSkeletonizer(enabled: true, child: built);
+      }
+
+      return Skeletonizer(child: built);
+    },
+  );
 }

--- a/packages/dartway_flutter/pubspec.yaml
+++ b/packages/dartway_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_flutter
 description: "The Flutter skeleton of a DartWay app: bootstrap runner, guarded UI actions, the AsyncValue rendering contract, notifications and error reporting. Riverpod-native."
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_flutter/test/dw_async_ui_test.dart
+++ b/packages/dartway_flutter/test/dw_async_ui_test.dart
@@ -1,0 +1,159 @@
+import 'package:dartway_flutter/dartway_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+/// A model the app's placeholder registry knows about.
+class _Known {
+  const _Known(this.title);
+  final String title;
+}
+
+/// A model it does not — the shape of every model a widget test never
+/// registered, which is all of them until the test says otherwise.
+class _Unknown {
+  const _Unknown(this.title);
+  final String title;
+}
+
+/// Stands in for an app's `DefaultModels` repository: it answers for the models
+/// it was told about and throws for the rest, message and all.
+T _defaultModelGetter<T>() {
+  if (T == _Known) return const _Known('placeholder') as T;
+
+  throw UnimplementedError(
+    "Default Objects Repository doesn't contain a model of type $T",
+  );
+}
+
+Widget _host(Widget child) => ProviderScope(
+  child: MaterialApp(home: Scaffold(body: child)),
+);
+
+void main() {
+  // One DwFlutter per test process — the singleton forbids re-creation.
+  DwFlutter(config: DwConfig(defaultModelGetter: _defaultModelGetter));
+
+  group('dwBuildListAsync builds its placeholder lazily', () {
+    testWidgets('data renders without reaching the placeholder registry', (
+      tester,
+    ) async {
+      const data = AsyncValue<List<_Unknown>>.data([_Unknown('real')]);
+
+      await tester.pumpWidget(
+        _host(
+          data.dwBuildListAsync(
+            childBuilder: (items) =>
+                Column(children: [for (final i in items) Text(i.title)]),
+          ),
+        ),
+      );
+
+      expect(find.text('real'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('an empty list is still just an empty list', (tester) async {
+      const data = AsyncValue<List<_Unknown>>.data([]);
+
+      await tester.pumpWidget(
+        _host(
+          data.dwBuildListAsync(
+            childBuilder: (items) => Text('${items.length} items'),
+          ),
+        ),
+      );
+
+      expect(find.text('0 items'), findsOneWidget);
+    });
+
+    testWidgets('error renders the error widget, registry untouched', (
+      tester,
+    ) async {
+      final failed = AsyncValue<List<_Unknown>>.error(
+        StateError('boom'),
+        StackTrace.empty,
+      );
+
+      await tester.pumpWidget(
+        _host(
+          failed.dwBuildListAsync(
+            childBuilder: (items) => const Text('unreachable'),
+            errorWidget: const Text('failed'),
+          ),
+        ),
+      );
+
+      expect(find.text('failed'), findsOneWidget);
+      expect(find.text('unreachable'), findsNothing);
+    });
+
+    testWidgets('loading does reach the registry, and skeletonizes', (
+      tester,
+    ) async {
+      const loading = AsyncValue<List<_Known>>.loading();
+
+      await tester.pumpWidget(
+        _host(
+          loading.dwBuildListAsync(
+            loadingItemsCount: 2,
+            childBuilder: (items) =>
+                Column(children: [for (final i in items) Text(i.title)]),
+          ),
+        ),
+      );
+
+      expect(find.text('placeholder'), findsNWidgets(2));
+      expect(find.byType(SkeletonizerScope), findsOneWidget);
+    });
+
+    testWidgets('loadingItem keeps the registry out of it entirely', (
+      tester,
+    ) async {
+      const loading = AsyncValue<List<_Unknown>>.loading();
+
+      await tester.pumpWidget(
+        _host(
+          loading.dwBuildListAsync(
+            loadingItem: const _Unknown('mine'),
+            loadingItemsCount: 1,
+            childBuilder: (items) =>
+                Column(children: [for (final i in items) Text(i.title)]),
+          ),
+        ),
+      );
+
+      expect(find.text('mine'), findsOneWidget);
+    });
+  });
+
+  group('dwBuildAsync', () {
+    testWidgets('data renders without reaching the placeholder registry', (
+      tester,
+    ) async {
+      const data = AsyncValue<_Unknown>.data(_Unknown('real'));
+
+      await tester.pumpWidget(
+        _host(data.dwBuildAsync(childBuilder: (value) => Text(value.title))),
+      );
+
+      expect(find.text('real'), findsOneWidget);
+    });
+
+    testWidgets('loadingWidget wins over the placeholder', (tester) async {
+      const loading = AsyncValue<_Unknown>.loading();
+
+      await tester.pumpWidget(
+        _host(
+          loading.dwBuildAsync(
+            childBuilder: (value) => Text(value.title),
+            loadingWidget: const Text('spinner'),
+          ),
+        ),
+      );
+
+      expect(find.text('spinner'), findsOneWidget);
+    });
+  });
+}

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -270,7 +270,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.5.1"
   dartway_lints:
     dependency: "direct dev"
     description:

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -67,6 +67,8 @@ dw.repo.setupRepository(
 
 The skeleton is drawn from your own widget built on that instance — that's why it resembles the future content rather than a generic shimmer. Without registration the very first `dwBuildListAsync` fails at runtime: `Default Objects Repository doesn't contain a model of type X`.
 
+**The placeholder is built in the loading state only**, so a widget test of a list screen that hands the builder a ready `AsyncData` does not have to stand up the default models — if a test does need them, that test is really exercising the loading state.
+
 ## 3. Filtering — `backendFilter` (server) + `.where` (client)
 
 **Why:** to narrow a list with a query to the DB — through `backendFilter`. Local filtering of already loaded data the framework deliberately **does not provide**: it is a trivial `.where`, do it yourself in the widget, don't look for a "framework" way.


### PR DESCRIPTION
`dwBuildListAsync` computed its placeholder list — and asserted that a placeholder was obtainable at all — before `dwBuildAsync` was even asked which branch to render. `dw.getDefaultModel<T>()` therefore ran on the data and error frames too. The single-value `dwBuildAsync` next door never had the problem: its placeholder is computed inside `loading: () { ... }`.

An app never notices, because `DefaultModels.initRepository()` runs at startup. A widget test pays for it: a list screen handed a ready `AsyncData<List<X>>([])`, with no loading state anywhere in the test, died with

```
UnimplementedError: Default Objects Repository doesn't contain a model of type X
```

— a message naming neither the screen nor the test, about a registry the author of the test had never seen.

## The change

Both public builders now delegate to one private `_dwBuildAsync` that takes the placeholder as a factory (`T Function()?`) instead of a value and calls it inside the loading branch. The assert moved there with it: its job is to catch a misconfiguration at the moment the placeholder is actually needed, not on every frame that has data. No second public parameter next to `loadingValue` — `docs/DESIGN.md` forbids two ways to do one thing — and both signatures are unchanged.

## Proof

`test/dw_async_ui_test.dart` stands up a `defaultModelGetter` that answers for one model and throws for the rest, the way a real `DefaultModels` repository does. Against the pre-fix implementation the three list tests that render data, an empty list and an error all fail with the `UnimplementedError` above; after the change they pass, while the loading tests still show that the registry *is* reached when a skeleton is genuinely drawn.

## Mirrors

- `toolkit/skills/dartway-data-layer` and `docs/3-flutter/data-layer.md` now say that the placeholder belongs to the loading state, so a list-screen widget test does not have to stand up the default models — and that a test which does need them is a test of the loading state.
- `example/` and `template/` need no source change (no signature moved); both analyze clean, and their lockfiles record the version bump.
- `dartway_flutter` 0.5.0 → 0.5.1, CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
