### PR TITLE
feat(core): server code an app can write, and a save hook a test can reach

### DIFF
--- a/docs/2-core/access-and-roles.md
+++ b/docs/2-core/access-and-roles.md
@@ -166,7 +166,14 @@ What the framework does provide on `Session` is two synchronous members:
   nullable column, an anonymous caller reads `null == null` and is let in.
 
 When you need the profile itself and not its id, `dw.currentUserProfile(session)` reads the row — and
-being a database call, it is the one you should not put in a hot path.
+being a database call, it is the one you should not put in a hot path. It has two siblings for the
+cases where the caller is not the subject: `dw.getUserProfile(session, userProfileId)` and
+`dw.getUserProfileByIdentifier(session, identifier)`.
+
+All three take an optional `transaction`, and **inside a CRUD save hook it has to be passed**:
+`dw.currentUserProfile(session, transaction: saveContext.transaction)`. Without it the read leaves
+the transaction it is running in — which production tolerates and the test suite does not. The
+failure mode is written up in [CRUD configs](crud-configs.md).
 
 Serverpod scopes are not used: `dwAuthenticationHandler` authenticates with an empty scope set, so
 scope annotations on endpoints would gate nothing.

--- a/docs/2-core/crud-configs.md
+++ b/docs/2-core/crud-configs.md
@@ -161,6 +161,32 @@ transaction and `allowSave` / `validateSave` are evaluated against what was actu
 is opt-in so the default lifecycle is unchanged, and it does nothing on insert — there is no row to
 lock yet.
 
+**Every read inside the transaction carries `saveContext.transaction`** — that is the two
+in-transaction hooks, and every call they make. A model repository takes it as a named argument, so
+does `dw.db(session)` (see
+[working with a model you only know as a type](../4-server/generic-database-access.md)), and so do
+the framework's profile reads:
+
+```dart
+beforeSaveTransaction: (session, saveContext) async {
+  final author = await dw.currentUserProfile(session, transaction: saveContext.transaction);
+  ...
+},
+```
+
+Omitting it runs the read on its own connection. In production that works — it is merely blind to
+the uncommitted rows around it, which is what makes the omission easy to miss. The bill arrives in
+the test: under `serverpod_test` with database rollbacks enabled, which is the default, the proxy
+sees a call arriving outside the active transaction, calls it concurrent, and throws `Concurrent
+database calls outside an already active transaction are not supported when database rollbacks are
+enabled`. The config keeps working in production and can no longer be driven through `save()` by an
+integration test at all. `example/` pins this in
+`test/integration/dw_core_profile_transaction_test.dart`.
+
+Half of these reads need not happen at all: when the hook only needs to know *who* the caller is,
+`session.signedInUserProfileId` is synchronous and costs nothing. Read the profile row when you need
+something on it — a role, a balance, a consent flag.
+
 **What comes back.** A successful save returns the persisted model plus `updatedModels`:
 `beforeUpdates` + the saved row + `afterUpdates`. The client applies that list to every open list
 and single-model provider, which is why the caller's own screens refresh without a refetch. Getting

--- a/docs/4-server/generic-database-access.md
+++ b/docs/4-server/generic-database-access.md
@@ -1,0 +1,58 @@
+# Working with a model you only know as a type
+
+Most server code names its model. `ClubSession.db.findById(session, id)` is typed, public, generated
+for you, and it is the right call — this page is not about replacing it.
+
+It is about the other kind of code: a data migration, a background cleanup, an export, a purge. There
+the model is a **type parameter**, the body is the same for every one of them, and Serverpod has
+nothing to offer. It generates a repository per model and none of a common type, so there is no
+`Repository<T>` to be handed. Its generic equivalents do exist — `session.db.find<T>()`,
+`insertRow<T>`, `updateRow<T>` — and every one of them is annotated `@internal`.
+
+That leaves an application two bad options: silence the analyzer with
+`// ignore_for_file: invalid_use_of_internal_member`, which is reaching into another package's
+private surface, or write a three-line adapter per model whose bodies differ only in the model's
+name.
+
+## `dw.db(session)`
+
+```dart
+Future<int> purgeStale<T extends TableRow>(Session session, Expression stale) async {
+  final db = dw.db(session);
+  final rows = await db.find<T>(where: stale);
+  for (final row in rows) {
+    await db.deleteRow<T>(row);
+  }
+  return rows.length;
+}
+```
+
+Five operations, and deliberately only five:
+
+| | |
+|---|---|
+| `find<T>({where, limit, offset, orderBy, orderByList, orderDescending, include, transaction})` | the rows |
+| `count<T>({where, limit, transaction})` | how many, without reading them |
+| `insertRow<T>(row, {transaction})` | returns the row with its id |
+| `updateRow<T>(row, {transaction})` | the row must carry its id |
+| `deleteRow<T>(row, {transaction})` | returns what was deleted |
+
+**Every one takes an optional `transaction`, and inside a save hook it is not optional in practice.**
+A call that omits it runs on its own connection: it cannot see the uncommitted rows around it and is
+not rolled back with them — and under `serverpod_test` with database rollbacks enabled, which is the
+default, it fails outright as a concurrent database call. Pass `saveContext.transaction`. The same
+applies to the framework's own profile reads, which take the argument for the same reason:
+`dw.currentUserProfile(session, transaction: saveContext.transaction)`.
+
+## Why this is not a second `session.db`
+
+Because the `ignore` has to live somewhere, and there is one good place for it.
+
+Concentrated in the core, it is written once and no application repeats it. When Serverpod changes
+those methods — they are marked internal precisely because it reserves the right to — one file needs
+fixing rather than every application that ever wrote a migration. And a facade over generic database
+access is the seam a replacement for the ORM would be fitted into, which a scatter of
+`ignore_for_file` lines across N projects would not be.
+
+The set stays small on purpose (see `DESIGN.md`: the core is a minimal contract). If something real
+needs `deleteWhere` or a lock mode, it gets added then — not in advance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ page and the code it describes travel in the same PR — the sync law in the roo
 | `1-getting-started/` | What DartWay is, how to start a project, what you get |
 | `2-core/` | The CRUD core: models, configs, access, realtime, error reports |
 | `3-flutter/` | The app side: data layer, actions, features, the kit, navigation, plugins, push |
