### PR TITLE
fix(push): the recipient comes from the session the server already trusts

### DIFF
--- a/docs/3-flutter/push-notifications.md
+++ b/docs/3-flutter/push-notifications.md
@@ -28,7 +28,6 @@ dw = DwCore<Client, UserProfile>(
     DwPush(
       config: DwPushConfig(
         providers: [DwRuStorePush(), DwFirebasePush(webVapidKey: kVapidKey)],
-        recipientIdProvider: dw.userProfileProvider.select((p) => p?.id),
         onOpened: (opened) => appRouter.go(routeFor(opened.data)),
       ),
     ),
@@ -88,6 +87,25 @@ The token and the signed-in user arrive independently and in either order, so th
 plugin sends the pair whenever both exist, once, and re-sends when either
 changes. Registration goes through the push module's CRUD action; an app on
 somebody else's backend passes `registerToken:` instead.
+
+**Who the token belongs to is not something you configure.** The plugin takes
+`dw.signedInUserIdProvider` at `init`, and that is not a convenience: the
+registration carries a token and a provider, never an id, so the recipient the
+server writes down is the one it derives from the authenticated call. The
+session is that same identity — the two sides therefore agree by construction,
+and there is no second source to keep in step.
+
+On the client the id is local bookkeeping only: whether there is anybody to
+register a token for, whether this exact registration has already been made, and
+whether a sign-out invalidated it. Which is why an app that supplied its own is
+not redirecting notifications — it is only desynchronizing that bookkeeping from
+what the server recorded, and the symptom shows up as push going quiet after an
+account switch.
+
+`DwPushConfig.recipientIdProvider` remains for the one app whose DartWay session
+is permanently empty because it authenticates through an
+`AuthenticationKeyManager` of its own. What it passes must mirror the identity
+its calls are authenticated as.
 
 **Call `dw.plugins.push.revokeToken()` before signing out**, while the session is
 still valid. Afterwards there is nobody to authenticate the call, and the device

--- a/packages/dartway_push/dartway_push_flutter/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_flutter/CHANGELOG.md
@@ -9,10 +9,18 @@ First release of the app half of DartWay push, reached as `dw.plugins.push`.
   plugin sends the pair once, resends after a refresh or a change of user, catches up when either
   changed mid-flight, and survives being offline. Registration goes through the module's CRUD
   action, or through a callback of your own.
+- **The recipient is not configured.** `init` takes `dw.signedInUserIdProvider`, which is the same
+  identity the server derives the real recipient from — a registration carries a token and a
+  provider, never an id. On the device the id is local bookkeeping only (is there anybody to
+  register for, has this exact registration been made, did a sign-out invalidate it), so a second
+  source redirects nothing; it only puts that bookkeeping out of step with what the server recorded,
+  and the symptom is push going quiet after an account switch. `DwPushConfig.recipientIdProvider`
+  survives as an override for the app that authenticates through an `AuthenticationKeyManager` of
+  its own, and what it passes must mirror the identity its calls are authenticated as.
 - **Taps that arrive exactly once.** A cold-start notification is held until the app can route it,
   then delivered after a frame the plugin asks for itself — a tap changes no widget, so nothing
   else would schedule one and the navigation would land on an unrelated gesture minutes later.
 - **Permission on the app's terms** — on attach by default, or on demand at a moment the user
   understands.
-- **`DwPushScope`** drives all of it from the widget tree, following the recipient through a
-  Riverpod listenable.
+- **`DwPushScope`** drives all of it from the widget tree, following the recipient through the
+  Riverpod listenable the plugin resolved.

--- a/packages/dartway_push/dartway_push_flutter/README.md
+++ b/packages/dartway_push/dartway_push_flutter/README.md
@@ -24,7 +24,6 @@ dw = DwCore<Client, UserProfile>(
     DwPush(
       config: DwPushConfig(
         providers: [DwRuStorePush(), DwFirebasePush()],
-        recipientIdProvider: dw.userProfileProvider.select((p) => p?.id),
         onOpened: (opened) => appRouter.go(routeFor(opened.data)),
       ),
     ),
@@ -33,6 +32,12 @@ dw = DwCore<Client, UserProfile>(
 ```
 
 Then wrap the app: `DwPushScope(push: dw.plugins.push, child: MaterialApp.router(...))`.
+
+**Who the token belongs to is not configured.** The plugin takes
+`dw.signedInUserIdProvider` — the same session your calls are authenticated with, and the one the
+server takes the recipient from when the token arrives, so the two sides agree by construction.
+`recipientIdProvider` exists for the app that authenticates through an `AuthenticationKeyManager` of
+its own; what it passes then must mirror the identity those calls are authenticated as.
 
 **Declaration order is the policy.** The first transport that both builds for this platform and
 answers for itself on this device wins — so the pair above means RuStore on Android, FCM on iOS and

--- a/packages/dartway_push/dartway_push_flutter/lib/src/dw_push.dart
+++ b/packages/dartway_push/dartway_push_flutter/lib/src/dw_push.dart
@@ -4,6 +4,7 @@ import 'package:dartway_push_client/dartway_push_client.dart';
 // Re-exports dartway_flutter (DwPlugin, DwPlugins) along with the data layer.
 import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/misc.dart';
 
 import 'dw_push_config.dart';
 import 'dw_push_notification.dart';
@@ -25,6 +26,9 @@ import 'logic/dw_push_token_sync.dart';
 ///   plugins: [DwPush(config: DwPushConfig(providers: [DwFirebasePush()]))],
 /// );
 /// ```
+///
+/// Who the token belongs to is not configured: the plugin follows the DartWay
+/// session, which is the one the server reads the recipient out of anyway.
 class DwPush extends DwPlugin {
   DwPush({required this.config});
 
@@ -38,6 +42,7 @@ class DwPush extends DwPlugin {
   );
 
   DwPushClientProvider? _provider;
+  ProviderListenable<int?>? _recipientIdProvider;
   int? _recipientId;
   bool _isAttached = false;
   bool _isAttaching = false;
@@ -50,13 +55,32 @@ class DwPush extends DwPlugin {
   /// The transport actually in use, or null while push is off or unavailable.
   DwPushClientProvider? get provider => _provider;
 
-  /// Nothing happens here. Transports are started by [DwPushScope], because a
-  /// permission prompt before the first frame is a prompt with no app behind
-  /// it, and a notification tap has nowhere to go until the tree is up.
+  /// Works out whose device this is, and nothing else. Transports are started
+  /// by [DwPushScope], because a permission prompt before the first frame is a
+  /// prompt with no app behind it, and a notification tap has nowhere to go
+  /// until the tree is up.
   @override
-  Future<void> init(DwFlutter core) async {}
+  Future<void> init(DwFlutter core) async {
+    _recipientIdProvider = config.recipientIdProvider ?? _fromSession(core);
+  }
+
+  /// The signed-in user of the DartWay session — the same one the server reads
+  /// the real recipient out of, so the two sides cannot disagree.
+  ///
+  /// Null on the plain toolbox: `dw.signedInUserIdProvider` arrives with the
+  /// data layer, and naming [DwCore] here says out loud that push wants it. A
+  /// core whose client authenticates through a key manager of its own does have
+  /// the provider, and it answers null there — nobody to register a token for,
+  /// which is the same standstill and needs no branch of its own.
+  ProviderListenable<int?>? _fromSession(DwFlutter core) =>
+      core is DwCore ? core.signedInUserIdProvider : null;
 
   // --- Driven by DwPushScope -------------------------------------------------
+
+  /// Who [DwPushScope] follows: the app's override when it gave one, DartWay's
+  /// own session otherwise. Null until [init] has run.
+  @internal
+  ProviderListenable<int?>? get recipientIdProvider => _recipientIdProvider;
 
   Future<void> attach() async {
     if (_isAttached || _isAttaching) return;
@@ -116,7 +140,9 @@ class DwPush extends DwPlugin {
     await provider?.detach();
   }
 
-  /// Who the token belongs to now. Null while signed out.
+  /// Who the token belongs to now. Null while signed out. Pushed in by
+  /// [DwPushScope] on every build, which is why repeats leave here immediately.
+  @internal
   void setRecipient(int? recipientId) {
     if (_recipientId == recipientId) return;
     if (recipientId == null) {

--- a/packages/dartway_push/dartway_push_flutter/lib/src/dw_push_config.dart
+++ b/packages/dartway_push/dartway_push_flutter/lib/src/dw_push_config.dart
@@ -28,12 +28,25 @@ final class DwPushConfig {
   /// and gets exactly that; an app that only knows FCM declares one.
   final List<DwPushClientProvider> providers;
 
-  /// Who the token belongs to, watched for changes.
+  /// Overrides who the token belongs to. Leave it null.
   ///
-  /// Typically `dw.userProfileProvider.select((profile) => profile?.id)`. A
-  /// listenable rather than a value because both halves of the pair — token and
-  /// user — arrive on their own schedule. Leave it null and drive it yourself
-  /// with `dw.plugins.push.setRecipient(...)`.
+  /// Left null, the plugin follows the DartWay session — the same session the
+  /// app's calls are authenticated with, and therefore the same one the server
+  /// takes the real recipient from when the token arrives. The two sides agree
+  /// by construction, not by the app keeping them aligned.
+  ///
+  /// Nothing here is sent anywhere: a registration carries a token and a
+  /// provider, never an id. The recipient is local bookkeeping — whether there
+  /// is anybody to register a token for, whether this exact registration has
+  /// already been made, and whether a sign-out invalidated it.
+  ///
+  /// Set it only when the app authenticates through an `AuthenticationKeyManager`
+  /// of its own, leaving DartWay's own session permanently empty. What you pass
+  /// then **must** mirror the identity those calls are authenticated as. A provider
+  /// that drifts from it redirects no notification whatsoever — it only
+  /// desynchronizes this device's "already registered" bookkeeping from what
+  /// the server recorded, and the symptom is push going quiet after an account
+  /// switch.
   final ProviderListenable<int?>? recipientIdProvider;
 
   /// The user opened a notification. This is where an app routes.

--- a/packages/dartway_push/dartway_push_flutter/lib/src/dw_push_scope.dart
+++ b/packages/dartway_push/dartway_push_flutter/lib/src/dw_push_scope.dart
@@ -18,8 +18,10 @@ import 'dw_push.dart';
 /// DwPushScope(push: dw.plugins.push, child: MaterialApp.router(...))
 /// ```
 ///
-/// The plugin is passed in rather than looked up: `dw` belongs to the app, and
-/// a package that reached for it would be assuming which app it is in.
+/// The plugin is passed in rather than looked up because *which* plugin this is
+/// is something only the app knows. Who is signed in is not passed in: a
+/// DartWay app has exactly one session, and [DwPush] resolved it when the core
+/// initialized it.
 class DwPushScope extends ConsumerStatefulWidget {
   const DwPushScope({super.key, required this.push, required this.child});
 
@@ -36,10 +38,6 @@ class _DwPushScopeState extends ConsumerState<DwPushScope> {
   @override
   void initState() {
     super.initState();
-    final recipientIdProvider = widget.push.config.recipientIdProvider;
-    if (recipientIdProvider != null) {
-      widget.push.setRecipient(ref.read(recipientIdProvider));
-    }
     unawaited(_start());
   }
 
@@ -73,12 +71,12 @@ class _DwPushScopeState extends ConsumerState<DwPushScope> {
 
   @override
   Widget build(BuildContext context) {
-    final recipientIdProvider = widget.push.config.recipientIdProvider;
+    // Read *and* subscribe in one line: the first build hands over whoever is
+    // already signed in, every later one whoever it changed to. Handing over
+    // the same person twice costs nothing — `setRecipient` returns on it.
+    final recipientIdProvider = widget.push.recipientIdProvider;
     if (recipientIdProvider != null) {
-      ref.listen<int?>(
-        recipientIdProvider,
-        (_, recipientId) => widget.push.setRecipient(recipientId),
-      );
+      widget.push.setRecipient(ref.watch(recipientIdProvider));
     }
     return widget.child;
   }

--- a/packages/dartway_push/dartway_push_flutter/test/dw_push_test.dart
+++ b/packages/dartway_push/dartway_push_flutter/test/dw_push_test.dart
@@ -1,4 +1,8 @@
+import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:dartway_push_flutter/dartway_push_flutter.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -152,33 +156,85 @@ void main() {
   });
 
   group('DwPush token registration', () {
-    test('registers once the app says who is signed in', () async {
+    testWidgets('registers once the session says who is signed in',
+        (tester) async {
       final registrations = <(String, String)>[];
       final firebase = _FakeProvider(id: DwPushProviderIds.fcm);
       final push = _push(
         providers: [firebase],
+        recipientIdProvider: _signedInUserIdProvider,
         registerToken: ({required token, required provider}) async {
           registrations.add((token, provider));
           return true;
         },
       );
+      await push.init(_core());
 
-      await push.attach();
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: DwPushScope(push: push, child: const SizedBox()),
+        ),
+      );
+      await tester.pump();
+
       expect(registrations, isEmpty, reason: 'nobody is signed in yet');
 
-      push.setRecipient(42);
-      await Future<void>.delayed(Duration.zero);
+      container.read(_signedInUserIdProvider.notifier).signIn(42);
+      await tester.pump();
+      await tester.pump();
 
       expect(registrations, [('token-fcm', DwPushProviderIds.fcm)]);
+
+      // The scope hands the recipient over on every build; a rebuild for some
+      // unrelated reason must not become a second registration.
+      tester.element(find.byType(DwPushScope)).markNeedsBuild();
+      await tester.pump();
+      await tester.pump();
+
+      expect(registrations, hasLength(1));
+    });
+
+    test('has nobody to follow on a core without the data layer', () async {
+      // `dw.signedInUserIdProvider` arrives with DwCore; the plain toolbox has
+      // no session of any kind. Rather than guess, the plugin stays in manual
+      // mode — the app supplies a provider or no token is ever registered.
+      final push = _push(providers: [_FakeProvider(id: DwPushProviderIds.fcm)]);
+
+      await push.init(_core());
+
+      expect(push.recipientIdProvider, isNull);
     });
   });
 }
+
+/// Stands in for the app's session — the provider `DwPush` resolves out of the
+/// core, driven here by hand so the whole path from a changed value to a
+/// registration runs for real.
+class _SignedInUserId extends Notifier<int?> {
+  @override
+  int? build() => null;
+
+  void signIn(int? userId) => state = userId;
+}
+
+final _signedInUserIdProvider = NotifierProvider<_SignedInUserId, int?>(
+  _SignedInUserId.new,
+);
+
+/// One core for the whole file: `DwFlutter`'s constructor claims the process-wide
+/// `dw` singleton and throws on a second instance.
+DwFlutter _core() => _instance ??= DwFlutter(config: const DwConfig());
+DwFlutter? _instance;
 
 DwPush _push({
   required List<DwPushClientProvider> providers,
   void Function(DwPushOpened opened)? onOpened,
   Future<bool> Function()? isEnabled,
   bool requestPermissionOnAttach = true,
+  ProviderListenable<int?>? recipientIdProvider,
   Future<bool> Function({required String token, required String provider})?
   registerToken,
 }) => DwPush(
@@ -187,6 +243,7 @@ DwPush _push({
     onOpened: onOpened,
     isEnabled: isEnabled,
     requestPermissionOnAttach: requestPermissionOnAttach,
+    recipientIdProvider: recipientIdProvider,
     registerToken:
         registerToken ?? ({required token, required provider}) async => true,
   ),

--- a/toolkit/skills/dartway-push-delivery/SKILL.md
+++ b/toolkit/skills/dartway-push-delivery/SKILL.md
@@ -269,7 +269,6 @@ plugins: [
   DwPush(
     config: DwPushConfig(
       providers: [DwRuStorePush(), DwFirebasePush(webVapidKey: kVapidKey)],
-      recipientIdProvider: dw.userProfileProvider.select((p) => p?.id),
       onOpened: (opened) => appRouter.go(routeFor(opened.data)),
     ),
   ),
@@ -280,6 +279,18 @@ Then wrap the app: `DwPushScope(push: dw.plugins.push, child: ...)`.
 
 Rules that matter:
 
+- **do not configure who the token belongs to.** The plugin takes
+  `dw.signedInUserIdProvider` at `init`, which is the same identity the server
+  derives the real recipient from — a registration carries a token and a
+  provider, never an id. On the client the id is local bookkeeping only (is
+  there anybody to register for, has this exact registration been made, did a
+  sign-out invalidate it), so a second source redirects nothing and only puts
+  that bookkeeping out of step with the server; the symptom is push going quiet
+  after an account switch. `recipientIdProvider` is for an app that
+  authenticates through an `AuthenticationKeyManager` of its own, and what it
+  passes must mirror the identity its calls are authenticated as. **Never write
+  `dw.<anything>` inside the `plugins:` list** — `dw` is being assigned by that
+  very constructor and throws `LateInitializationError` before the first frame;
 - **declaration order is the policy** — the first transport that builds for the
   platform and is available on the device wins. No platform switch in app code;
 - the plugin **never navigates**. `onOpened` fires once per tap, after a frame,
@@ -312,6 +323,8 @@ user. The module deliberately keeps no "who is admin" concept.
   transport refused the target itself, never on timeout/429/5xx;
 - token registration goes through `tokenRegistrationConfig()`, not through an
   endpoint of the app's own, and never takes the recipient from the request;
+- the app half passes no `recipientIdProvider`, and the `plugins:` list mentions
+  `dw` nowhere;
 - raw token/credentials/provider body never logged;
 - deduplication key stable and unique; `expiresAt` always set;
 - worker scheduled via `DwRecurringFutureCall`; several instances safe;


### PR DESCRIPTION
`DwPushConfig.recipientIdProvider` was documented as wiring every app writes, and the line it asked for crashed on startup:

```dart
plugins: [
  DwPush(config: DwPushConfig(
    recipientIdProvider: dw.userProfileProvider.select((p) => p?.id),  // throws
  )),
],
```

`plugins:` is a constructor argument, evaluated before `dw` is assigned, so an app declaring `late final DwCore<Client, UserProfile> dw` gets a `LateInitializationError` before the first frame. It compiles silently. The package README, `docs/3-flutter/push-notifications.md` and `toolkit/skills/dartway-push-delivery/SKILL.md` all shipped that line — #50 named the trap and fixed the mechanism; this fixes the example that fell into it.

## The parameter should not have been load-bearing

A recipient id never leaves the device. `DwPushTokenRegistrar` takes `(token, provider)`, `DwPushTokenRegistration` carries no id, and the server derives the real recipient from the authenticated call. On the client the id is local bookkeeping only:

- the gate — is there anybody to register a token for;
- the dedup key — `(token, provider, recipient)`;
- the reset — a sign-out invalidates the registration without invalidating the token.

So an app supplying a source of its own redirects nothing. It desynchronizes that bookkeeping from what the server actually recorded, and the symptom surfaces much later as push going quiet after an account switch.

## What changed

`DwPush.init` takes `dw.signedInUserIdProvider` off the core it is handed — which is what `DwPlugin.init(DwFlutter core)` exists for — and falls back to nothing on the plain toolbox. Landing on top of #51 turned this into one line: that PR made the id a provider on `DwCore` that already answers `null` for an app without a DartWay session, so there is no second branch to write.

`recipientIdProvider` survives as a rare override for an app that authenticates through an `AuthenticationKeyManager` of its own. Its doc comment now states the invariant — what you pass **must** mirror the identity the calls are authenticated as — instead of suggesting a line to copy.

`DwPush.setRecipient` is `@internal`; `DwPushScope` is its only caller. The scope loses its `initState` half: `ref.watch` in `build` both reads the current recipient and subscribes to the next, and `setRecipient` already returns on a repeat.

After the fix the `recipientIdProvider` line simply disappears from the wiring — `providers` and `onOpened` remain.

## Tests

The registration test used to poke `setRecipient` directly, which is exactly the path an app never takes. It now declares a provider of its own and changes its value through a mounted `DwPushScope`, so the route from a changed value to a registration runs for real; a rebuild is asserted not to register twice. A second test covers the plain toolbox having no session to follow.

## Synchronisation law

- `example/` and `template/` declare no plugins and no push — both analyze clean and their tests pass (the `DwPushConfig` in `example/dartway_example_server` is the unrelated server-side class);
- `toolkit/skills/dartway-push-delivery/SKILL.md` — snippet fixed, plus a rule and a check;
- `docs/3-flutter/push-notifications.md` — snippet fixed, plus the section on why the recipient is not configurable;
- `packages/dartway_push/dartway_push_flutter/CHANGELOG.md` — folded into the unreleased 0.1.0, on the precedent of #50 and #51, which both changed this package without bumping it. Say the word if it has in fact been published and it becomes 0.2.0.

`dart analyze` across the workspace reports only the three findings already on `master` (dead code in generated `dw_updates_transport.dart`, two deprecated Serverpod `Widget` uses). Every unit suite passes; the `example`/`template` server suites are integration-only and need a live Postgres, so they were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)