### PR TITLE
fix(core): scope=serverOnly holds on the way out and on the way back

### DIFF
--- a/docs/2-core/access-and-roles.md
+++ b/docs/2-core/access-and-roles.md
@@ -255,5 +255,6 @@ Four places where the config is not the whole answer, and all four are ordinary 
   decide what is worth showing, never what is allowed. Anything they hide must be unreachable
   server-side as well, or it is only hidden from honest users.
 - **Field-level secrets.** `accessFilter` selects rows, not columns. A column no client may ever see
-  — a verification code, an internal hash — is `scope=serverOnly`, which keeps it out of the
-  generated client class entirely ([models.md](models.md#scopes-fields-the-client-must-never-see)).
+  — a verification code, an internal hash — is `scope=serverOnly`: it is kept out of the generated
+  client class, never put on the wire, and not blanked when that client saves the row back
+  ([models.md](models.md#scopes-fields-the-client-must-never-see)).

--- a/docs/2-core/crud-configs.md
+++ b/docs/2-core/crud-configs.md
@@ -161,6 +161,24 @@ transaction and `allowSave` / `validateSave` are evaluated against what was actu
 is opt-in so the default lifecycle is unchanged, and it does nothing on insert — there is no row to
 lock yet.
 
+**A `scope=serverOnly` column is not overwritten by a client save, and there is nothing to switch on
+for that.** Such a field does not exist on the client class, so it is never in the JSON a client
+sends, and the model the server deserialises carries `null` there — an update writing the whole row
+would blank the column, with no error and an `isOk` response. It is left out of the `UPDATE`
+instead, and the database keeps its value. (The outbound half is held too: the value is never sent
+to a client in the first place — see
+[fields the client must never see](models.md#scopes-fields-the-client-must-never-see).)
+
+The rule is narrow on purpose: the column is skipped **only** when the incoming value is `null` and
+the stored row has one. A `beforeSaveTransaction` hook that *computes* a `serverOnly` value assigns
+it, and it is written like any other field. The one case that needs an opt-out is a hook meaning to
+**clear** such a field back to `null` — `allowServerOnlyOverwrite: true`, which then also lets an
+ordinary client save blank the column.
+
+The model is not re-read from the database after the write, so from `afterSaveTransaction` onwards a
+`serverOnly` field on `currentModel` still holds what the client sent, even though the stored row
+kept its value. A hook that needs the stored one reads `saveContext.initialModel`.
+
 **Every read inside the transaction carries `saveContext.transaction`** — that is the two
 in-transaction hooks, and every call they make. A model repository takes it as a named argument, so
 does `dw.db(session)` (see

--- a/docs/2-core/models.md
+++ b/docs/2-core/models.md
@@ -156,10 +156,23 @@ testVerificationCode: String?, scope=serverOnly
 password: String?, !persist
 ```
 
-`scope=serverOnly` keeps the field out of the generated **client** class entirely — it is not
-withheld at runtime, it does not exist there, so no accidental read is possible. `!persist` is the
-opposite direction: the field travels over the wire but is never written to a column, which is how
-`DwAuthRequest` carries a password to the server without it ever landing in the database.
+`scope=serverOnly` keeps the field out of the generated **client** class entirely — it does not exist
+there, so no accidental read is possible. The framework holds that promise in both directions:
+
+- **The value is never sent.** It is stripped from every CRUD response, every realtime broadcast and
+  the sign-in payload. Worth stating explicitly, because the absent client field alone would not
+  achieve it: a client that has no field for a key simply drops the key while reading, and the value
+  would still have crossed the network.
+- **The value is never blanked by a client save.** Since the field cannot be in the JSON a client
+  sends, the model the server deserialises carries `null` there — and an update writing the whole row
+  would erase the column. It is left out of the `UPDATE` instead, and the database keeps what it had.
+  A server-side hook that *computes* the value still writes it normally; the one case needing an
+  opt-out is a hook meaning to clear the field back to `null`, which is
+  `DwSaveConfig.allowServerOnlyOverwrite` ([crud-configs.md](crud-configs.md)).
+
+`!persist` is the opposite direction: the field travels over the wire but is never written to a
+column, which is how `DwAuthRequest` carries a password to the server without it ever landing in the
+database.
 
 ## Base and Event models
 

--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.7.0
+  dartway_serverpod_core_client: ^0.8.0
 
   # The client half of the optional push module. Required because the generated
   # protocol imports it — the server consumes the module, so its `Caller` shows

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -306,21 +306,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_studio_bridge:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.7.0
+  dartway_serverpod_core_flutter: ^0.8.0
 
   dartway_studio_bridge: ^0.6.0
 

--- a/example/dartway_example_server/lib/src/models/user_profile/user_profile.spy.yaml
+++ b/example/dartway_example_server/lib/src/models/user_profile/user_profile.spy.yaml
@@ -18,8 +18,11 @@ fields:
   # admin (full access). Enforced by CRUD config access filters.
   role: UserRole, default=client
 
-  # Rotatable test/reviewer OTP code. serverOnly: NEVER serialized to the client,
-  # so a regular client cannot read test codes. Real users leave it null and get
-  # a random code (secure-by-default); the admin sets/rotates it via a dedicated
-  # admin endpoint, and the users that have it set are the Studio demo personas.
+  # Rotatable test/reviewer OTP code. serverOnly, which the framework holds in
+  # both directions: the value is never serialized to the client, so a regular
+  # client cannot read test codes, and a client saving this profile back does not
+  # blank the column — it is left out of the UPDATE and the stored code survives.
+  # Real users leave it null and get a random code (secure-by-default); the admin
+  # sets/rotates it via a dedicated admin endpoint, and the users that have it
+  # set are the Studio demo personas.
   testVerificationCode: String?, scope=serverOnly

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -134,14 +134,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   ffi:
     dependency: transitive
     description:

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.7.0
+  dartway_serverpod_core_server: ^0.8.0
 
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.

--- a/example/dartway_example_server/test/integration/dw_save_config_server_only_test.dart
+++ b/example/dartway_example_server/test/integration/dw_save_config_server_only_test.dart
@@ -1,0 +1,301 @@
+import 'package:dartway_example_server/src/generated/protocol.dart';
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+const _testIdentifierPrefix = 'dw_server_only_test_';
+
+/// `scope=serverOnly` has to hold in both directions, and only a real database
+/// can show the second one.
+///
+/// Outbound: the column never reaches the client. Inbound: a save from that
+/// client does not blank it. The two are the same mechanism seen from either
+/// end — the client class has no such field, so the value is neither sent to it
+/// nor sent back by it, and an update that writes the whole row would therefore
+/// write `null` over it.
+///
+/// `UserProfile.testVerificationCode` is the fixture because it is a real
+/// `serverOnly` column on a real table, and because getting it wrong is not
+/// abstract: it is the fixed sign-in code for reviewer and demo accounts.
+/// Leaking it hands over a login; blanking it locks those accounts out.
+void main() {
+  withServerpod('DwSaveConfig and scope=serverOnly', (
+    sessionBuilder,
+    endpoints,
+  ) {
+    setUp(() => _clearTestProfiles(sessionBuilder.build()));
+    tearDown(() => _clearTestProfiles(sessionBuilder.build()));
+
+    /// A stored profile that has a server-side code, so a save has something to
+    /// destroy and a response has something to leak.
+    Future<UserProfile> storedProfile(
+      Session session, {
+      required String suffix,
+      String? testVerificationCode = 'THE-CODE',
+    }) => UserProfile.db.insertRow(
+      session,
+      UserProfile(
+        userIdentifier: '$_testIdentifierPrefix$suffix',
+        phone: '$_testIdentifierPrefix$suffix',
+        agreedForMarketingCommunications: false,
+        conditionsAcceptedAt: DateTime.now().toUtc(),
+        firstName: 'Ada',
+        testVerificationCode: testVerificationCode,
+      ),
+    );
+
+    /// The model as it comes back from a client.
+    ///
+    /// Round-tripped through `toJsonForProtocol` on purpose rather than by
+    /// setting the field to null by hand: that map *is* what the client was
+    /// given, so what survives the trip is exactly what a client is able to
+    /// send back. The `serverOnly` field is not omitted by this helper — it is
+    /// missing because the wire form never carried it.
+    UserProfile asReturnedByClient(UserProfile stored) =>
+        UserProfile.fromJson(stored.toJsonForProtocol());
+
+    test('the wire form a client sends back has no serverOnly field', () {
+      // The premise of every test below. If this stopped holding, they would
+      // all keep passing while testing nothing.
+      final profile = UserProfile(
+        userIdentifier: 'x',
+        phone: 'x',
+        agreedForMarketingCommunications: false,
+        conditionsAcceptedAt: DateTime.now().toUtc(),
+        firstName: 'Ada',
+        testVerificationCode: 'THE-CODE',
+      );
+
+      expect(profile.toJson(), contains('testVerificationCode'));
+      expect(profile.toJsonForProtocol(), isNot(contains('testVerificationCode')));
+      expect(asReturnedByClient(profile).testVerificationCode, isNull);
+    });
+
+    test('a client save leaves the serverOnly column as it was', () async {
+      final session = sessionBuilder.build();
+      final stored = await storedProfile(session, suffix: 'plain_save');
+
+      final response = await DwSaveConfig<UserProfile>(
+        allowSave: (session, context) async => true,
+      ).save(
+        session,
+        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+      );
+
+      expect(response.isOk, isTrue);
+      final reloaded = await UserProfile.db.findById(session, stored.id!);
+      // The edit the client actually made goes through...
+      expect(reloaded?.firstName, 'Grace');
+      // ...and the column it could not see is untouched.
+      expect(reloaded?.testVerificationCode, 'THE-CODE');
+    });
+
+    test('the locked update path protects the column too', () async {
+      // A separate entry point into the same write, and the one a config with
+      // state-dependent rules uses. Worth its own test: a fix applied to only
+      // one of the two paths would look complete.
+      final session = sessionBuilder.build();
+      final stored = await storedProfile(session, suffix: 'locked_save');
+
+      final response = await DwSaveConfig<UserProfile>(
+        lockInitialModelForUpdate: true,
+        allowSave: (session, context) async => true,
+      ).save(
+        session,
+        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+      );
+
+      expect(response.isOk, isTrue);
+      final reloaded = await UserProfile.db.findById(session, stored.id!);
+      expect(reloaded?.firstName, 'Grace');
+      expect(reloaded?.testVerificationCode, 'THE-CODE');
+    });
+
+    test('a hook that assigns a serverOnly value writes it', () async {
+      // The legitimate case the narrow rule exists to keep working: the server
+      // computes the value itself, so it is not null on the way in and is
+      // written like any other column.
+      final session = sessionBuilder.build();
+      final stored = await storedProfile(session, suffix: 'hook_assigns');
+
+      final response = await DwSaveConfig<UserProfile>(
+        allowSave: (session, context) async => true,
+        beforeSaveTransaction: (session, context) async {
+          context.currentModel = context.currentModel.copyWith(
+            testVerificationCode: 'ROTATED',
+          );
+          return null;
+        },
+      ).save(session, asReturnedByClient(stored));
+
+      expect(response.isOk, isTrue);
+      expect(
+        (await UserProfile.db.findById(
+          session,
+          stored.id!,
+        ))?.testVerificationCode,
+        'ROTATED',
+      );
+    });
+
+    test('a hook cannot clear the column without the opt-out', () async {
+      // The one case the narrow rule costs, stated as a test so it is a known
+      // trade-off rather than a surprise.
+      final session = sessionBuilder.build();
+      final stored = await storedProfile(session, suffix: 'hook_clears');
+
+      await DwSaveConfig<UserProfile>(
+        allowSave: (session, context) async => true,
+        beforeSaveTransaction: (session, context) async {
+          context.currentModel = context.currentModel.copyWith(
+            testVerificationCode: null,
+          );
+          return null;
+        },
+      ).save(session, asReturnedByClient(stored));
+
+      expect(
+        (await UserProfile.db.findById(
+          session,
+          stored.id!,
+        ))?.testVerificationCode,
+        'THE-CODE',
+      );
+    });
+
+    test('allowServerOnlyOverwrite lets the column be cleared', () async {
+      final session = sessionBuilder.build();
+      final stored = await storedProfile(session, suffix: 'opt_out');
+
+      final response = await DwSaveConfig<UserProfile>(
+        allowServerOnlyOverwrite: true,
+        allowSave: (session, context) async => true,
+      ).save(session, asReturnedByClient(stored));
+
+      expect(response.isOk, isTrue);
+      expect(
+        (await UserProfile.db.findById(
+          session,
+          stored.id!,
+        ))?.testVerificationCode,
+        isNull,
+      );
+    });
+
+    test('an insert still writes the serverOnly value', () async {
+      // Inserts are outside the guard entirely — there is no stored row to
+      // protect, and a skipped column here would silently drop the value.
+      final session = sessionBuilder.build();
+
+      final response = await DwSaveConfig<UserProfile>(
+        allowSave: (session, context) async => true,
+      ).save(
+        session,
+        UserProfile(
+          userIdentifier: '${_testIdentifierPrefix}insert',
+          phone: '${_testIdentifierPrefix}insert',
+          agreedForMarketingCommunications: false,
+          conditionsAcceptedAt: DateTime.now().toUtc(),
+          firstName: 'Ada',
+          testVerificationCode: 'FRESH',
+        ),
+      );
+
+      expect(response.isOk, isTrue);
+      final inserted = await UserProfile.db.findFirstRow(
+        session,
+        where: (t) =>
+            t.userIdentifier.equals('${_testIdentifierPrefix}insert'),
+      );
+      expect(inserted?.testVerificationCode, 'FRESH');
+    });
+
+    test('a save leaves an unrelated row alone', () async {
+      // The column list is built per row. A bug that built it once and reused
+      // it would show up as a neighbour losing its code.
+      final session = sessionBuilder.build();
+      final mine = await storedProfile(session, suffix: 'mine');
+      final neighbour = await storedProfile(
+        session,
+        suffix: 'neighbour',
+        testVerificationCode: 'NEIGHBOUR-CODE',
+      );
+
+      await DwSaveConfig<UserProfile>(
+        allowSave: (session, context) async => true,
+      ).save(session, asReturnedByClient(mine).copyWith(firstName: 'Grace'));
+
+      expect(
+        (await UserProfile.db.findById(
+          session,
+          neighbour.id!,
+        ))?.testVerificationCode,
+        'NEIGHBOUR-CODE',
+      );
+    });
+
+    test('a row whose serverOnly column is null saves normally', () async {
+      // The gate that skips the work compares map sizes, and a null column is
+      // missing from both maps — so this row takes the cheap path. It must
+      // still save everything else.
+      final session = sessionBuilder.build();
+      final stored = await storedProfile(
+        session,
+        suffix: 'null_code',
+        testVerificationCode: null,
+      );
+
+      final response = await DwSaveConfig<UserProfile>(
+        allowSave: (session, context) async => true,
+      ).save(
+        session,
+        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+      );
+
+      expect(response.isOk, isTrue);
+      final reloaded = await UserProfile.db.findById(session, stored.id!);
+      expect(reloaded?.firstName, 'Grace');
+      expect(reloaded?.testVerificationCode, isNull);
+    });
+
+    test('the save response does not carry the serverOnly column', () async {
+      // The outbound half, end to end and through the real envelope:
+      // DwApiResponse -> DwModelWrapper -> model. Only reachable with a booted
+      // server, because the wrapper resolves its class name through
+      // `Serverpod.instance` — which is why the unit suite in core_server stops
+      // one level short of this.
+      final session = sessionBuilder.build();
+      final stored = await storedProfile(session, suffix: 'response');
+
+      final response = await DwSaveConfig<UserProfile>(
+        allowSave: (session, context) async => true,
+      ).save(
+        session,
+        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+      );
+
+      final wire = response.toJsonForProtocol();
+      expect(wire['value']['data'], isNot(contains('testVerificationCode')));
+      for (final updated in wire['updatedModels'] as List) {
+        expect(updated['data'], isNot(contains('testVerificationCode')));
+      }
+      // The encoder Serverpod actually runs over the result, as the last word:
+      // no assertion about maps can rule out the string on the socket.
+      expect(
+        SerializationManager.encodeForProtocol(response),
+        isNot(contains('testVerificationCode')),
+      );
+    });
+  }, rollbackDatabase: RollbackDatabase.disabled);
+}
+
+Future<void> _clearTestProfiles(Session session) async {
+  await session.db.unsafeExecute('''
+DELETE FROM "user_profile"
+WHERE "userIdentifier" LIKE @identifierPrefix
+''', parameters: QueryParameters.named({
+    'identifierPrefix': '$_testIdentifierPrefix%',
+  }));
+}

--- a/packages/dartway_push/dartway_push_client/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_client/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   # wrapper types. Inside the workspace this resolved without being declared,
   # which is exactly the kind of dependency that only fails once the package is
   # published and somebody else resolves it.
-  dartway_serverpod_core_client: ^0.7.0
+  dartway_serverpod_core_client: ^0.8.0

--- a/packages/dartway_push/dartway_push_flutter/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_flutter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   # app half talks to the server half through the generated protocol, not
   # through an endpoint of its own.
   dartway_push_client: ^0.2.0
-  dartway_serverpod_core_flutter: ^0.7.0
+  dartway_serverpod_core_flutter: ^0.8.0
 
   flutter_riverpod: ^3.0.0
 

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_server: ^0.7.0
+  dartway_serverpod_core_server: ^0.8.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.8.0 is the
+server side making `scope=serverOnly` hold in both directions — such a field was being sent to
+clients, and a client save was blanking it. See the changelog of `dartway_serverpod_core_server`;
+if your models use `scope=serverOnly`, read it.
+
 ## 0.7.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.7.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.8.0 is the
+server side making `scope=serverOnly` hold in both directions — such a field was being sent to
+clients, and a client save was blanking it. See the changelog of `dartway_serverpod_core_server`;
+if your models use `scope=serverOnly`, read it.
+
 ## 0.7.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.7.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -19,8 +19,8 @@ dependencies:
   serverpod_client: ^3.4.11
 
   dartway_flutter: ^0.5.0
-  dartway_serverpod_core_client: ^0.7.0
-  dartway_serverpod_core_shared: ^0.7.0
+  dartway_serverpod_core_client: ^0.8.0
+  dartway_serverpod_core_shared: ^0.8.0
 
   collection: ^1.19.1
   flutter_riverpod: ^3.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.8.0
+
+**`scope=serverOnly` did not hold, in either direction. Worth upgrading now rather than at your
+convenience** — the outbound half is a data leak that is live in every application on 0.7.0 and
+earlier, and neither half reported anything while it was happening.
+
+- **Fixed: `serverOnly` fields were sent to clients.** Serverpod asks a model for
+  `toJsonForProtocol()` — the map without the `serverOnly` fields — for everything it sends a
+  client, but only for the objects it reaches by walking the result. The core's own envelopes
+  flatten their contents by hand before Serverpod ever sees them, and all three called `toJson()`
+  inside: `DwApiResponse` (which additionally did not declare `ProtocolSerialization` at all, so it
+  was never asked), `DwModelWrapper`, and `DwAuthData`.
+
+  So every CRUD response, every realtime broadcast and the sign-in response carried the full row.
+  **Invisible from the application, which is why it survived:** the generated client class has no
+  field for a `serverOnly` column, its `fromJson` drops the key on arrival, and every screen looks
+  correct — while the value sits in the response body on the wire.
+
+  What was travelling in this repository's own models: `DwAuthRequest.verificationHash`, and the
+  `testVerificationCode` that example and template put on `UserProfile` — a fixed sign-in code, so
+  the leak handed over a working login. **Check your own models for `scope=serverOnly` and treat
+  anything you find as disclosed to every client that received such a row**; rotate it if it is a
+  secret. Serialisation now goes through one place, and a regression test stands on the generator's
+  own output.
+
+- **Fixed: a client save blanked `serverOnly` columns.** A `serverOnly` field does not exist on the
+  client class, so it is never in the JSON a client sends; the server's `fromJson` read the missing
+  key as `null`, and the update wrote the whole row — including the column the client could not have
+  said anything about. No error, `isOk` in the response, the value silently gone.
+
+  Such a column is now left out of the `UPDATE` when the incoming value is `null` and the stored row
+  has one, so the database keeps what it had. The rule is deliberately narrow: a
+  `beforeSaveTransaction` hook that *computes* a `serverOnly` value still writes it normally.
+
+- **Added: `DwSaveConfig.allowServerOnlyOverwrite`**, default `false`. The one case the narrow rule
+  costs is a hook that means to clear a `serverOnly` field back to `null`; turn this on for that
+  config, and accept that an ordinary client save will then blank the column too.
+
+  Note what the hooks see afterwards: the model is not rebuilt from the database, so from
+  `afterSaveTransaction` onwards a `serverOnly` field on `currentModel` still holds what the client
+  sent. A hook that needs the stored value reads `saveContext.initialModel`.
+
 ## 0.7.0
 
 Two additions, both about server code an application could not write — or could not test — until now.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_api_response.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_api_response.dart
@@ -1,8 +1,19 @@
 import 'package:serverpod/serverpod.dart';
 
 import 'dw_model_wrapper.dart';
+import 'dw_protocol_json.dart';
 
-class DwApiResponse<T> implements SerializableModel {
+/// The envelope every CRUD call answers with.
+///
+/// Implements [ProtocolSerialization] deliberately, and it is the link that
+/// makes the rest of the chain reachable. This envelope flattens its own
+/// contents — the value and the updated models are turned into maps here, by
+/// hand — so by the time Serverpod's encoder walks the result there are no
+/// model objects left in it to recognise. Whatever choice is made *here* is the
+/// final one for everything nested; a `toJson` on this level publishes the
+/// `serverOnly` columns of every model inside, no matter how carefully the
+/// wrappers below it serialise themselves.
+class DwApiResponse<T> implements SerializableModel, ProtocolSerialization {
   static SerializationManagerServer get _protocol =>
       Serverpod.instance.serializationManager;
 
@@ -64,23 +75,35 @@ class DwApiResponse<T> implements SerializableModel {
     );
   }
 
+  /// Everything the envelope carries, `serverOnly` fields included. For
+  /// server-side use; [toJsonForProtocol] is what reaches a client.
   @override
-  toJson() {
+  toJson() => _json(forProtocol: false);
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() => _json(forProtocol: true);
+
+  Map<String, dynamic> _json({required bool forProtocol}) {
     return {
       'isOk': isOk,
-      'value': _serializeValue(value),
+      'value': _serializeValue(value, forProtocol: forProtocol),
       if (warning != null) 'warning': warning,
       if (error != null) 'error': error,
       if (updatedModels != null)
-        'updatedModels': updatedModels?.toJson(valueToJson: (v) => v.toJson()),
+        'updatedModels': [
+          for (final model in updatedModels!)
+            forProtocol ? model.toJsonForProtocol() : model.toJson(),
+        ],
     };
   }
 
-  static dynamic _serializeValue(dynamic value) {
+  static dynamic _serializeValue(dynamic value, {required bool forProtocol}) {
     if (value is SerializableModel) {
-      return value.toJson();
+      return forProtocol ? dwJsonForProtocol(value) : value.toJson();
     } else if (value is List) {
-      return value.map((e) => _serializeValue(e)).toList();
+      return value
+          .map((e) => _serializeValue(e, forProtocol: forProtocol))
+          .toList();
     }
     return value;
   }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_auth_data.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_auth_data.dart
@@ -1,5 +1,7 @@
 import 'package:serverpod/serverpod.dart';
 
+import 'dw_protocol_json.dart';
+
 class DwAuthData implements SerializableModel, ProtocolSerialization {
   static SerializationManagerServer get _protocol =>
       Serverpod.instance.serializationManager;
@@ -27,6 +29,8 @@ class DwAuthData implements SerializableModel, ProtocolSerialization {
     );
   }
 
+  /// The whole profile row, `serverOnly` fields included — server-side use
+  /// only. What the client gets on sign-in is [toJsonForProtocol].
   @override
   toJson() {
     return {
@@ -43,7 +47,7 @@ class DwAuthData implements SerializableModel, ProtocolSerialization {
       'className': className,
       'key': key,
       'keyId': keyId,
-      'data': userProfile.toJson(),
+      'data': dwJsonForProtocol(userProfile),
     };
   }
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_model_wrapper.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_model_wrapper.dart
@@ -1,5 +1,7 @@
 import 'package:serverpod/serverpod.dart';
 
+import 'dw_protocol_json.dart';
+
 class DwModelWrapper implements SerializableModel, ProtocolSerialization {
   static SerializationManagerServer get _protocol =>
       Serverpod.instance.serializationManager;
@@ -44,6 +46,9 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
     return DwModelWrapper(object: object);
   }
 
+  /// The whole row, `serverOnly` fields included. Server-side only: caches,
+  /// logs, and the hop to another server instance through Redis. Never what a
+  /// client is handed — that is [toJsonForProtocol].
   @override
   toJson() {
     return {
@@ -57,7 +62,7 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
   Map<String, dynamic> toJsonForProtocol() {
     return {
       'className': className,
-      'data': object.toJson(),
+      'data': dwJsonForProtocol(object),
       'isDeleted': isDeleted,
     };
   }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_protocol_json.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_protocol_json.dart
@@ -1,0 +1,28 @@
+import 'package:serverpod/serverpod.dart';
+
+/// The JSON a model is allowed to put on the wire.
+///
+/// The generator writes **two** maps for every model: [SerializableModel.toJson]
+/// is the whole row, and [ProtocolSerialization.toJsonForProtocol] is that row
+/// minus its `scope=serverOnly` fields. Serverpod picks the second one for
+/// everything it sends a client — but only for the objects it reaches itself,
+/// walking the value it was handed. It never reaches inside an envelope this
+/// package has already flattened into a map.
+///
+/// So each hand-written payload here — `DwApiResponse`, `DwModelWrapper`,
+/// `DwAuthData` — has to make that choice for its own contents, and this is the
+/// one place that makes it. Calling `toJson` on a nested model instead
+/// publishes the columns the schema marked server-side.
+///
+/// **The failure is silent from the app, which is what makes it worth a named
+/// function.** The generated client class has no field for a `serverOnly`
+/// column, so its `fromJson` drops the key on arrival and every screen looks
+/// correct — while the value itself has already crossed the network and sits in
+/// the response body, readable by anyone holding the socket.
+///
+/// No fallback to `toJson` once [ProtocolSerialization] is on the model: a
+/// fallback is how the leak comes back.
+dynamic dwJsonForProtocol(SerializableModel model) => model
+        is ProtocolSerialization
+    ? (model as ProtocolSerialization).toJsonForProtocol()
+    : model.toJson();

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
@@ -45,6 +45,7 @@ class DwSaveConfig<T extends TableRow> {
     this.afterSaveTransform,
     this.afterSaveSideEffects,
     this.lockInitialModelForUpdate = false,
+    this.allowServerOnlyOverwrite = false,
     this.broadcastTo,
   });
 
@@ -109,6 +110,34 @@ class DwSaveConfig<T extends TableRow> {
   /// row to lock yet — which is why those still validate before their
   /// transaction.
   final bool lockInitialModelForUpdate;
+
+  /// Lets a save write `null` over a `scope=serverOnly` column that currently
+  /// holds a value. Off by default, and the default is the one you want.
+  ///
+  /// A `serverOnly` field does not exist on the client class at all, so it is
+  /// never in the JSON a client sends, and the server's `fromJson` reads the
+  /// missing key as `null`. An update writes the whole row, so without this
+  /// gate every client save would blank the column — no error, `isOk` in the
+  /// response, the value simply gone. Left off, such a column is dropped from
+  /// the `UPDATE` and the database keeps what it had.
+  ///
+  /// The exclusion is deliberately narrow: it applies only when the incoming
+  /// model has `null` where the stored row has a value. A
+  /// [beforeSaveTransaction] hook that *computes* a `serverOnly` value and
+  /// assigns it writes that value normally — which is the whole point of
+  /// computing it — because the incoming model is no longer null there.
+  ///
+  /// That leaves exactly one case this costs you: a hook that means to clear a
+  /// `serverOnly` field back to `null`. Turn this on for that config, and
+  /// accept that an ordinary client save will then blank the column too.
+  ///
+  /// **What the hooks see afterwards.** The model is not rebuilt from the
+  /// database after the write, so from [afterSaveTransaction] onwards a
+  /// `serverOnly` field on `currentModel` still holds what the client sent —
+  /// `null` — even though the stored row kept its value. Nothing is lost to the
+  /// caller, who cannot see the field either way. A hook that needs the stored
+  /// value reads `saveContext.initialModel`.
+  final bool allowServerOnlyOverwrite;
 
   /// The channels everything this save changed is broadcast to — so that one
   /// user's change lands on the other users' screens without a refresh.
@@ -278,6 +307,7 @@ class DwSaveConfig<T extends TableRow> {
           )
         : await session.db.updateRow<T>(
             saveContext.currentModel,
+            columns: _columnsToWrite(saveContext),
             transaction: transaction,
           );
 
@@ -286,6 +316,79 @@ class DwSaveConfig<T extends TableRow> {
       final error = await afterSaveTransaction!(session, saveContext);
       if (error != null) throw _DwSaveRejection(error);
     }
+  }
+
+  /// The columns this update may write, or `null` for "all of them" — which is
+  /// what [Database.updateRow] means by an absent list, and what every save
+  /// that has nothing to protect returns.
+  ///
+  /// Guards the `serverOnly` columns described on [allowServerOnlyOverwrite]:
+  /// one whose incoming value is `null` while the stored row has a value is
+  /// left out of the `UPDATE`, so the database keeps what it had.
+  ///
+  /// **How a `serverOnly` field is recognised without reflection.** The
+  /// generator writes two maps for every model — `toJson` carries them,
+  /// `toJsonForProtocol` does not — so the difference between the key sets is
+  /// the answer, and it costs two map builds.
+  ///
+  /// **The difference is taken on [DwSaveContext.initialModel], the row as it
+  /// is in the database, and that is not interchangeable with taking it on the
+  /// type.** Both maps write a key under `if (value != null)`, so a nullable
+  /// `serverOnly` column that is null in *this row* is missing from both and
+  /// registers as no difference at all. That makes "this type has no
+  /// `serverOnly` fields" a property of the row, never of the class — which is
+  /// why the result must not be cached per type. A cached negative would turn
+  /// one such row into a permanent hole for every other row of the same model.
+  ///
+  /// The length comparison is the cheap gate that keeps the rest rare:
+  /// `toJsonForProtocol` is by construction a subset of `toJson`, so equal
+  /// sizes mean equal key sets and there is nothing to protect. Two map builds
+  /// against the `findById`, the transaction and the `UPDATE` around them are
+  /// microseconds against milliseconds.
+  List<Column>? _columnsToWrite(DwSaveContext<T> saveContext) {
+    if (allowServerOnlyOverwrite) return null;
+
+    final initialModel = saveContext.initialModel;
+    // Inserts never get here — there is no stored row to protect.
+    if (initialModel == null || initialModel is! ProtocolSerialization) {
+      return null;
+    }
+
+    final stored = initialModel.toJson();
+    final wire = (initialModel as ProtocolSerialization).toJsonForProtocol();
+    if (stored is! Map<String, dynamic> || wire is! Map<String, dynamic>) {
+      return null;
+    }
+    if (stored.length == wire.length) return null;
+
+    final incoming = saveContext.currentModel.toJson();
+    if (incoming is! Map<String, dynamic>) return null;
+
+    // A key the wire form drops, holding a value in the database, and absent
+    // from what arrived. Both maps omit a null under `if (value != null)`, so
+    // "absent from `incoming`" and "explicitly null" are the same thing here —
+    // and they should be, since the client cannot express either one.
+    final atRisk = {
+      for (final key in stored.keys)
+        if (!wire.containsKey(key) && incoming[key] == null) key,
+    };
+    if (atRisk.isEmpty) return null;
+
+    // Keyed by `fieldName`: it is the name the JSON uses, and it is not always
+    // the name of the column (`Column.fieldName` falls back to `columnName`
+    // only when the model does not remap it).
+    //
+    // Built from `managedColumns` rather than `columns` because that is what
+    // `updateRow` writes when handed no list — starting anywhere else would
+    // change more than the one thing this method is for.
+    final managedColumns = saveContext.currentModel.table.managedColumns;
+    final columns = managedColumns
+        .where((column) => !atRisk.contains(column.fieldName))
+        .toList();
+
+    // Everything at risk turned out not to be a column — a `!persist` field,
+    // say. Nothing to exclude, so hand back the default.
+    return columns.length == managedColumns.length ? null : columns;
   }
 
   /// Everything after the transaction commits — shared by both paths.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_shared: ^0.7.0
+  dartway_serverpod_core_shared: ^0.8.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/api/server_only_serialization_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/api/server_only_serialization_test.dart
@@ -1,0 +1,133 @@
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:dartway_serverpod_core_server/src/domain/api/dw_protocol_json.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+/// `scope=serverOnly` must hold on the way out: a field the schema marked
+/// server-side never reaches a client.
+///
+/// The fixture is a real generated model rather than a hand-written double, and
+/// that is the point of the suite. What is being tested is the agreement
+/// between two maps the *generator* writes — `toJson` carries
+/// `verificationHash`, `toJsonForProtocol` does not — and a double would only
+/// assert that this test file agrees with itself. `DwAuthRequest` lives in this
+/// package, so the check travels with the code it guards.
+///
+/// Why it is worth pinning: the leak is invisible from the app. The client
+/// class has no field for a `serverOnly` column, so `fromJson` drops the key
+/// and every screen looks right — while the value has already crossed the
+/// network. Nothing fails, nothing is logged, and the only witness is the
+/// response body.
+///
+/// `DwModelWrapper` and `DwAuthData` are absent here for a mechanical reason:
+/// both resolve `className` through `Serverpod.instance` in their constructor,
+/// so building one needs a booted server — the same limitation
+/// `send_updates_test.dart` records. Their shared choice of serialiser is what
+/// [dwJsonForProtocol] is, and it is tested directly below.
+void main() {
+  /// A request with every server-side field populated, so a leak has something
+  /// to leak.
+  DwAuthRequest authRequest() => DwAuthRequest(
+    id: 7,
+    requestType: DwAuthRequestType.login,
+    userIdentifier: '+70000000000',
+    authProvider: DwAuthProvider.phone,
+    verificationHash: 'the-hash-that-must-not-travel',
+  );
+
+  group('the generator still marks the fixture serverOnly', () {
+    // If this pair ever stops disagreeing, every assertion below would pass for
+    // the wrong reason — a check against a field that is no longer serverOnly
+    // proves nothing at all.
+    test('toJson carries verificationHash and toJsonForProtocol does not', () {
+      final request = authRequest();
+
+      expect(request.toJson(), contains('verificationHash'));
+      expect(request.toJsonForProtocol(), isNot(contains('verificationHash')));
+    });
+  });
+
+  group('dwJsonForProtocol', () {
+    test('drops the serverOnly field of a protocol-aware model', () {
+      final json = dwJsonForProtocol(authRequest()) as Map<String, dynamic>;
+
+      expect(json, isNot(contains('verificationHash')));
+      // The ordinary fields still travel — stripping the row of everything
+      // would pass the assertion above and break the app.
+      expect(json['userIdentifier'], '+70000000000');
+      expect(json['id'], 7);
+    });
+  });
+
+  group('DwApiResponse', () {
+    test('is the protocol serialiser Serverpod will actually call', () {
+      // The encoder picks `toJsonForProtocol` only for objects that declare the
+      // interface. Without this the envelope falls back to `toJson`, and since
+      // it flattens its own contents, nothing below it is ever consulted.
+      expect(
+        const DwApiResponse<bool>(isOk: true, value: true),
+        isA<ProtocolSerialization>(),
+      );
+    });
+
+    test('strips the serverOnly field from a single value', () {
+      final response = DwApiResponse<DwAuthRequest>(
+        isOk: true,
+        value: authRequest(),
+      );
+
+      final value = response.toJsonForProtocol()['value'];
+      expect(value, isNot(contains('verificationHash')));
+      expect(value['userIdentifier'], '+70000000000');
+    });
+
+    test('strips it from every element of a list value', () {
+      final response = DwApiResponse<List<DwAuthRequest>>(
+        isOk: true,
+        value: [authRequest(), authRequest()],
+      );
+
+      final values = response.toJsonForProtocol()['value'] as List;
+      expect(values, hasLength(2));
+      for (final value in values) {
+        expect(value, isNot(contains('verificationHash')));
+      }
+    });
+
+    test('keeps the serverOnly field in the server-side toJson', () {
+      // The two maps are not interchangeable, and this is the one that says so.
+      // `toJson` still feeds caches, logs and the Redis hop between server
+      // instances, where the full row is the correct answer.
+      final response = DwApiResponse<DwAuthRequest>(
+        isOk: true,
+        value: authRequest(),
+      );
+
+      expect(response.toJson()['value'], contains('verificationHash'));
+    });
+
+    test('carries the plain envelope fields through unchanged', () {
+      final response = DwApiResponse<DwAuthRequest>(
+        isOk: false,
+        value: null,
+        error: 'nope',
+        warning: 'careful',
+      );
+
+      final json = response.toJsonForProtocol();
+      expect(json['isOk'], false);
+      expect(json['value'], isNull);
+      expect(json['error'], 'nope');
+      expect(json['warning'], 'careful');
+    });
+
+    test('leaves a non-model value alone', () {
+      // `getCount` and `delete` answer with an int and a bool; the walk must not
+      // touch them.
+      expect(
+        const DwApiResponse<int>(isOk: true, value: 42).toJsonForProtocol(),
+        containsPair('value', 42),
+      );
+    });
+  });
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.8.0 is the
+server side making `scope=serverOnly` hold in both directions — such a field was being sent to
+clients, and a client save was blanking it. See the changelog of `dartway_serverpod_core_server`;
+if your models use `scope=serverOnly`, read it.
+
 ## 0.7.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.7.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/template/dartway_starter_client/pubspec.yaml
+++ b/template/dartway_starter_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.7.0
+  dartway_serverpod_core_client: ^0.8.0
 
 # Inside the monorepo — a local build. `dartway create` removes this block.
 dependency_overrides:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -292,21 +292,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_starter_client:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.7.0
+  dartway_serverpod_core_flutter: ^0.8.0
 
   dartway_studio_bridge: ^0.6.0
 

--- a/template/dartway_starter_server/lib/src/models/user_profile/user_profile.spy.yaml
+++ b/template/dartway_starter_server/lib/src/models/user_profile/user_profile.spy.yaml
@@ -18,11 +18,13 @@ fields:
   # access filters. Add your own roles as your domain needs them.
   role: UserRole, default=user
 
-  # Fixed test/reviewer OTP code. serverOnly: NEVER serialized to the client, so
-  # a regular client cannot read test codes. Real users leave it null and get a
-  # random code (secure-by-default); a profile that has one set signs in with it
-  # in any run mode — which is what a store reviewer and a Studio demo persona
-  # need. Nothing in the skeleton writes this field: set it, and rotate it, from
-  # wherever the project decides to (an admin screen is a fair place, and one it
-  # would have to build).
+  # Fixed test/reviewer OTP code. serverOnly, which the framework holds in both
+  # directions: the value is never serialized to the client, so a regular client
+  # cannot read test codes, and a client saving this profile back does not blank
+  # the column — it is left out of the UPDATE and the stored code survives.
+  # Real users leave it null and get a random code (secure-by-default); a profile
+  # that has one set signs in with it in any run mode — which is what a store
+  # reviewer and a Studio demo persona need. Nothing in the skeleton writes this
+  # field: set it, and rotate it, from wherever the project decides to (an admin
+  # screen is a fair place, and one it would have to build).
   testVerificationCode: String?, scope=serverOnly

--- a/template/dartway_starter_server/pubspec.lock
+++ b/template/dartway_starter_server/pubspec.lock
@@ -127,14 +127,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   ffi:
     dependency: transitive
     description:

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.7.0
+  dartway_serverpod_core_server: ^0.8.0
 
   http: ^1.5.0
 

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -139,6 +139,28 @@ A read that omits it runs on its own connection: in production it works, merely 
 
 **If the rule depends on the current state of the row itself** (roles, consent flags, balance, a deleted marker) — turn on `lockInitialModelForUpdate: true`. Then on an **update** the initial model is re-read under `FOR UPDATE` inside the transaction, and steps 1–2 are evaluated against it: a parallel save of the same row waits and gets re-validated against what was actually committed, instead of passing on a stale pre-state. The flag is optional (defaults to `false`, the cycle is unchanged) and has no effect on insert — there is nothing to lock yet.
 
+**A `scope=serverOnly` field is held in both directions, and there is nothing to configure for it.** Such a field is absent from the generated **client** class entirely, and the framework honours that on both legs of the round trip:
+
+- it is **never sent** — stripped out of every CRUD response, every realtime broadcast and the sign-in payload;
+- it is **never blanked by a client save** — the field cannot be in the JSON a client sends, so the deserialised model carries `null` there, and an update writing the whole row would erase the column. It is left out of the `UPDATE` instead, and the database keeps its value.
+
+So `scope=serverOnly` is the right tool for anything the server owns and the client must not read: an internal hash, a computed score, a verification secret, a moderation note.
+
+The second rule is narrow on purpose — it skips the column **only** when the incoming value is `null` and the stored row has one. A hook that *computes* a `serverOnly` value writes it like any other field:
+
+```dart
+beforeSaveTransaction: (session, saveContext) async {
+  saveContext.currentModel = saveContext.currentModel.copyWith(
+    internalScore: await recomputeScore(session, saveContext),
+  );
+  return null;
+},
+```
+
+The one case that needs an opt-out is a hook meaning to **clear** a `serverOnly` field back to `null`: set `allowServerOnlyOverwrite: true` on the config, and accept that an ordinary client save will then blank the column too.
+
+One residual behaviour worth knowing: the model is not re-read from the database after the write, so from `afterSaveTransaction` onwards a `serverOnly` field on `currentModel` still holds what the client sent — `null` — even though the stored row kept its value. A hook that needs the stored value reads `saveContext.initialModel`.
+
 **To make other users see the change** — `broadcastTo` in the config: a callback over the context that returns the list of channels all the models touched by the save fly into. On the subscribers' side they are routed by type into any `dw.repo.modelList<T>()`, and the list redraws itself — nothing has to be written in Flutter (the app is subscribed to the public channel at the root).
 
 ```dart


### PR DESCRIPTION
`scope=serverOnly` was not honoured in either direction: the value was sent to clients, and a save from those clients blanked it. Neither half reported anything.

## Part 1 — the leak

Serverpod asks a model for `toJsonForProtocol()` — the map without the `serverOnly` fields — for everything it sends a client, but **only for the objects it reaches by walking the result**. The core's own envelopes flatten their contents by hand before Serverpod ever sees them, and all three called `toJson()` inside:

| Envelope | What was wrong |
|---|---|
| `DwApiResponse` | Did not declare `ProtocolSerialization` at all, so it was never asked — and it resolves its nested value and `updatedModels` eagerly, which is why fixing only the wrapper would have changed nothing for HTTP responses |
| `DwModelWrapper` | `'data': object.toJson()` |
| `DwAuthData` | `'data': userProfile.toJson()` — the sign-in response, the whole profile |

So every CRUD response, every realtime broadcast and the sign-in payload carried the full row. **Invisible from the application, which is why it survived:** the generated client class has no field for a `serverOnly` column, its `fromJson` drops the key on arrival, and every screen looks correct — while the value sits in the response body on the wire.

Travelling in this repository's own models: `DwAuthRequest.verificationHash`, and the `testVerificationCode` example and template put on `UserProfile` — a fixed sign-in code, so the leak handed over a working login.

The broadcast path needed nothing beyond the wrapper: `DwUpdatesTransport` is generated and already delegates correctly. The Redis hop is server-to-server and stays on `toJson`, which is right.

## Part 2 — the overwrite

A `serverOnly` field does not exist on the client class, so it is never in the JSON a client sends; the server's `fromJson` read the missing key as `null`, and `updateRow` wrote the whole row — including the column the client could not have said anything about. No error, `isOk`, value gone.

Recognising such a field without reflection: the generator writes two maps, and the difference between the key sets is the answer. **Taken on `initialModel`, the stored row — never on the type.** Both maps omit a key under `if (value != null)`, so a nullable `serverOnly` column that is null in *this row* is missing from both; "this type has no `serverOnly` fields" is therefore a property of the row, and a cached negative would turn one such row into a permanent hole for the model. A length comparison gates the work, since the protocol map is by construction a subset.

The exclusion is narrow: only when the incoming value is `null` and the stored row has one. A `beforeSaveTransaction` hook that **computes** a `serverOnly` value writes it normally. The one case it costs — a hook clearing the field back to `null` — is covered by the new `DwSaveConfig.allowServerOnlyOverwrite`, default `false`.

Written through `updateRow(columns:)`, built from `managedColumns` and keyed by `Column.fieldName` (the JSON name, which is not always the column name).

## Tests

Both suites were verified to fail when the fix is reverted, not merely to pass.

- `core_server/test/api/server_only_serialization_test.dart` — 8 tests on `DwAuthRequest.verificationHash`. The fixture is a real generated model, not a double: what is under test is the agreement between two maps the *generator* writes, and a double would only assert the test agrees with itself. One test pins that the fixture is still `serverOnly`, so the others cannot pass for the wrong reason.
- `example/test/integration/dw_save_config_server_only_test.dart` — 10 tests against a real database on `UserProfile.testVerificationCode`. The incoming model is round-tripped through `toJsonForProtocol` rather than nulled by hand, so what it can carry is exactly what a client can send. Covers both update paths, hook-assigns, the opt-out, inserts, a neighbouring row, a null-valued row, and the outbound half end to end — including `SerializationManager.encodeForProtocol` over the real response, which is the one assertion no map comparison can replace.

`DwModelWrapper` and `DwAuthData` are absent from the unit suite for a mechanical reason: both resolve `className` through `Serverpod.instance` in their constructor, so building one needs a booted server. The integration suite covers them.

## Synchronisation

Four `dartway_serverpod_core_*` packages to 0.8.0 in lockstep, with the twelve dependent constraints and four lockfiles. `example/` and `template/` compile and their suites pass; `toolkit/skills/dartway-crud-config`, `docs/2-core/{models,crud-configs,access-and-roles}.md` updated. The `testVerificationCode` comments in example and template promised "NEVER serialized to the client" — untrue until this PR, true now.

No `dartway check` rule was added: after this fix it would flag a problem that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