-| `4-server/` | Serverpod-side capabilities: uploads, jobs, locks, secrets, push |
+| `4-server/` | Serverpod-side capabilities: uploads, jobs, locks, secrets, push, generic database access |
 | `5-tooling/` | The CLI, the conventions checker, the agent toolkit |
 | `6-studio/` | DartWay Studio and the bridge an app opens to it |
 

--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.6.0
+  dartway_serverpod_core_client: ^0.7.0
 
   # The client half of the optional push module. Required because the generated
   # protocol imports it — the server consumes the module, so its `Caller` shows

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -306,21 +306,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_studio_bridge:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.6.0
+  dartway_serverpod_core_flutter: ^0.7.0
 
   dartway_studio_bridge: ^0.6.0
 

--- a/example/dartway_example_server/dart_test.yaml
+++ b/example/dartway_example_server/dart_test.yaml
@@ -1,9 +1,12 @@
 tags:
   integration: {}
 
-# The integration suite runs against one real database with `RollbackDatabase.disabled` —
-# the only way to observe things that must actually commit: a race between two
-# concurrent sign-ins, or a password hash upgraded during a login.
+# The integration suite runs against one real database, and most of its files ask for
+# `RollbackDatabase.disabled` — the only way to observe things that must actually
+# commit: a race between two concurrent sign-ins, or a password hash upgraded during
+# a login. (`dw_db_test` and `dw_core_profile_transaction_test` are the exceptions and
+# keep the default rollback; the second one exists precisely to prove that a config
+# reading the caller's profile survives it.)
 #
 # That makes the files stateful neighbours rather than isolated units: each wipes
 # the auth tables around itself, so run in parallel they wipe each other's rows

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -134,14 +134,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   ffi:
     dependency: transitive
     description:

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.6.0
+  dartway_serverpod_core_server: ^0.7.0
 
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.

--- a/example/dartway_example_server/test/integration/dw_core_profile_transaction_test.dart
+++ b/example/dartway_example_server/test/integration/dw_core_profile_transaction_test.dart
@@ -1,0 +1,158 @@
+import 'package:dartway_example_server/src/dartway/dartway_core.dart';
+import 'package:dartway_example_server/src/generated/protocol.dart';
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+/// A CRUD config whose save hooks read the caller's profile is the ordinary
+/// shape — it is what every config does when the server stamps the author
+/// itself rather than trusting the client to send it. This file exists because
+/// that shape used to be untestable.
+///
+/// `beforeSaveTransaction` runs **inside** the save transaction. Until 0.7.0 the
+/// profile reads on `dw` had no way to be told about it, so they went to the
+/// database on their own connection. In production that is a second query; here
+/// it is fatal, and deliberately so: this group runs with the default
+/// `rollbackDatabase`, under which the test proxy sees a call that arrives
+/// without the active transaction, calls it concurrent, and throws
+/// `Concurrent database calls outside an already active transaction are not
+/// supported when database rollbacks are enabled`.
+///
+/// Hence the default rollback here — the point is not that these reads work,
+/// it is that a config built this way can be driven through `save()` by a test
+/// at all. Note the contrast with the neighbouring files, which switch rollback
+/// off because they observe races that must genuinely commit.
+void main() {
+  withServerpod(
+    'Given save hooks that read the caller profile inside the transaction',
+    (sessionBuilder, endpoints) {
+      setUp(() {
+        initDartwayCore(
+          passwords: const {
+            'dwVerificationCodeSalt': 'test-verification-code-salt',
+            'dwAuthKeySalt': 'test-auth-key-salt',
+          },
+        );
+      });
+
+      test(
+        'all three profile reads answer through saveContext.transaction',
+        () async {
+          final session = sessionBuilder.build();
+          final author = await UserProfile.db.insertRow(
+            session,
+            UserProfile(
+              userIdentifier: _identifier,
+              phone: _identifier,
+              firstName: 'Author',
+              role: UserRole.staff,
+              agreedForMarketingCommunications: false,
+              conditionsAcceptedAt: DateTime.now().toUtc(),
+            ),
+          );
+          final authored = sessionBuilder
+              .copyWith(
+                authentication: AuthenticationOverride.authenticationInfo(
+                  '${author.id!}',
+                  {},
+                ),
+              )
+              .build();
+
+          UserProfile? current;
+          UserProfile? byId;
+          UserProfile? byIdentifier;
+
+          final response = await DwSaveConfig<AppSetting>(
+            allowSave: (session, saveContext) async => true,
+            beforeSaveTransaction: (session, saveContext) async {
+              final transaction = saveContext.transaction;
+              current = await dw.currentUserProfile(
+                session,
+                transaction: transaction,
+              );
+              byId = await dw.getUserProfile(
+                session,
+                saveContext.currentUserId!,
+                transaction: transaction,
+              );
+              byIdentifier = await dw.getUserProfileByIdentifier(
+                session,
+                _identifier,
+                transaction: transaction,
+              );
+              return null;
+            },
+            // The same read after the write, still inside the transaction: the
+            // second hook is where an audit row or a counter would be updated,
+            // and it hits the same wall.
+            afterSaveTransaction: (session, saveContext) async {
+              final seen = await dw.currentUserProfile(
+                session,
+                transaction: saveContext.transaction,
+              );
+              return seen == null ? 'The author vanished mid-save' : null;
+            },
+          ).save(
+            authored,
+            AppSetting(settingKey: _settingKey, settingValue: 'stamped'),
+          );
+
+          expect(response.isOk, isTrue, reason: response.error);
+          expect(current?.id, author.id);
+          expect(byId?.id, author.id);
+          expect(byIdentifier?.id, author.id);
+        },
+      );
+
+      test(
+        'a hook sees a profile the same transaction has not committed yet',
+        () async {
+          final session = sessionBuilder.build();
+          final settled = await DwSaveConfig<AppSetting>(
+            allowSave: (session, saveContext) async => true,
+            beforeSaveTransaction: (session, saveContext) async {
+              // Written inside the save transaction and invisible to anything
+              // reading around it — which is the other half of why the reads
+              // take a transaction, and the half that also bites in production.
+              final latecomer = await UserProfile.db.insertRow(
+                session,
+                UserProfile(
+                  userIdentifier: _latecomerIdentifier,
+                  phone: _latecomerIdentifier,
+                  firstName: 'Latecomer',
+                  role: UserRole.client,
+                  agreedForMarketingCommunications: false,
+                  conditionsAcceptedAt: DateTime.now().toUtc(),
+                ),
+                transaction: saveContext.transaction,
+              );
+
+              final read = await dw.getUserProfile(
+                session,
+                latecomer.id!,
+                transaction: saveContext.transaction,
+              );
+              return read == null ? 'Uncommitted profile not visible' : null;
+            },
+          ).save(
+            session,
+            AppSetting(settingKey: _latecomerKey, settingValue: 'stamped'),
+          );
+
+          expect(settled.isOk, isTrue, reason: settled.error);
+        },
+      );
+    },
+    runMode: 'test',
+    applyMigrations: true,
+    // Left at the default on purpose — see the note above. Everything these
+    // tests write is rolled back with it, so they need no cleanup of their own.
+  );
+}
+
+const _identifier = '+79990002000';
+const _latecomerIdentifier = '+79990002001';
+const _settingKey = 'dw_core_profile_transaction_test_authored';
+const _latecomerKey = 'dw_core_profile_transaction_test_latecomer';

--- a/example/dartway_example_server/test/integration/dw_db_test.dart
+++ b/example/dartway_example_server/test/integration/dw_db_test.dart
@@ -1,0 +1,167 @@
+import 'package:dartway_example_server/src/dartway/dartway_core.dart';
+import 'package:dartway_example_server/src/generated/protocol.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+/// `dw.db(session)` is what an application reaches for when the model is a type
+/// parameter — a data migration, a background cleanup, an export. Serverpod's
+/// per-model repositories cannot express that, and its generic equivalents are
+/// `@internal`.
+///
+/// So the test is written the way such code is written: through a helper that
+/// knows nothing about the model it is handed.
+void main() {
+  withServerpod(
+    'Given generic database access through dw.db',
+    (sessionBuilder, endpoints) {
+      setUp(() {
+        initDartwayCore(
+          passwords: const {
+            'dwVerificationCodeSalt': 'test-verification-code-salt',
+            'dwAuthKeySalt': 'test-auth-key-salt',
+          },
+        );
+      });
+
+      test('the five operations round-trip a row of an unknown model', () async {
+        final session = sessionBuilder.build();
+
+        final inserted = await dw
+            .db(session)
+            .insertRow<AppSetting>(
+              AppSetting(settingKey: _settingKey, settingValue: 'initial'),
+            );
+        expect(inserted.id, isNotNull);
+
+        final updated = await dw
+            .db(session)
+            .updateRow<AppSetting>(inserted.copyWith(settingValue: 'updated'));
+        expect(updated.settingValue, 'updated');
+
+        final found = await dw
+            .db(session)
+            .find<AppSetting>(
+              where: AppSetting.t.settingKey.equals(_settingKey),
+            );
+        expect(found.single.settingValue, 'updated');
+
+        expect(
+          await dw
+              .db(session)
+              .count<AppSetting>(
+                where: AppSetting.t.settingKey.equals(_settingKey),
+              ),
+          1,
+        );
+
+        await dw.db(session).deleteRow<AppSetting>(updated);
+        expect(
+          await dw
+              .db(session)
+              .count<AppSetting>(
+                where: AppSetting.t.settingKey.equals(_settingKey),
+              ),
+          0,
+        );
+      });
+
+      test('a caller that does not know the model still gets its rows', () async {
+        final session = sessionBuilder.build();
+        await dw
+            .db(session)
+            .insertRow<AppSetting>(
+              AppSetting(settingKey: '${_sweepPrefix}a', settingValue: 'stale'),
+            );
+        await dw
+            .db(session)
+            .insertRow<AppSetting>(
+              AppSetting(settingKey: '${_sweepPrefix}b', settingValue: 'stale'),
+            );
+
+        expect(
+          await _sweep<AppSetting>(
+            session,
+            where: AppSetting.t.settingValue.equals('stale'),
+          ),
+          2,
+        );
+        expect(
+          await dw
+              .db(session)
+              .count<AppSetting>(
+                where: AppSetting.t.settingValue.equals('stale'),
+              ),
+          0,
+        );
+      });
+
+      test('every operation can be pinned to an open transaction', () async {
+        final session = sessionBuilder.build();
+
+        // Rolled back by hand — the point is that the writes inside a
+        // transaction are visible to `dw.db` reads carrying the same handle,
+        // and gone once it unwinds.
+        await expectLater(
+          session.db.transaction((transaction) async {
+            await dw
+                .db(session)
+                .insertRow<AppSetting>(
+                  AppSetting(
+                    settingKey: _transactionalKey,
+                    settingValue: 'pending',
+                  ),
+                  transaction: transaction,
+                );
+
+            expect(
+              await dw
+                  .db(session)
+                  .count<AppSetting>(
+                    where: AppSetting.t.settingKey.equals(_transactionalKey),
+                    transaction: transaction,
+                  ),
+              1,
+            );
+
+            throw _Abort();
+          }),
+          throwsA(isA<_Abort>()),
+        );
+
+        expect(
+          await dw
+              .db(session)
+              .count<AppSetting>(
+                where: AppSetting.t.settingKey.equals(_transactionalKey),
+              ),
+          0,
+        );
+      });
+    },
+    runMode: 'test',
+    applyMigrations: true,
+    // The default: everything written here is rolled back with the test.
+  );
+}
+
+/// The kind of helper `dw.db` exists for: one body, any model.
+Future<int> _sweep<T extends TableRow>(
+  Session session, {
+  required Expression where,
+  Transaction? transaction,
+}) async {
+  final db = dw.db(session);
+  final stale = await db.find<T>(where: where, transaction: transaction);
+  for (final row in stale) {
+    await db.deleteRow<T>(row, transaction: transaction);
+  }
+  return stale.length;
+}
+
+class _Abort implements Exception {}
+
+const _settingKey = 'dw_db_test_round_trip';
+const _sweepPrefix = 'dw_db_test_sweep_';
+const _transactionalKey = 'dw_db_test_transactional';

--- a/packages/dartway_push/dartway_push_client/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_client/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   # wrapper types. Inside the workspace this resolved without being declared,
   # which is exactly the kind of dependency that only fails once the package is
   # published and somebody else resolves it.
-  dartway_serverpod_core_client: ^0.6.0
+  dartway_serverpod_core_client: ^0.7.0

--- a/packages/dartway_push/dartway_push_flutter/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_flutter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   # app half talks to the server half through the generated protocol, not
   # through an endpoint of its own.
   dartway_push_client: ^0.2.0
-  dartway_serverpod_core_flutter: ^0.6.0
+  dartway_serverpod_core_flutter: ^0.7.0
 
   flutter_riverpod: ^3.0.0
 

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_server: ^0.6.0
+  dartway_serverpod_core_server: ^0.7.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.7.0 is the
+server side gaining a `Transaction` parameter on the profile reads and the generic `dw.db(session)`
+facade — see the changelog of `dartway_serverpod_core_server`.
+
 ## 0.6.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.6.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.6.0
+version: 0.7.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.7.0 is the
+server side gaining a `Transaction` parameter on the profile reads and the generic `dw.db(session)`
+facade — see the changelog of `dartway_serverpod_core_server`.
+
 ## 0.6.0
 
 **Breaking: the `ref.watchSignedInUserId` / `ref.readSignedInUserId` extensions are gone, replaced by

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.6.0
+version: 0.7.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -19,8 +19,8 @@ dependencies:
   serverpod_client: ^3.4.11
 
   dartway_flutter: ^0.5.0
-  dartway_serverpod_core_client: ^0.6.0
-  dartway_serverpod_core_shared: ^0.6.0
+  dartway_serverpod_core_client: ^0.7.0
+  dartway_serverpod_core_shared: ^0.7.0
 
   collection: ^1.19.1
   flutter_riverpod: ^3.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.7.0
+
+Two additions, both about server code an application could not write — or could not test — until now.
+
+- **`dw.getUserProfile`, `dw.getUserProfileByIdentifier` and `dw.currentUserProfile` take an optional
+  `Transaction`.** Without one the read runs on its own connection, so a CRUD hook that reads the
+  caller's profile — `beforeSaveTransaction`, `afterSaveTransaction`, anything inside the save
+  transaction — was asking the database a question from outside the transaction it was running in.
+
+  In production that is a second query with a slightly stale answer. Under `serverpod_test` it is
+  fatal: with database rollbacks enabled, which is the default, the proxy sees a call arriving
+  without the active transaction, treats it as concurrent, and throws `Concurrent database calls
+  outside an already active transaction are not supported when database rollbacks are enabled`. So
+  **any CRUD config whose hooks read the caller's profile** — nearly every config where the server
+  stamps the author itself — could not be driven through `save()` in an integration test at all.
+  Found twice, in different configs of different projects.
+
+  Pass `saveContext.transaction` from inside a hook. Purely additive: existing calls keep compiling
+  and keep their behaviour. Half of these cases need no query in the first place — when only the
+  caller's id is wanted, `session.signedInUserProfileId` is synchronous and free.
+
+- **`dw.db(session)` — generic, model-agnostic database access.** Five operations: `find<T>`,
+  `insertRow<T>`, `updateRow<T>`, `deleteRow<T>`, `count<T>`, each taking an optional `Transaction`.
+
+  Serverpod generates a repository per model and gives no repository of a common type, and its
+  generic `session.db.find<T>()` / `insertRow<T>` / `updateRow<T>` are marked `@internal` — the core
+  has been calling them behind `// ignore_for_file: invalid_use_of_internal_member` in seven files.
+  An application with an operation spanning several models (a data migration, a background cleanup,
+  an export) had the choice of repeating that ignore or writing a three-line adapter per model whose
+  bodies differ only in the model's name. The exposure is now concentrated in one file inside the
+  core instead of being copied into every application: when Serverpod changes those methods one file
+  needs fixing rather than N applications, and that same file is the seam a replacement for the ORM
+  would be fitted into.
+
+  For a single known model keep using that model's own repository — typed, public, and more
+  readable. `dw.db` is for the cases where the model is a type parameter.
+
 ## 0.6.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.6.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/dartway_serverpod_core_server.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/dartway_serverpod_core_server.dart
@@ -4,6 +4,7 @@ export 'src/business/auth/dw_auth_config.dart';
 export 'src/business/auth/dw_authentification_handler.dart';
 export 'src/business/auth/dw_password_hashing.dart';
 export 'src/business/dw_advisory_lock.dart';
+export 'src/business/dw_db.dart';
 export 'src/business/auth/dw_orphaned_auth_key_cleanup.dart';
 export 'src/business/dw_recurring_future_call.dart';
 export 'src/business/cloud_storage/dw_cloud_storage_config.dart';

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/dw_db.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/dw_db.dart
@@ -1,0 +1,97 @@
+// The whole reason this file exists — see the class doc below. Concentrated
+// here so no application has to write it.
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:serverpod/serverpod.dart';
+
+/// Generic, model-agnostic database access — `dw.db(session)`.
+///
+/// **Not a duplicate of `session.db`, and here for a reason.** Serverpod
+/// generates a repository per model (`ClubSession.db.find(...)`) and gives no
+/// repository of a common type, so an operation shared by several models has to
+/// reach for the generic `session.db.find<T>()` / `insertRow<T>` / `updateRow<T>`
+/// — and every one of those is marked `@internal`. An application calling them
+/// either repeats `// ignore_for_file: invalid_use_of_internal_member`, which is
+/// reaching into another package's private surface, or writes a three-line
+/// adapter per model whose bodies differ only in the model's name.
+///
+/// So the exposure is concentrated instead of multiplied: the `ignore` lives in
+/// this file and nowhere else. When Serverpod changes those methods, one file
+/// needs fixing rather than N applications — and this is the seam a replacement
+/// for the ORM would be fitted into later.
+///
+/// Reach it through the core, never by constructing it: `dw.db(session).find<T>()`.
+/// For a single known model prefer that model's own repository — it is typed,
+/// public, and reads better. This is for the cases where the model is a type
+/// parameter: a data migration, a background cleanup, an export.
+///
+/// ```dart
+/// Future<int> purge<T extends TableRow>(Session session, Expression stale) async {
+///   final db = dw.db(session);
+///   final rows = await db.find<T>(where: stale);
+///   for (final row in rows) {
+///     await db.deleteRow<T>(row);
+///   }
+///   return rows.length;
+/// }
+/// ```
+///
+/// **Every method takes an optional [Transaction], and inside one it is not
+/// optional in practice.** A call that omits it runs on its own connection, so
+/// it does not see the uncommitted work around it and is not rolled back with
+/// it — and under `serverpod_test` with database rollbacks enabled (the default)
+/// it fails outright as a concurrent call. Pass `saveContext.transaction` when
+/// you are inside a CRUD save hook.
+///
+/// The set is deliberately small: five operations, added to when something real
+/// needs more. See `docs/DESIGN.md` — the core is a minimal contract.
+class DwDb {
+  /// Built by [DwCore.db]; applications do not construct it.
+  const DwDb(this._session);
+
+  final Session _session;
+
+  /// The rows of [T] matching [where], or all of them when it is omitted.
+  Future<List<T>> find<T extends TableRow>({
+    Expression? where,
+    int? limit,
+    int? offset,
+    Column? orderBy,
+    List<Order>? orderByList,
+    bool orderDescending = false,
+    Include? include,
+    Transaction? transaction,
+  }) => _session.db.find<T>(
+    where: where,
+    limit: limit,
+    offset: offset,
+    orderBy: orderBy,
+    orderByList: orderByList,
+    orderDescending: orderDescending,
+    include: include,
+    transaction: transaction,
+  );
+
+  /// Inserts [row] and returns it with its assigned id.
+  Future<T> insertRow<T extends TableRow>(T row, {Transaction? transaction}) =>
+      _session.db.insertRow<T>(row, transaction: transaction);
+
+  /// Updates [row], which must already carry its id.
+  Future<T> updateRow<T extends TableRow>(T row, {Transaction? transaction}) =>
+      _session.db.updateRow<T>(row, transaction: transaction);
+
+  /// Deletes [row] and returns the row that was deleted.
+  Future<T> deleteRow<T extends TableRow>(T row, {Transaction? transaction}) =>
+      _session.db.deleteRow<T>(row, transaction: transaction);
+
+  /// How many rows of [T] match [where] — without reading them.
+  Future<int> count<T extends TableRow>({
+    Expression? where,
+    int? limit,
+    Transaction? transaction,
+  }) => _session.db.count<T>(
+    where: where,
+    limit: limit,
+    transaction: transaction,
+  );
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
@@ -175,6 +175,13 @@ class DwCore<UserProfileClass extends TableRow> {
   /// Non-blocking, transaction-scoped advisory locks — `dw.advisoryLock`.
   DwAdvisoryLock get advisoryLock => const DwAdvisoryLock();
 
+  /// Generic, model-agnostic database access for [session] — `dw.db(session)`.
+  ///
+  /// For an operation shared by several models, where Serverpod's per-model
+  /// repositories cannot help. See [DwDb] for what it is and why it is not a
+  /// second `session.db`.
+  DwDb db(Session session) => DwDb(session);
+
   DwCrudConfig<TableRow>? getCrudConfig(String className, {String? api}) =>
       _crudConfiguration[api ?? DwCoreConst.defaultApi]?[className];
 
@@ -204,10 +211,26 @@ class DwCore<UserProfileClass extends TableRow> {
     );
   }
 
-  Future<UserProfileClass?> getUserProfile(Session session, int userId) async {
+  /// The profile row for [userId], or `null` when there is none.
+  ///
+  /// **Pass [transaction] when you are inside one** — a CRUD save hook has it as
+  /// `saveContext.transaction`. Omitted, the read runs on its own connection:
+  /// blind to the uncommitted rows around it in production, and under
+  /// `serverpod_test` with database rollbacks enabled (the default) it fails
+  /// outright as a concurrent database call, which makes the config
+  /// untestable rather than merely stale.
+  ///
+  /// When all you need is the caller's id, `session.signedInUserProfileId` is
+  /// synchronous and costs no query at all.
+  Future<UserProfileClass?> getUserProfile(
+    Session session,
+    int userId, {
+    Transaction? transaction,
+  }) async {
     final profile = await session.db.findFirstRow<UserProfileClass>(
       where: _userInfoIdColumn.equals(userId),
       include: _userProfileInclude,
+      transaction: transaction,
     );
 
     if (profile == null) {
@@ -217,13 +240,18 @@ class DwCore<UserProfileClass extends TableRow> {
     return profile;
   }
 
+  /// The profile row carrying [identifier], or `null` when there is none.
+  ///
+  /// [transaction] carries the same meaning as on [getUserProfile].
   Future<UserProfileClass?> getUserProfileByIdentifier(
     Session session,
-    String identifier,
-  ) async {
+    String identifier, {
+    Transaction? transaction,
+  }) async {
     final profile = await session.db.findFirstRow<UserProfileClass>(
       where: _userIdentifierColumn.equals(identifier),
       include: _userProfileInclude,
+      transaction: transaction,
     );
 
     if (profile == null) {
@@ -233,10 +261,16 @@ class DwCore<UserProfileClass extends TableRow> {
     return profile;
   }
 
-  Future<UserProfileClass?> currentUserProfile(Session session) async {
+  /// The signed-in caller's profile row, or `null` for a caller with no session.
+  ///
+  /// [transaction] carries the same meaning as on [getUserProfile].
+  Future<UserProfileClass?> currentUserProfile(
+    Session session, {
+    Transaction? transaction,
+  }) async {
     final userId = session.signedInUserProfileId;
     if (userId == null) return null;
-    return getUserProfile(session, userId);
+    return getUserProfile(session, userId, transaction: transaction);
   }
 
   Future<int> createUserProfile(

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.6.0
+version: 0.7.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_shared: ^0.6.0
+  dartway_serverpod_core_shared: ^0.7.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.7.0 is the
+server side gaining a `Transaction` parameter on the profile reads and the generic `dw.db(session)`
+facade — see the changelog of `dartway_serverpod_core_server`.
+
 ## 0.6.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.6.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.6.0
+version: 0.7.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/template/dartway_starter_client/pubspec.yaml
+++ b/template/dartway_starter_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.6.0
+  dartway_serverpod_core_client: ^0.7.0
 
 # Inside the monorepo — a local build. `dartway create` removes this block.
 dependency_overrides:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -292,21 +292,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_starter_client:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.6.0
+  dartway_serverpod_core_flutter: ^0.7.0
 
   dartway_studio_bridge: ^0.6.0
 

--- a/template/dartway_starter_server/pubspec.lock
+++ b/template/dartway_starter_server/pubspec.lock
@@ -127,14 +127,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   ffi:
     dependency: transitive
     description:

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.6.0
+  dartway_serverpod_core_server: ^0.7.0
 
   http: ^1.5.0
 

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -124,6 +124,19 @@ Execution order and signatures:
 
 **Why this and not `validateSave`:** steps 1–2 run BEFORE the transaction, so a rule guarding a shared counter (seats, stock, limits) is evaluated there — two parallel saves would both get a "yes". Check such a rule in `beforeSaveTransaction`, taking a **row lock** in the same transaction: `findById(..., transaction:, lockMode: LockMode.forUpdate)` — a single call both locks the row (`SELECT ... FOR UPDATE`) and returns it. `validateSave` checks the model, `beforeSaveTransaction` checks the world around it.
 
+**A hook that runs inside the transaction reads the database only through `saveContext.transaction`.** That is `beforeSaveTransaction` and `afterSaveTransaction`, and it applies to every read they make — a model repository (`UserProfile.db.findById(session, id, transaction: saveContext.transaction)`), `dw.db`, or the framework's own profile reads, which take the transaction as a named argument:
+
+```dart
+beforeSaveTransaction: (session, saveContext) async {
+  final author = await dw.currentUserProfile(session, transaction: saveContext.transaction);
+  ...
+},
+```
+
+A read that omits it runs on its own connection: in production it works, merely blind to the uncommitted rows around it — which is what makes the omission easy to miss. **The bill arrives in the test.** Under `serverpod_test` with database rollbacks enabled, which is the default, the proxy sees a call arriving outside the active transaction, calls it concurrent, and throws `Concurrent database calls outside an already active transaction are not supported when database rollbacks are enabled`. So the config still runs in production and can no longer be driven through `save()` by an integration test at all.
+
+**And half of these reads should not happen.** When the hook only needs to know *who* the caller is — stamping an author, an owner, a `createdBy` — `session.signedInUserProfileId` is synchronous, costs no query, and sidesteps the question entirely. Reach for the profile row only when you need something on it (a role, a balance, a consent flag).
+
 **If the rule depends on the current state of the row itself** (roles, consent flags, balance, a deleted marker) — turn on `lockInitialModelForUpdate: true`. Then on an **update** the initial model is re-read under `FOR UPDATE` inside the transaction, and steps 1–2 are evaluated against it: a parallel save of the same row waits and gets re-validated against what was actually committed, instead of passing on a stale pre-state. The flag is optional (defaults to `false`, the cycle is unchanged) and has no effect on insert — there is nothing to lock yet.
 
 **To make other users see the change** — `broadcastTo` in the config: a callback over the context that returns the list of channels all the models touched by the save fly into. On the subscribers' side they are routed by type into any `dw.repo.modelList<T>()`, and the list redraws itself — nothing has to be written in Flutter (the app is subscribed to the public channel at the root).
@@ -210,7 +223,8 @@ Parameters: `allowDelete` `(session, model) => bool` (without it → `notConfigu
 ```dart
 final userProfileDeleteConfig = DwDeleteConfig<UserProfile>(
   allowDelete: (session, model) async => model.balance <= 0,
-  afterDelete: (session, model) async => session.db.find<BalanceEvent>(
+  afterDelete: (session, model) async => BalanceEvent.db.find(
+    session,
     where: (t) => t.userProfileId.equals(model.id),
   ),
 );
@@ -223,6 +237,27 @@ final userProfileDeleteConfig = DwDeleteConfig<UserProfile>(
 - **Workflow** (session-aware: external APIs, orchestration) → `/app`.
 - **Transactional/money flows** → Event models (`BalanceEvent`) instead of updating a field directly: safety from races, an audit trail, one place for the rules.
 - Wrap all updates in responses in `DwModelWrapper`.
+
+### An operation that spans several models goes through `dw.db`
+
+In `/app` you will hit work where the model is a **type parameter**, not a name: a data migration, a background cleanup, an export, a purge. Serverpod generates a repository per model and none of a common type, so there is nothing typed to call — and its generic `session.db.find<T>()` / `insertRow<T>` / `updateRow<T>` are marked `@internal`. Use `dw.db(session)` instead, which wraps the five that matter:
+
+```dart
+Future<int> purgeStale<T extends TableRow>(Session session, Expression stale) async {
+  final db = dw.db(session);
+  final rows = await db.find<T>(where: stale);
+  for (final row in rows) {
+    await db.deleteRow<T>(row);
+  }
+  return rows.length;
+}
+// find<T>, insertRow<T>, updateRow<T>, deleteRow<T>, count<T> — each takes an
+// optional `transaction`, and inside a hook that is not optional (see above).
+```
+
+**`// ignore_for_file: invalid_use_of_internal_member` in application code means a Serverpod upgrade can break your build silently** — you have reached into another package's private surface, and nothing warns you when it moves. If you catch yourself writing that line, or writing a three-line adapter per model whose bodies differ only in the model's name, `dw.db` is the answer.
+
+For **one known model**, keep using that model's own repository (`ClubSession.db.findById(...)`) — typed, public, and more readable. `dw.db` is not a replacement for it.
 
 ## A custom endpoint — the last resort
 


### PR DESCRIPTION
Two additive gaps in the core's server API. One theme: an application either could not write the code, or could not test it.

## 1. `Transaction?` on the profile reads

`beforeSaveTransaction` runs **inside** the save transaction; `DwCore.getUserProfile` went to the database beside it. In production that is a second query with a slightly stale answer. Under `serverpod_test` with `RollbackDatabase` at its default it is fatal — the proxy sees a call arriving without the active transaction, calls it concurrent, and throws:

```
Concurrent database calls outside an already active transaction are not supported
when database rollbacks are enabled.
```

So **any CRUD config whose hooks read the caller's profile** — nearly every config where the server stamps the author itself rather than trusting the client — could not be driven through `save()` in an integration test at all. Found twice, in different configs of different projects.

`getUserProfile`, `getUserProfileByIdentifier` and `currentUserProfile` now take an optional `Transaction` and pass it to `findFirstRow`. Purely additive.

Two things are written down alongside it, because the parameter alone does not stop the next occurrence:

- the rule, in `dartway-crud-config`: a hook inside the transaction reads the database **only** through `saveContext.transaction`;
- the observation that removes half the cases without any query — when only the caller's *id* is wanted, `session.signedInUserProfileId` is synchronous and free. In one of the two real cases the profile was fetched for exactly that.

## 2. `dw.db(session)`

Serverpod generates a repository per model and gives none of a common type, and its generic `session.db.find<T>()` / `insertRow<T>` / `updateRow<T>` are `@internal` — the core calls them behind `// ignore_for_file: invalid_use_of_internal_member` in seven files. An application with an operation spanning several models (a data migration, a background cleanup, an export) had two bad options: repeat that ignore, or write a three-line adapter per model whose bodies differ only in the model's name.

```dart
dw.db(session).find<T>(where: ..., transaction: ...)
dw.db(session).insertRow<T>(row, transaction: ...)
dw.db(session).updateRow<T>(row, transaction: ...)
dw.db(session).deleteRow<T>(row, transaction: ...)
dw.db(session).count<T>(...)
```

Five operations and no more — the core is a minimal contract (`docs/DESIGN.md`); the rest is added when something real needs it. The `ignore` lives inside the facade, which is the entire point: the exposure does not grow, it concentrates. When Serverpod breaks those methods, one file needs fixing rather than N applications, and that same file is the seam a replacement for the ORM would be fitted into.

Session-scoped so `session` is not threaded through every call, and reached through the core like `dw.advisoryLock`.

## The proof

`example/dartway_example_server/test/integration/dw_core_profile_transaction_test.dart` — an integration test on a config whose `beforeSaveTransaction` reads the profile through the transaction, running with the **default** `RollbackDatabase`. Verified both ways: with the pass-through removed it fails with the concurrency error above; with it, green. `dw_db_test.dart` covers the five operations, a helper that only knows its model as a type parameter, and a hand-rolled transaction that rolls back.

## Sync law

- `example/` — exercises both additions in its integration suite (34 tests green against the real database); no lib-side use case for `dw.db` exists there without inventing one.
- `template/` — compiles; nothing it does was touched.
- `toolkit/skills/dartway-crud-config` — both rules added; the `afterDelete` sample no longer calls the `@internal` `session.db.find<T>`, which would have made the analyzer complain in the app that copied it.
- `docs/` — `2-core/crud-configs.md`, `2-core/access-and-roles.md`, and a new `4-server/generic-database-access.md`.
- CHANGELOGs — the server's carries the entry, the other three "version bump only", as their history already does.

The four `dartway_serverpod_core_*` packages move to **0.7.0** in lockstep, with every dependent constraint bumped (`^0.6.0` excludes 0.7.0 for a pre-1.0 caret).

## Checks

`dart analyze` across the workspace clean but for two pre-existing warnings; all package suites green (`flutter test` for the Flutter ones). `template/dartway_starter_server`'s own integration tests do not run in this repository — the skeleton ships `passwords.yaml.example` and no `passwords.yaml`, so they hang waiting for credentials. Pre-existing, unrelated.

Not in this branch, as agreed: the "reference rows supplied from code" seeding mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
