### PR TITLE
feat(bridge): a one-shot question, and a refusal that says so

### DIFF
--- a/docs/6-studio/studio-bridge.md
+++ b/docs/6-studio/studio-bridge.md
@@ -37,6 +37,14 @@ The open `dartway_studio_bridge` package is the only integration surface:
   a page that embedded the build without presenting anything can neither drive
   it nor read its feature passports.
 
+  **A refusal is answered, once it is a refusal of something.** If the token
+  presented parses as a signed Studio token and then fails the check — expired,
+  or signed by another key — the app replies `connectRefused`. Anything else (an
+  empty token, a guess, noise) is met with silence as before, so a stranger who
+  guessed the preview's URL does not learn there is a bridge here at all. The
+  distinction is the whole value: "this build carries no bridge" and "your
+  signature is stale" are two different repairs and used to look identical.
+
   Your build holds no secret and copies nothing out of Studio: the public half
   of the pair ships inside the bridge package, and a public key can only check
   signatures, never make them. The build names one thing — where it answers:
@@ -66,6 +74,33 @@ The open `dartway_studio_bridge` package is the only integration surface:
   its own logical size, so the app converts. A feature is matched on the area
   it actually paints into: something scaled down, scrolled out of its viewport
   or clipped away does not answer for a point where the user sees nothing.
+
+## Asking whether an app has a bridge at all
+
+Studio has a second reason to talk to an app: not to preview it, but to find out
+whether it answers. `probeStudioBridge(appUrl: …)` performs exactly one
+handshake and returns one of three things:
+
+```dart
+switch (await probeStudioBridge(appUrl: url, accessToken: myTokenSupplier)) {
+  StudioHandshakeResult.accepted => 'connected',
+  StudioHandshakeResult.rejected => 'the signature was refused',
+  StudioHandshakeResult.silent   => 'no answer',
+}
+```
+
+The frame is created and removed inside the call — nothing to render, nothing to
+know about. That matters because the preview's own `StudioFrameController` hands
+out a *platform view*: its iframe is not in the document until the embedder lays
+it out, and a detached iframe never fetches its `src`, so no layout means no
+load means no handshake. Asking this question through the preview therefore cost
+a 1×1 frame parked on screen for the lifetime of the app.
+
+`silent` covers several causes at once — no bridge in the build, a page that
+never loaded, a deployment that forbids being framed, an older app refusing in
+silence. Cross-origin they are one silence and cannot be separated from here:
+check that the URL serves a page, and that it permits `frame-ancestors`, as
+steps of their own before the probe.
 
 See the package [README](../packages/dartway_studio_bridge/README.md) for the
 full API, and `example/dartway_example_flutter/lib/core/studio/` for the reference

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -327,7 +327,7 @@ packages:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.7.1"
+    version: "0.8.0"
   dbus:
     dependency: transitive
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
 
   dartway_serverpod_core_flutter: ^0.7.0
 
-  dartway_studio_bridge: ^0.7.0
+  dartway_studio_bridge: ^0.8.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/js/studio-bridge/CHANGELOG.md
+++ b/js/studio-bridge/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.2.0
+
+**A refused handshake now gets an answer instead of silence.** The app sends
+`connectRefused` when the token it was shown parses as a signed Studio token and
+fails the check — expired, or signed by another key. Until now a refusal and a
+build with no bridge in it looked identical from the other side: an empty frame.
+They are two entirely different repairs, and whoever is connecting a project had
+no way to tell which one they were looking at.
+
+**Only a token that parses gets answered.** An empty, absent or garbled token is
+still met with silence (`looksLikeStudioBridgeToken`, exported for anyone who
+wants the same distinction), so a stranger who guessed the preview URL does not
+learn that there is a bridge on this page. Studio signs correctly by
+construction, so a refusal it can read means "your signature is stale or your
+key is wrong". A build in the zero-config local-dev mode (`appOrigin` left out)
+accepts everyone and therefore refuses nobody.
+
+**The protocol version stays 4.** It is checked strictly on decode, so bumping
+it would silence every build in the field in *both* directions the moment it
+shipped. A new message type is additive instead: a Studio that has never heard
+of `connectRefused` drops the envelope and behaves exactly as it did before.
+The golden wire string for it is in `test/protocol.test.ts`, character for
+character identical to the one in the Dart package's tests.
+
+Ships alongside `dartway_studio_bridge` 0.8.0, which adds the same message and
+the same refusal rule, plus a Studio-side one-shot probe that reads it.
+
 ## 0.1.0
 
 First release: the app side of the Studio bridge for JavaScript apps, speaking

--- a/js/studio-bridge/README.md
+++ b/js/studio-bridge/README.md
@@ -161,6 +161,12 @@ package, a public key can only check signatures and never make them, and it is
 the same for every project. There is nothing to copy out of Studio, store, or
 rotate.
 
+A token that parses as a signed Studio token and then fails the check gets a
+`connectRefused` back, so Studio can say "the signature was refused" instead of
+"not connected". Anything that is not a token — nothing presented, a guess,
+noise — is met with silence as before: a stranger who guessed the preview's URL
+does not learn that there is a bridge on this page.
+
 A build that names no origin (`appOrigin` left out) accepts any connection.
 That is deliberate — it is what makes `npm run dev` previewable with no keys at
 all — and it is why a deployed build should always name its address.

--- a/js/studio-bridge/package-lock.json
+++ b/js/studio-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dartway/studio-bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dartway/studio-bridge",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/js/studio-bridge/package.json
+++ b/js/studio-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dartway/studio-bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "App side of the DartWay Studio bridge for JavaScript apps: declare your screens and features, let Studio preview and drive the running build.",
   "license": "Apache-2.0",
   "type": "module",

--- a/js/studio-bridge/src/access/token.ts
+++ b/js/studio-bridge/src/access/token.ts
@@ -156,6 +156,42 @@ function reportOnce(reason: string, error?: unknown): void {
 
 const reported = new Set<string>();
 
+/**
+ * Whether `accessToken` is *shaped* like a token Studio signs — two base64url
+ * segments, the first of which decodes to a JSON object carrying an `origin`
+ * string and an integer `exp`. Nothing here is checked against a key, an origin
+ * or a clock: a forged token passes this and is still refused by
+ * {@link verifyStudioBridgeToken}.
+ *
+ * It exists to separate two refusals that are otherwise one. A token that
+ * parses came from something that knows the format — in practice, from Studio —
+ * so refusing it is worth *saying* (`connectRefused`): whoever sent it can be
+ * told their signature is stale rather than left to guess whether the bridge is
+ * there at all. Anything that does not parse is met with silence, so a stranger
+ * who guessed the preview's URL learns nothing.
+ *
+ * A stranger who bothers to construct a well-formed token does learn that this
+ * page carries a bridge. That is the price of the diagnosis, it is bounded —
+ * nothing else crosses the bridge without a valid signature — and it was chosen
+ * deliberately over leaving a misconfigured Studio with no way to tell "the app
+ * has no bridge" from "the app rejected my key".
+ */
+export function looksLikeStudioBridgeToken(accessToken: string): boolean {
+  const segments = accessToken.split(tokenSegmentSeparator);
+  if (segments.length !== 2 || segments.some((segment) => segment === '')) return false;
+  try {
+    const claims: unknown = JSON.parse(
+      new TextDecoder().decode(decodeSegment(segments[0] as string)),
+    );
+    decodeSegment(segments[1] as string);
+    if (typeof claims !== 'object' || claims === null || Array.isArray(claims)) return false;
+    const { origin, exp } = claims as Record<string, unknown>;
+    return typeof origin === 'string' && typeof exp === 'number' && Number.isInteger(exp);
+  } catch {
+    return false;
+  }
+}
+
 export interface StudioSignedAccessOptions {
   /**
    * Exists for tests and for the day an app has to trust a Studio running on

--- a/js/studio-bridge/src/host.ts
+++ b/js/studio-bridge/src/host.ts
@@ -12,7 +12,7 @@ import {
 } from './models.ts';
 import { studioBridgeProtocol } from './protocol/protocol.ts';
 import type { StudioBridgeMessage } from './protocol/messages.ts';
-import { studioSignedAccessValidator } from './access/token.ts';
+import { looksLikeStudioBridgeToken, studioSignedAccessValidator } from './access/token.ts';
 import { createStudioHostChannel, type StudioMessageChannel } from './transport.ts';
 
 export interface StudioBridgeConfig {
@@ -172,10 +172,19 @@ class StudioBridgeHostImpl implements StudioBridgeHost {
 
   #onMessage(message: StudioBridgeMessage): void {
     if (message.type === studioBridgeProtocol.studioConnect) {
-      // Answer the handshake only if the token is accepted; on refusal stay
-      // silent — the app keeps running, Studio shows "not connected".
-      void this.#validateAccessToken(message.accessToken).then((accepted) => {
-        if (!accepted || this.#detached) return;
+      const { accessToken } = message;
+      void this.#validateAccessToken(accessToken).then((accepted) => {
+        if (this.#detached) return;
+        if (!accepted) {
+          // A refusal is answered only when the token was one — see
+          // `looksLikeStudioBridgeToken` and `ConnectRefusedMessage`. Anything
+          // else (nothing presented, a guess, noise) is met with silence, as it
+          // always was: the app keeps running and the sender learns nothing.
+          if (looksLikeStudioBridgeToken(accessToken)) {
+            this.#channel.send({ type: studioBridgeProtocol.connectRefused });
+          }
+          return;
+        }
         this.#connected = true;
         this.#channel.send({
           type: studioBridgeProtocol.manifest,

--- a/js/studio-bridge/src/index.ts
+++ b/js/studio-bridge/src/index.ts
@@ -24,6 +24,7 @@ export {
   decodeStudioBridgeMessage,
   encodeStudioBridgeMessage,
   type AppReadyMessage,
+  type ConnectRefusedMessage,
   type FeaturesChangedMessage,
   type InspectPointRequestMessage,
   type InspectPointResultMessage,
@@ -40,6 +41,7 @@ export {
 } from './protocol/messages.ts';
 
 export {
+  looksLikeStudioBridgeToken,
   studioSignedAccessValidator,
   studioSigningPublicKey,
   verifyStudioBridgeToken,

--- a/js/studio-bridge/src/protocol/messages.ts
+++ b/js/studio-bridge/src/protocol/messages.ts
@@ -21,6 +21,29 @@ export interface AppReadyMessage {
 }
 
 /**
+ * The handshake was heard and refused — the token presented in
+ * `studioConnect` parsed as a signed Studio token and did not pass the app's
+ * check (expired, or signed by another key).
+ *
+ * It carries no reason. Which of the two it was is Studio's to work out from
+ * the token it issued itself, and an app that spelled it out would be telling
+ * whoever asked how to get closer.
+ *
+ * **Only a token that parses gets an answer.** An empty, absent or garbled
+ * token is still met with silence, so a stranger who guessed the preview's URL
+ * does not learn that there is a bridge here at all.
+ *
+ * **This type was added without bumping the protocol version, on purpose**
+ * (see `studioBridgeProtocol.version`). An app built before it exists simply
+ * never sends it, and a probe reads that as "no answer" — exactly what it read
+ * before this message existed. Do not bump the version to "fix" this: that
+ * would cut off every build in the field in both directions.
+ */
+export interface ConnectRefusedMessage {
+  type: typeof studioBridgeProtocol.connectRefused;
+}
+
+/**
  * The handshake response — the full manifest plus the current route, session,
  * features and locale, so Studio renders correctly right away.
  */
@@ -135,6 +158,7 @@ export interface InspectPointRequestMessage {
 
 export type StudioBridgeMessage =
   | AppReadyMessage
+  | ConnectRefusedMessage
   | ManifestMessage
   | RouteChangedMessage
   | SessionChangedMessage
@@ -156,6 +180,7 @@ export type StudioBridgeMessage =
 function payloadToJson(message: StudioBridgeMessage): Record<string, unknown> {
   switch (message.type) {
     case studioBridgeProtocol.appReady:
+    case studioBridgeProtocol.connectRefused:
     case studioBridgeProtocol.signOutRequest:
       return {};
     case studioBridgeProtocol.manifest:
@@ -232,6 +257,8 @@ export function decodeStudioBridgeMessage(data: unknown): StudioBridgeMessage | 
   switch (envelope[studioBridgeProtocol.typeKey]) {
     case studioBridgeProtocol.appReady:
       return { type: studioBridgeProtocol.appReady };
+    case studioBridgeProtocol.connectRefused:
+      return { type: studioBridgeProtocol.connectRefused };
     case studioBridgeProtocol.manifest:
       return {
         type: studioBridgeProtocol.manifest,

--- a/js/studio-bridge/src/protocol/protocol.ts
+++ b/js/studio-bridge/src/protocol/protocol.ts
@@ -16,6 +16,13 @@ export const studioBridgeProtocol = {
    * See the Dart package for the history of versions 1-3.
    * v4: `studioConnect` presents a short-lived `accessToken` — signed by
    * Studio, issued for the app's own origin — instead of a shared secret.
+   *
+   * **Adding a message type is not a schema change and must not bump this.**
+   * The version is checked strictly on decode, so a bump silences every build
+   * already in the field, in both directions, the moment it ships. A new type
+   * costs nothing instead: an old side drops the envelope it does not
+   * recognise and carries on, which is how `connectRefused` arrived inside v4.
+   * Bump only when the *meaning* of an existing message changes.
    */
   version: 4,
 
@@ -33,6 +40,13 @@ export const studioBridgeProtocol = {
   featuresChanged: 'featuresChanged',
   localeChanged: 'localeChanged',
   inspectPointResult: 'inspectPointResult',
+
+  /**
+   * The refusal of a handshake: the app heard `studioConnect`, understood the
+   * token it carried, and would not accept it. Added *inside* version 4 — see
+   * `version` for why adding a type is not a schema change.
+   */
+  connectRefused: 'connectRefused',
 
   // Studio → app.
   studioConnect: 'studioConnect',

--- a/js/studio-bridge/test/host.test.ts
+++ b/js/studio-bridge/test/host.test.ts
@@ -168,7 +168,7 @@ describe('the handshake', () => {
     host?.detach();
   });
 
-  test('a token issued for someone else gets nothing at all', async () => {
+  test('a token issued for someone else gets no manifest', async () => {
     const studio = new FakeStudio();
     const host = attachStudioBridge({
       manifest,
@@ -188,7 +188,7 @@ describe('the handshake', () => {
     host?.detach();
   });
 
-  test('an expired token gets nothing at all', async () => {
+  test('an expired token gets no manifest', async () => {
     const studio = new FakeStudio();
     const host = attachStudioBridge({
       manifest,
@@ -205,6 +205,63 @@ describe('the handshake', () => {
 
     assert.deepEqual(studio.of('manifest'), []);
     assert.equal(host?.isConnected, false);
+    host?.detach();
+  });
+
+  test('a refused token is told so — Studio signs correctly, so a refusal it can read means its signature is stale', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({
+      manifest,
+      appOrigin,
+      publicKey: studioPublicKey,
+      transport: studio,
+    });
+
+    studio.say({
+      type: 'studioConnect',
+      accessToken: await tokenFor(appOrigin, new Date(Date.now() - 1000)),
+    });
+    await waitFor(() => studio.of('connectRefused').length === 1, 'the refusal');
+
+    // Being answered is not being let in.
+    assert.equal(host?.isConnected, false);
+    studio.say({ type: 'navigateRequest', path: '/admin' });
+    await settle();
+    assert.deepEqual(studio.of('manifest'), []);
+    host?.detach();
+  });
+
+  test('anything that is not a token is met with silence, so a stranger who guessed the URL learns nothing', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({
+      manifest,
+      appOrigin,
+      publicKey: studioPublicKey,
+      transport: studio,
+    });
+
+    for (const accessToken of ['', 'forged', 'not.atoken', 'e30.AAAA']) {
+      studio.say({ type: 'studioConnect', accessToken });
+    }
+    await settle();
+
+    assert.deepEqual(studio.heard, [{ type: 'appReady' }]);
+    assert.equal(host?.isConnected, false);
+    host?.detach();
+  });
+
+  test('the zero-config mode refuses nobody, so it answers no refusals', async () => {
+    const studio = new FakeStudio();
+    const host = attachStudioBridge({ manifest, transport: studio });
+
+    studio.say({ type: 'studioConnect', accessToken: 'not.atoken' });
+    studio.say({
+      type: 'studioConnect',
+      accessToken: await tokenFor('https://someone-else.example.com', new Date(Date.now() - 1000)),
+    });
+    await waitFor(() => studio.of('manifest').length === 2, 'the manifests');
+
+    assert.deepEqual(studio.of('connectRefused'), []);
     host?.detach();
   });
 

--- a/js/studio-bridge/test/protocol.test.ts
+++ b/js/studio-bridge/test/protocol.test.ts
@@ -22,6 +22,17 @@ describe('the wire format matches the Dart implementation byte for byte', () => 
     );
   });
 
+  test('connectRefused', () => {
+    // The same string, character for character, as the golden in
+    // `packages/dartway_studio_bridge/test/studio_bridge_message_test.dart`.
+    // Note the envelope still says 4: a new message type is additive, and
+    // bumping the version would cut off every build in the field instead.
+    assert.equal(
+      encodeStudioBridgeMessage({ type: 'connectRefused' }),
+      '{"dartwayStudioBridge":4,"type":"connectRefused","payload":{}}',
+    );
+  });
+
   test('manifest — the handshake response', () => {
     assert.equal(
       encodeStudioBridgeMessage({
@@ -250,6 +261,10 @@ describe('decoding rejects foreign and malformed input', () => {
   });
 
   test('unknown message type', () => {
+    // Also the reason the protocol version stayed at 4 when `connectRefused`
+    // was added: an unknown *type* is dropped here, exactly as it would be on a
+    // build that predates the message — whereas an unknown *version* drops
+    // every message, in both directions, for every build in the field.
     assert.equal(
       decodeStudioBridgeMessage(
         `{"dartwayStudioBridge":${studioBridgeProtocol.version},"type":"bogus","payload":{}}`,
@@ -267,6 +282,7 @@ describe('decoding rejects foreign and malformed input', () => {
 test('every message type survives a round trip', () => {
   const messages: StudioBridgeMessage[] = [
     { type: 'appReady' },
+    { type: 'connectRefused' },
     { type: 'routeChanged', path: '/ad/1', routeName: 'adDetail' },
     { type: 'sessionChanged', session: { isSignedIn: true, userIdentifier: '1', isBusy: false } },
     {

--- a/js/studio-bridge/test/token.test.ts
+++ b/js/studio-bridge/test/token.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { before, describe, test } from 'node:test';
 
 import {
+  looksLikeStudioBridgeToken,
   studioSignedAccessValidator,
   studioSigningPublicKey,
   verifyStudioBridgeToken,
@@ -284,6 +285,42 @@ function captureConsole(): { messages: string[]; restore: () => void } {
     },
   };
 }
+
+describe('looksLikeStudioBridgeToken', () => {
+  test('recognises the shape of a real token', () => {
+    assert.equal(looksLikeStudioBridgeToken(validToken), true);
+  });
+
+  test('recognises an expired, foreign or forged one just the same — shape is all it reads', async () => {
+    const expired = await signToken({
+      signingKey: studioKeyPair.privateKey,
+      origin: 'https://someone-else.example.com',
+      expiresAt: new Date(Date.now() - 24 * 3600 * 1000),
+    });
+    assert.equal(looksLikeStudioBridgeToken(expired), true);
+    assert.equal(
+      await verifyStudioBridgeToken(expired, { appOrigin, publicKey: studioPublicKey }),
+      false,
+      'shape must never be mistaken for validity',
+    );
+  });
+
+  test('turns down anything that is not a token', () => {
+    const notTokens = [
+      '', // nothing presented at all
+      'not-a-token', // no segments
+      'a.b.c', // three of them
+      'aGk=.###', // a segment that is not base64url
+      'not.atoken', // two segments, neither one base64url json
+      'e30.AAAA', // a payload that parses, claiming nothing
+      '.AAAA', // an empty payload segment
+      'eyJvcmlnaW4iOiJodHRwczovL2EuYiJ9.AAAA', // origin, no expiry
+    ];
+    for (const value of notTokens) {
+      assert.equal(looksLikeStudioBridgeToken(value), false, `took "${value}" for a token`);
+    }
+  });
+});
 
 describe('studioSignedAccessValidator', () => {
   test('lets a valid token in and keeps everything else out', async () => {

--- a/packages/dartway_studio_bridge/CHANGELOG.md
+++ b/packages/dartway_studio_bridge/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## 0.8.0
+
+**The bridge can be asked whether it is there, and it can say no.** Two halves
+of one gap: there was no way to put the question without building a live
+preview, and no way to tell "this build carries no bridge" from "your signature
+was refused". Both came out as the same thing — an empty frame.
+
+**`probeStudioBridge(appUrl: …)` — one handshake and nothing else.** It answers
+with a `StudioHandshakeResult`:
+
+- `accepted` — the app answered and took the token;
+- `rejected` — the app answered and refused it (new, see below);
+- `silent` — nobody answered inside the timeout.
+
+The frame is opened and closed inside the call. That is the point of it:
+`StudioFrameController` hands out a *platform view*, so its iframe loads nothing
+until the embedder lays it out — a detached iframe never fetches its `src`, and
+no load means no handshake. Asking the question through the preview's own
+machinery therefore cost a 1×1 frame parked on screen for the lifetime of the
+app, which could be neither hidden nor moved off the viewport. The probe appends
+its own hidden container to the document instead, outside the widget tree, and
+takes it away again on the answer or on the timeout.
+
+`silent` is honestly several outcomes at once — no bridge in the build, a page
+that never loaded, a deployment that forbids being framed, or an older app
+refusing in silence. Cross-origin those are one silence and always will be; the
+distinctions come from checks made *before* the probe (is the page served? does
+it allow `frame-ancestors`?), and the doc comment says so, so nobody waits for
+`silent` to get sharper.
+
+Split in two so that the interesting half is testable: `runStudioHandshake`
+(the state machine, over any `StudioMessageChannel`) and `StudioProbeFrame` (the
+web element's lifecycle). All three outcomes are covered by tests; only the DOM
+is not, as with the other two transports.
+
+**A refused handshake gets an answer: `ConnectRefusedMessage`.** The host used
+to stay silent on refusal, deliberately — but that left the person connecting a
+project unable to tell a missing bridge from a stale key, which are two entirely
+different repairs.
+
+It is answered **only when the presented token parses as a signed Studio token**
+(`looksLikeStudioBridgeToken`) and then fails the check. An empty, absent or
+garbled token is still met with silence, so a stranger who guessed the preview
+URL does not learn that there is a bridge here. Studio signs correctly by
+construction, so what it gets back means "your signature is stale or your key is
+wrong". The zero-config local-dev mode accepts everyone and therefore refuses
+nobody.
+
+**No protocol version bump — 4 stays 4, and this is deliberate.** The version is
+checked strictly on decode, so bumping it would silence every build in the field
+in *both* directions the moment it shipped. A new message *type* is additive
+instead: an app that predates it never sends it, a probe reads that as `silent`
+— exactly what it read before — and a newer app hands back a diagnosis. The
+constant carries a note saying so; do not "fix" the version on this message's
+account.
+
+The same message and the same refusal rule ship in `@dartway/studio-bridge`
+0.2.0, held to this implementation by an identical golden wire string in both
+packages' tests.
+
 ## 0.7.1
 
 **The access gate now covers every command, which is what this package has been

--- a/packages/dartway_studio_bridge/README.md
+++ b/packages/dartway_studio_bridge/README.md
@@ -150,8 +150,16 @@ origin of the first valid Studio message for its replies.
 ## Access control
 
 The `studioConnect` handshake carries an `accessToken`; the host answers with
-its manifest only if `validateAccessToken` accepts it, otherwise it stays
-silent (Studio shows "not connected"). The gate covers every command, not just
+its manifest only if `validateAccessToken` accepts it. A refusal is answered
+with `ConnectRefusedMessage` — but **only when the token was a token**: it has
+to parse as a signed Studio token (`looksLikeStudioBridgeToken`) and then fail
+the check. An empty, absent or garbled one is met with silence as before, so a
+stranger who guessed the preview's URL learns nothing, while a Studio — which
+signs correctly by construction — is told that its signature is stale rather
+than left guessing whether the app has a bridge at all. A build in the
+zero-config mode accepts everyone and so refuses nobody.
+
+The gate covers every command, not just
 the manifest — otherwise an embedding page could walk the app through its
 screens without presenting anything. It covers the app's own reports too
 (`reportRoute`, `reportSession`, `reportLocale`, `reportFeatures`): they are
@@ -204,3 +212,35 @@ client.requestLocale('ru');
 
 The handshake is dual-initiated and survives reloads and hot restarts of either
 side. Protocol details live in `StudioBridgeProtocol`.
+
+## Asking one question (Studio side)
+
+Sometimes the question is not "preview this app" but "does this URL answer at
+all". `probeStudioBridge` performs a single handshake and returns what came
+back:
+
+```dart
+final result = await probeStudioBridge(
+  appUrl: 'https://feature-x.preview.example.com/',
+  accessToken: () => myTokenCache.tokenFor(project),
+);
+// accepted — the app took the token
+// rejected — the app answered and refused it: a stale signature or a foreign key
+// silent   — nobody answered inside the timeout
+```
+
+The frame is created and removed inside the call: nothing to render, nothing to
+hold on to. `StudioFrameController` cannot serve this — it hands out a platform
+view, so its iframe is not in the document until the embedder lays it out, and a
+detached iframe never fetches its `src`. No layout, no load, no handshake; the
+frame has to be *somewhere* on screen for the question to be asked at all. The
+probe owns its element instead, in a hidden container outside the widget tree.
+
+`silent` is several answers at once — no bridge in the build, a page that never
+loaded, a deployment that refuses to be framed, an older app refusing without a
+word. Cross-origin those cannot be told apart from here, and they never will be.
+Check that the URL serves a page, and that it permits `frame-ancestors`, as
+separate steps before this one.
+
+`runStudioHandshake(channel)` is the same state machine over a channel you
+already own — what the probe is with the frame taken out of it.

--- a/packages/dartway_studio_bridge/lib/dartway_studio_bridge.dart
+++ b/packages/dartway_studio_bridge/lib/dartway_studio_bridge.dart
@@ -23,5 +23,7 @@ export 'src/host/studio_bridge_host.dart';
 // Studio side.
 export 'src/client/studio_bridge_client.dart';
 export 'src/client/studio_bridge_event.dart';
+export 'src/client/studio_handshake_probe.dart';
 export 'src/transport/client/studio_frame_controller.dart';
+export 'src/transport/client/studio_probe_frame.dart';
 export 'src/transport/studio_message_channel.dart';

--- a/packages/dartway_studio_bridge/lib/src/access/studio_bridge_token.dart
+++ b/packages/dartway_studio_bridge/lib/src/access/studio_bridge_token.dart
@@ -96,6 +96,39 @@ Future<bool> verifyStudioBridgeToken(
   );
 }
 
+/// Whether [accessToken] is *shaped* like a token Studio signs — two base64url
+/// segments, the first of which decodes to a JSON object carrying an `origin`
+/// string and an integer `exp`. Nothing here is checked against a key, an
+/// origin or a clock: a forged token passes this and is still refused by
+/// [verifyStudioBridgeToken].
+///
+/// It exists to separate two refusals that are otherwise one. A token that
+/// parses came from something that knows the format — in practice, from Studio
+/// — so refusing it is worth *saying* (`ConnectRefusedMessage`): whoever sent
+/// it can be told their signature is stale rather than left to guess whether
+/// the bridge is there at all. Anything that does not parse is met with
+/// silence, so a stranger who guessed the preview's URL learns nothing.
+///
+/// A stranger who bothers to construct a well-formed token does learn that this
+/// page carries a bridge. That is the price of the diagnosis, it is bounded —
+/// nothing else crosses the bridge without a valid signature — and it was
+/// chosen deliberately over leaving a misconfigured Studio with no way to tell
+/// "the app has no bridge" from "the app rejected my key".
+bool looksLikeStudioBridgeToken(String accessToken) {
+  final segments = accessToken.split(_tokenSegmentSeparator);
+  if (segments.length != 2 || segments.any((s) => s.isEmpty)) return false;
+  try {
+    final claims =
+        jsonDecode(utf8.decode(_decodeSegment(segments.first))) as Object?;
+    _decodeSegment(segments.last);
+    return claims is Map<String, dynamic> &&
+        claims['origin'] is String &&
+        claims['exp'] is int;
+  } catch (_) {
+    return false;
+  }
+}
+
 /// The access-token check an app hands to `StudioBridgeHost.attach`: accept a
 /// connecting Studio only when it presents a token issued for [appOrigin] —
 /// this app's own public address — and signed by Studio's key.

--- a/packages/dartway_studio_bridge/lib/src/client/studio_handshake_probe.dart
+++ b/packages/dartway_studio_bridge/lib/src/client/studio_handshake_probe.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import '../protocol/studio_bridge_message.dart';
+import '../transport/client/studio_probe_frame.dart';
+import '../transport/studio_message_channel.dart';
+import 'studio_bridge_client.dart';
+
+/// What came back from one handshake — the three answers a preview cannot tell
+/// apart, because all three of them look like an empty frame.
+enum StudioHandshakeResult {
+  /// The app answered and took the token: there is a bridge here, and this
+  /// Studio may drive it.
+  accepted,
+
+  /// The app answered and refused the token it was shown. The token parsed, so
+  /// it came from something that knows the format — in practice from Studio
+  /// itself, which signs correctly. Read it as "the signature is stale or the
+  /// key is wrong", not as "the app is broken".
+  ///
+  /// Only apps built against a bridge that knows [ConnectRefusedMessage] send
+  /// this. An older one refuses in silence and shows up as [silent] — the same
+  /// answer it gave before this existed, which is the whole reason the protocol
+  /// version did not move.
+  rejected,
+
+  /// Nobody answered before the timeout, and this outcome is honestly several
+  /// at once: the app carries no bridge, the page never loaded, the deployment
+  /// forbids being framed, or it is an older build refusing in silence.
+  ///
+  /// **Those cannot be told apart from here.** Cross-origin, a frame that
+  /// stayed empty and a frame that loaded an app with nothing to say are the
+  /// same silence — the probe has no read access to what is inside. Whoever
+  /// needs the distinction gets it *before* this call, from steps that do not
+  /// involve the bridge: fetch the URL to see whether the page is served at
+  /// all, and check its `frame-ancestors` / `X-Frame-Options` to see whether
+  /// embedding is permitted. Do not expect [silent] to grow more precise later;
+  /// it is as precise as the browser lets it be.
+  silent,
+}
+
+/// One handshake with the app at [appUrl], and nothing else.
+///
+/// The frame is opened and closed inside: the caller neither renders it nor
+/// needs to know it exists. That is the point — the bridge's preview frame is a
+/// platform view, so it loads nothing until whoever embeds it lays it out, and
+/// asking "do you recognise me?" through it meant keeping a 1×1 frame parked on
+/// screen for the lifetime of the app. This owns its element instead.
+///
+/// One question, one token, one answer. [accessToken] is asked exactly once —
+/// a probe is a single connect attempt, however many times the message has to
+/// be repeated at a frame that is still loading — and nothing retries: an
+/// answer that has not arrived within [timeout] is [StudioHandshakeResult.silent].
+///
+/// Throws whatever [accessToken] throws. A supplier that cannot produce a token
+/// leaves the question unasked, and reporting that as silence would blame the
+/// app for something on this side.
+///
+/// Web only; on any other platform the underlying frame throws
+/// [UnsupportedError], as Studio runs on web.
+Future<StudioHandshakeResult> probeStudioBridge({
+  required String appUrl,
+  StudioAccessTokenSupplier? accessToken,
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final frame = openStudioProbeFrame(appUrl: appUrl);
+  try {
+    return await runStudioHandshake(
+      frame.channel,
+      accessToken: accessToken,
+      timeout: timeout,
+    );
+  } finally {
+    frame.dispose();
+  }
+}
+
+/// The handshake itself, over a [channel] somebody else owns and disposes —
+/// what [probeStudioBridge] is once the frame is taken out of it.
+///
+/// Presents a token, then waits for one of the three outcomes. The connect
+/// message is sent again on every `appReady`, because the ordinary case is
+/// racing a frame that has not finished loading: the app was not listening when
+/// the first one went out, and announces itself the moment it attaches.
+///
+/// Cancels its own subscription on the way out and leaves [channel] otherwise
+/// untouched.
+Future<StudioHandshakeResult> runStudioHandshake(
+  StudioMessageChannel channel, {
+  StudioAccessTokenSupplier? accessToken,
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final answer = Completer<StudioHandshakeResult>();
+  String? token;
+
+  final subscription = channel.messages.listen((message) {
+    if (answer.isCompleted) return;
+    switch (message) {
+      case ManifestMessage():
+        answer.complete(StudioHandshakeResult.accepted);
+      case ConnectRefusedMessage():
+        answer.complete(StudioHandshakeResult.rejected);
+      case AppReadyMessage():
+        // The app attached only now, so the connect below was spoken into an
+        // empty frame. Same token, same question, asked again to somebody who
+        // is finally there to hear it. (If the token has not arrived yet, the
+        // send that follows this listener covers the case anyway.)
+        if (token case final presented?) {
+          channel.send(StudioConnectMessage(accessToken: presented));
+        }
+      default:
+        break; // Studio → app messages echoed back, and reports we did not ask
+      // for, are none of a probe's business.
+    }
+  });
+
+  try {
+    // Awaited before the clock starts: [timeout] is how long the app is given
+    // to answer, not how long this side takes to produce a token.
+    token = await accessToken?.call() ?? '';
+    channel.send(StudioConnectMessage(accessToken: token));
+    return await answer.future.timeout(
+      timeout,
+      onTimeout: () => StudioHandshakeResult.silent,
+    );
+  } finally {
+    unawaited(subscription.cancel());
+  }
+}

--- a/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
+++ b/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../access/studio_bridge_token.dart';
 import '../models/studio_feature_info.dart';
 import '../models/studio_project_manifest.dart';
 import '../models/studio_session_state.dart';
@@ -127,12 +128,19 @@ class StudioBridgeHost {
 
   void _onMessage(StudioBridgeMessage message) {
     if (message case StudioConnectMessage(:final accessToken)) {
-      // Answer the handshake only if the token is accepted; on refusal stay
-      // silent — the app keeps running, Studio shows "not connected".
       _validateAccessToken(accessToken).then((accepted) {
-        if (!accepted) return;
-        _connected = true;
-        _sendManifest();
+        if (accepted) {
+          _connected = true;
+          _sendManifest();
+          return;
+        }
+        // A refusal is answered only when the token was one — see
+        // [looksLikeStudioBridgeToken] and [ConnectRefusedMessage]. Anything
+        // else (nothing presented, a guess, noise) is met with silence, as it
+        // always was: the app keeps running and the sender learns nothing.
+        if (looksLikeStudioBridgeToken(accessToken)) {
+          _channel.send(const ConnectRefusedMessage());
+        }
       });
       return;
     }

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
@@ -8,6 +8,31 @@ class AppReadyMessage extends StudioBridgeMessage {
   String get type => StudioBridgeProtocol.appReady;
 }
 
+/// App → Studio: the handshake was heard and refused — the token presented in
+/// [StudioConnectMessage] parsed as a signed Studio token and did not pass the
+/// app's check (expired, or signed by another key).
+///
+/// It carries no reason. Which of the two it was is Studio's to work out from
+/// the token it issued itself, and an app that spelled it out would be telling
+/// whoever asked how to get closer.
+///
+/// **Only a token that parses gets an answer.** An empty, absent or garbled
+/// token is still met with silence, so a stranger who guessed the preview's URL
+/// does not learn that there is a bridge here at all.
+///
+/// **This type was added without bumping the protocol version, on purpose**
+/// (see [StudioBridgeProtocol.version]). An app built before it exists simply
+/// never sends it, and a probe reads that as "no answer" — exactly what it read
+/// before this message existed. Newer apps hand back a diagnosis instead. Do
+/// not bump the version to "fix" this: that would cut off every build in the
+/// field in both directions, which is the opposite of what this buys.
+class ConnectRefusedMessage extends StudioBridgeMessage {
+  const ConnectRefusedMessage();
+
+  @override
+  String get type => StudioBridgeProtocol.connectRefused;
+}
+
 /// App → Studio: the handshake response — the full manifest plus the current
 /// route, session and locale so Studio renders correctly right away.
 class ManifestMessage extends StudioBridgeMessage {

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
@@ -43,6 +43,7 @@ sealed class StudioBridgeMessage {
             const {};
     return switch (decoded[StudioBridgeProtocol.typeKey]) {
       StudioBridgeProtocol.appReady => const AppReadyMessage(),
+      StudioBridgeProtocol.connectRefused => const ConnectRefusedMessage(),
       StudioBridgeProtocol.manifest => ManifestMessage.fromPayload(payload),
       StudioBridgeProtocol.routeChanged =>
         RouteChangedMessage.fromPayload(payload),

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_protocol.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_protocol.dart
@@ -13,6 +13,13 @@ abstract final class StudioBridgeProtocol {
   /// v4: `studioConnect` presents a short-lived `accessToken` — signed by
   /// Studio, issued for the app's own origin — instead of the shared
   /// per-project secret (`accessKey`) it used to carry.
+  ///
+  /// **Adding a message type is not a schema change and must not bump this.**
+  /// The version is checked strictly on decode, so a bump silences every build
+  /// already in the field, in both directions, the moment it ships. A new type
+  /// costs nothing instead: an old side drops the envelope it does not
+  /// recognise and carries on, which is how [connectRefused] arrived inside
+  /// v4. Bump only when the *meaning* of an existing message changes.
   static const version = 4;
 
   /// Envelope marker key carrying [version].
@@ -29,6 +36,11 @@ abstract final class StudioBridgeProtocol {
   static const featuresChanged = 'featuresChanged';
   static const localeChanged = 'localeChanged';
   static const inspectPointResult = 'inspectPointResult';
+
+  /// The refusal of a handshake: the app heard [studioConnect], understood the
+  /// token it carried, and would not accept it. Added *inside* version 4 — see
+  /// [version] for why adding a type is not a schema change.
+  static const connectRefused = 'connectRefused';
 
   // Studio → app.
   static const studioConnect = 'studioConnect';

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_client_web_channel.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_client_web_channel.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:web/web.dart' as web;
+
+import '../../protocol/studio_bridge_message.dart';
+import '../studio_message_channel.dart';
+
+/// The Studio-side channel to an app in an iframe: `window` message events,
+/// filtered down to bridge messages that really came from that frame.
+///
+/// Shared by everything on this side that owns a frame — the long-lived preview
+/// (`StudioFrameController`) and the one-shot probe — so that the filtering is
+/// written once. Two copies of it would be two chances to forget the source
+/// check, and the one that forgot would accept messages from any page that
+/// happens to sit on the app's origin.
+class StudioClientWebChannel implements StudioMessageChannel {
+  StudioClientWebChannel(this._frame, this._appOrigin) {
+    _jsListener = _onMessageEvent.toJS;
+    web.window.addEventListener('message', _jsListener);
+  }
+
+  final web.HTMLIFrameElement _frame;
+  final String _appOrigin;
+  final _controller = StreamController<StudioBridgeMessage>.broadcast();
+  late final JSFunction _jsListener;
+
+  @override
+  Stream<StudioBridgeMessage> get messages => _controller.stream;
+
+  void _onMessageEvent(web.Event event) {
+    if (!event.isA<web.MessageEvent>()) return;
+    event as web.MessageEvent;
+    if (event.origin != _appOrigin) return;
+    final appWindow = _frame.contentWindow;
+    if (appWindow == null ||
+        event.source == null ||
+        !(event.source as JSObject)
+            .strictEquals(appWindow as JSObject)
+            .toDart) {
+      return;
+    }
+    final data = event.data;
+    if (data == null || !data.isA<JSString>()) return;
+    final message = StudioBridgeMessage.tryDecode((data as JSString).toDart);
+    if (message == null) return;
+    _controller.add(message);
+  }
+
+  @override
+  void send(StudioBridgeMessage message) {
+    _frame.contentWindow?.postMessage(message.encode().toJS, _appOrigin.toJS);
+  }
+
+  @override
+  void dispose() {
+    web.window.removeEventListener('message', _jsListener);
+    _controller.close();
+  }
+}

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_web.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_web.dart
@@ -1,11 +1,9 @@
-import 'dart:async';
-import 'dart:js_interop';
 import 'dart:ui_web' as ui_web;
 
 import 'package:web/web.dart' as web;
 
-import '../../protocol/studio_bridge_message.dart';
 import '../studio_message_channel.dart';
+import 'studio_client_web_channel.dart';
 import 'studio_frame_controller.dart';
 
 int _instanceCounter = 0;
@@ -15,8 +13,7 @@ StudioFrameController createStudioFrameController({required String appUrl}) =>
 
 class _StudioFrameControllerWeb implements StudioFrameController {
   _StudioFrameControllerWeb(String appUrl)
-      : _appOrigin = Uri.parse(appUrl).origin,
-        viewType = 'dartway-studio-frame-${_instanceCounter++}' {
+      : viewType = 'dartway-studio-frame-${_instanceCounter++}' {
     _frame = web.document.createElement('iframe') as web.HTMLIFrameElement
       ..src = appUrl;
     _frame.style
@@ -27,12 +24,11 @@ class _StudioFrameControllerWeb implements StudioFrameController {
       viewType,
       (int viewId) => _frame,
     );
-    _channel = _StudioClientWebChannel(_frame, _appOrigin);
+    _channel = StudioClientWebChannel(_frame, Uri.parse(appUrl).origin);
   }
 
-  final String _appOrigin;
   late final web.HTMLIFrameElement _frame;
-  late final _StudioClientWebChannel _channel;
+  late final StudioClientWebChannel _channel;
 
   @override
   final String viewType;
@@ -42,50 +38,4 @@ class _StudioFrameControllerWeb implements StudioFrameController {
 
   @override
   void dispose() => _channel.dispose();
-}
-
-class _StudioClientWebChannel implements StudioMessageChannel {
-  _StudioClientWebChannel(this._frame, this._appOrigin) {
-    _jsListener = _onMessageEvent.toJS;
-    web.window.addEventListener('message', _jsListener);
-  }
-
-  final web.HTMLIFrameElement _frame;
-  final String _appOrigin;
-  final _controller = StreamController<StudioBridgeMessage>.broadcast();
-  late final JSFunction _jsListener;
-
-  @override
-  Stream<StudioBridgeMessage> get messages => _controller.stream;
-
-  void _onMessageEvent(web.Event event) {
-    if (!event.isA<web.MessageEvent>()) return;
-    event as web.MessageEvent;
-    if (event.origin != _appOrigin) return;
-    final appWindow = _frame.contentWindow;
-    if (appWindow == null ||
-        event.source == null ||
-        !(event.source as JSObject)
-            .strictEquals(appWindow as JSObject)
-            .toDart) {
-      return;
-    }
-    final data = event.data;
-    if (data == null || !data.isA<JSString>()) return;
-    final message = StudioBridgeMessage.tryDecode((data as JSString).toDart);
-    if (message == null) return;
-    _controller.add(message);
-  }
-
-  @override
-  void send(StudioBridgeMessage message) {
-    _frame.contentWindow
-        ?.postMessage(message.encode().toJS, _appOrigin.toJS);
-  }
-
-  @override
-  void dispose() {
-    web.window.removeEventListener('message', _jsListener);
-    _controller.close();
-  }
 }

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame.dart
@@ -1,0 +1,25 @@
+import '../studio_message_channel.dart';
+
+export 'studio_probe_frame_stub.dart'
+    if (dart.library.js_interop) 'studio_probe_frame_web.dart';
+
+/// A frame nobody has to render: opened into a hidden container of its own,
+/// outside the host framework's widget tree, and closed again by whoever opened
+/// it.
+///
+/// This is the difference from [StudioFrameController], which hands out a
+/// platform view for the embedder to lay out — and therefore loads nothing
+/// until the embedder does. An iframe that is not in the document does not
+/// fetch its `src`, so no load means no handshake, which is why asking the
+/// question through the preview's own machinery costs a 1×1 frame parked in a
+/// corner of the screen for the lifetime of the app.
+///
+/// Create instances via `openStudioProbeFrame` from the compile-time
+/// implementation; the non-web stub throws, as Studio runs on web only.
+abstract interface class StudioProbeFrame {
+  /// Channel to the app inside the frame (origin-locked to the app URL).
+  StudioMessageChannel get channel;
+
+  /// Closes the channel and takes the frame back out of the document.
+  void dispose();
+}

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_stub.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_stub.dart
@@ -1,0 +1,7 @@
+import 'studio_probe_frame.dart';
+
+/// The Studio client loads an app in an iframe — web only.
+StudioProbeFrame openStudioProbeFrame({required String appUrl}) =>
+    throw UnsupportedError(
+      'StudioProbeFrame is only available in web builds',
+    );

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_web.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_web.dart
@@ -1,0 +1,59 @@
+import 'package:web/web.dart' as web;
+
+import '../studio_message_channel.dart';
+import 'studio_client_web_channel.dart';
+import 'studio_probe_frame.dart';
+
+StudioProbeFrame openStudioProbeFrame({required String appUrl}) =>
+    _StudioProbeFrameWeb(appUrl);
+
+class _StudioProbeFrameWeb implements StudioProbeFrame {
+  _StudioProbeFrameWeb(String appUrl) {
+    _frame = web.document.createElement('iframe') as web.HTMLIFrameElement
+      ..src = appUrl;
+    _frame.style
+      ..border = 'none'
+      ..width = '1px'
+      ..height = '1px';
+
+    // The frame lives in a container of ours, appended straight to the body:
+    // the probe owns the element outright, so there is no "has the embedder
+    // laid it out yet" to wait on.
+    //
+    // Hidden, but not by any means that would stop the load. `display: none`
+    // and `visibility: hidden` are exactly that — a browser is free to skip
+    // fetching a frame it will not paint, and a frame that never loads never
+    // answers, which would turn every probe into a timeout. Zero opacity over
+    // one pixel, pinned out of the flow and deaf to the pointer, is a frame
+    // that loads and runs while being neither seen nor reachable.
+    _container = web.document.createElement('div') as web.HTMLDivElement;
+    _container.style
+      ..position = 'fixed'
+      ..left = '0'
+      ..top = '0'
+      ..width = '1px'
+      ..height = '1px'
+      ..overflow = 'hidden'
+      ..opacity = '0'
+      ..pointerEvents = 'none'
+      ..zIndex = '-1';
+    _container.appendChild(_frame);
+    (web.document.body ?? web.document.documentElement!)
+        .appendChild(_container);
+
+    _channel = StudioClientWebChannel(_frame, Uri.parse(appUrl).origin);
+  }
+
+  late final web.HTMLIFrameElement _frame;
+  late final web.HTMLDivElement _container;
+  late final StudioClientWebChannel _channel;
+
+  @override
+  StudioMessageChannel get channel => _channel;
+
+  @override
+  void dispose() {
+    _channel.dispose();
+    _container.remove();
+  }
+}

--- a/packages/dartway_studio_bridge/pubspec.yaml
+++ b/packages/dartway_studio_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_studio_bridge
 description: "Open bridge between a DartWay app and DartWay Studio: in-code screen spec registry models and the runtime postMessage protocol."
-version: 0.7.1
+version: 0.8.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -22,3 +22,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  # The probe's timeout is one of its three answers, so a test has to be able to
+  # reach it without waiting for a real clock — or without trusting one.
+  fake_async: ^1.3.0

--- a/packages/dartway_studio_bridge/test/studio_bridge_host_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_host_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -71,6 +72,19 @@ const _manifest = StudioProjectManifest(
 /// than about signatures — those have a file of their own.
 Future<bool> _acceptsOnly(String accessToken) async => accessToken == 'good';
 
+/// Shaped exactly like a token Studio signs — two base64url segments, the first
+/// carrying an `origin` and an `exp` — and signed by nobody. Refusing it is
+/// what a stale or foreign signature looks like from the host's side.
+String _wellFormedToken() {
+  final payload = base64Url
+      .encode(utf8.encode(jsonEncode({
+        'origin': 'https://app.example.com',
+        'exp': 1765540000,
+      })))
+      .replaceAll('=', '');
+  return '$payload.${base64Url.encode(List.filled(64, 7)).replaceAll('=', '')}';
+}
+
 void main() {
   late _FakeStudio studio;
   late _RecordingDelegate delegate;
@@ -127,13 +141,51 @@ void main() {
     expect(host.isConnected, isTrue);
   });
 
-  test('a refused token is answered with silence', () async {
-    final host = attach();
-    studio.say(const StudioConnectMessage(accessToken: 'forged'));
-    await pumpEventQueue();
+  group('a refused token', () {
+    test('gets no manifest, whatever it looked like', () async {
+      final host = attach();
+      studio.say(const StudioConnectMessage(accessToken: 'forged'));
+      studio.say(StudioConnectMessage(accessToken: _wellFormedToken()));
+      await pumpEventQueue();
 
-    expect(studio.of<ManifestMessage>(), isEmpty);
-    expect(host.isConnected, isFalse);
+      expect(studio.of<ManifestMessage>(), isEmpty);
+      expect(host.isConnected, isFalse);
+    });
+
+    test('is told so when it was a token — Studio signs correctly, so a '
+        'refusal it can read means its signature is stale', () async {
+      attach();
+      studio.say(StudioConnectMessage(accessToken: _wellFormedToken()));
+      await pumpEventQueue();
+
+      expect(studio.of<ConnectRefusedMessage>(), hasLength(1));
+    });
+
+    test('is met with silence when it was not — a stranger who guessed the '
+        'URL does not learn that there is a bridge here', () async {
+      attach();
+      studio.say(const StudioConnectMessage(accessToken: 'forged'));
+      studio.say(const StudioConnectMessage(accessToken: ''));
+      // Two segments, and neither of them a token.
+      studio.say(const StudioConnectMessage(accessToken: 'not.atoken'));
+      // Shaped right, but claiming nothing: no origin, no expiry.
+      studio.say(const StudioConnectMessage(accessToken: 'e30.AAAA'));
+      await pumpEventQueue();
+
+      expect(studio.heard, [isA<AppReadyMessage>()]);
+    });
+
+    test('does not open the gate by being answered', () async {
+      final host = attach();
+      studio.say(StudioConnectMessage(accessToken: _wellFormedToken()));
+      await pumpEventQueue();
+
+      studio.say(const NavigateRequestMessage('/admin'));
+      await pumpEventQueue();
+
+      expect(delegate.done, isEmpty);
+      expect(host.isConnected, isFalse);
+    });
   });
 
   group('the gate covers every command, not just the manifest', () {

--- a/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
@@ -16,6 +16,13 @@ void main() {
       expect(_roundTrip(const AppReadyMessage()), isA<AppReadyMessage>());
     });
 
+    test('connectRefused', () {
+      expect(
+        _roundTrip(const ConnectRefusedMessage()),
+        isA<ConnectRefusedMessage>(),
+      );
+    });
+
     test('studioConnect carries the access token', () {
       final decoded =
           _roundTrip(const StudioConnectMessage(accessToken: 'abc'));
@@ -207,6 +214,32 @@ void main() {
       const AppReadyMessage().encode(),
       contains('"${StudioBridgeProtocol.envelopeKey}":'
           '${StudioBridgeProtocol.version}'),
+    );
+  });
+
+  test('connectRefused goes on the wire exactly as the JS package writes it',
+      () {
+    // The literal below is the same string, character for character, as the
+    // golden in `js/studio-bridge/test/protocol.test.ts`. The two
+    // implementations share no schema — only this — and an app on either of
+    // them talks to a Studio that was never told which it is.
+    expect(
+      const ConnectRefusedMessage().encode(),
+      '{"dartwayStudioBridge":4,"type":"connectRefused","payload":{}}',
+    );
+  });
+
+  test('an old build that never heard of connectRefused just drops it', () {
+    // The reason the protocol version stayed at 4: an unknown *type* falls
+    // through to null here, exactly as it would on a build that predates this
+    // message — whereas an unknown *version* would drop every message, in both
+    // directions, for every build in the field.
+    expect(
+      StudioBridgeMessage.tryDecode(
+        '{"dartwayStudioBridge":${StudioBridgeProtocol.version},'
+        '"type":"somethingAddedLater","payload":{}}',
+      ),
+      isNull,
     );
   });
 }

--- a/packages/dartway_studio_bridge/test/studio_bridge_token_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_token_test.dart
@@ -180,6 +180,51 @@ void main() {
     });
   });
 
+  group('looksLikeStudioBridgeToken', () {
+    test('recognises the shape of a real token', () async {
+      expect(looksLikeStudioBridgeToken(validToken), isTrue);
+    });
+
+    test('recognises one that is expired, foreign or forged just the same — '
+        'shape is all it reads', () async {
+      final expired = await _signToken(
+        signingKeyPair: studioKeyPair,
+        origin: 'https://someone-else.example.com',
+        expiresAt: DateTime.now().subtract(const Duration(days: 1)),
+      );
+      expect(looksLikeStudioBridgeToken(expired), isTrue);
+      expect(
+        await verifyStudioBridgeToken(
+          expired,
+          appOrigin: appOrigin,
+          publicKey: studioPublicKey,
+        ),
+        isFalse,
+        reason: 'shape must never be mistaken for validity',
+      );
+    });
+
+    test('turns down anything that is not a token', () {
+      const notTokens = [
+        '', // nothing presented at all
+        'not-a-token', // no segments
+        'a.b.c', // three of them
+        'aGk=.###', // a segment that is not base64url
+        'not.atoken', // two segments, neither one base64url json
+        'e30.AAAA', // a payload that parses, claiming nothing
+        '.AAAA', // an empty payload segment
+        'eyJvcmlnaW4iOiJodHRwczovL2EuYiJ9.AAAA', // origin, no expiry
+      ];
+      for (final value in notTokens) {
+        expect(
+          looksLikeStudioBridgeToken(value),
+          isFalse,
+          reason: 'took "$value" for a token',
+        );
+      }
+    });
+  });
+
   group('studioSignedAccessValidator', () {
     test('lets a valid token in and keeps everything else out', () async {
       final validator = studioSignedAccessValidator(

--- a/packages/dartway_studio_bridge/test/studio_handshake_probe_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_handshake_probe_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+
+import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The app at the other end of the probe. Everything it hears and says crosses
+/// the wire first — encoded and decoded exactly as the real channel would — so
+/// nothing passes here that would not survive `postMessage`.
+class _FakeApp implements StudioMessageChannel {
+  final _incoming = StreamController<StudioBridgeMessage>.broadcast();
+  final heard = <StudioBridgeMessage>[];
+  bool disposed = false;
+
+  @override
+  Stream<StudioBridgeMessage> get messages => _incoming.stream;
+
+  @override
+  void send(StudioBridgeMessage message) {
+    final decoded = StudioBridgeMessage.tryDecode(message.encode());
+    expect(decoded, isNotNull);
+    heard.add(decoded!);
+  }
+
+  @override
+  void dispose() {
+    disposed = true;
+    _incoming.close();
+  }
+
+  void say(StudioBridgeMessage message) {
+    final decoded = StudioBridgeMessage.tryDecode(message.encode());
+    expect(decoded, isNotNull);
+    _incoming.add(decoded!);
+  }
+
+  Iterable<T> of<T extends StudioBridgeMessage>() => heard.whereType<T>();
+}
+
+void main() {
+  late _FakeApp app;
+
+  setUp(() => app = _FakeApp());
+  tearDown(() => app.dispose());
+
+  const manifest = StudioProjectManifest(projectName: 'Demo', zones: []);
+  const manifestAnswer = ManifestMessage(
+    manifest: manifest,
+    currentPath: '/schedule',
+    session: StudioSessionState.signedOut,
+  );
+
+  /// Runs the handshake and answers it once the connect has actually arrived,
+  /// the way an app that is already loaded would.
+  Future<StudioHandshakeResult> probe(
+    void Function() answer, {
+    StudioAccessTokenSupplier? accessToken,
+    Duration timeout = const Duration(seconds: 5),
+  }) {
+    final result = runStudioHandshake(
+      app,
+      accessToken: accessToken,
+      timeout: timeout,
+    );
+    return pumpEventQueue().then((_) {
+      answer();
+      return result;
+    });
+  }
+
+  test('the manifest means the token was accepted', () async {
+    expect(
+      await probe(() => app.say(manifestAnswer)),
+      StudioHandshakeResult.accepted,
+    );
+  });
+
+  test('a refusal means the app is there and would not have us', () async {
+    expect(
+      await probe(() => app.say(const ConnectRefusedMessage())),
+      StudioHandshakeResult.rejected,
+    );
+  });
+
+  test('no answer at all is silence, not a hang', () {
+    // The channel is built inside the fake zone on purpose: a stream created
+    // outside it delivers on the real clock, and half of this test would then
+    // be waiting on a queue `elapse` cannot reach.
+    fakeAsync((async) {
+      final silentApp = _FakeApp();
+      StudioHandshakeResult? result;
+      unawaited(
+        runStudioHandshake(silentApp, timeout: const Duration(seconds: 10))
+            .then((value) => result = value),
+      );
+
+      async.elapse(const Duration(seconds: 9));
+      expect(result, isNull, reason: 'gave up before the timeout was out');
+
+      async.elapse(const Duration(seconds: 2));
+      expect(result, StudioHandshakeResult.silent);
+      silentApp.dispose();
+    });
+  });
+
+  test('the token presented is the one the supplier handed over', () async {
+    await probe(
+      () => app.say(manifestAnswer),
+      accessToken: () async => 'a-token',
+    );
+
+    expect(app.of<StudioConnectMessage>().single.accessToken, 'a-token');
+  });
+
+  test('no supplier presents nothing, which only local dev accepts', () async {
+    await probe(() => app.say(manifestAnswer));
+
+    expect(app.of<StudioConnectMessage>().single.accessToken, '');
+  });
+
+  test('a supplier that fails leaves the question unasked', () async {
+    await expectLater(
+      runStudioHandshake(app, accessToken: () => throw StateError('no token')),
+      throwsStateError,
+    );
+
+    expect(app.heard, isEmpty);
+  });
+
+  test('an app that announces itself late is asked again', () async {
+    // The ordinary case: the frame is still loading, so the first connect is
+    // spoken into an empty page and only the second one is heard.
+    final result = runStudioHandshake(app, accessToken: () => 'a-token');
+    await pumpEventQueue();
+    expect(app.of<StudioConnectMessage>(), hasLength(1));
+
+    app.say(const AppReadyMessage());
+    await pumpEventQueue();
+    expect(
+      app.of<StudioConnectMessage>().map((m) => m.accessToken),
+      ['a-token', 'a-token'],
+      reason: 'the app that just attached was never asked',
+    );
+
+    app.say(manifestAnswer);
+    expect(await result, StudioHandshakeResult.accepted);
+  });
+
+  test('the clock starts when the question is asked, not before', () {
+    fakeAsync((async) {
+      final slowApp = _FakeApp();
+      final slowToken = Completer<String>();
+      StudioHandshakeResult? result;
+      unawaited(
+        runStudioHandshake(
+          slowApp,
+          accessToken: () => slowToken.future,
+          timeout: const Duration(seconds: 10),
+        ).then((value) => result = value),
+      );
+
+      // A supplier that takes its time must not eat the app's answer window.
+      async.elapse(const Duration(seconds: 30));
+      expect(result, isNull);
+      expect(slowApp.of<StudioConnectMessage>(), isEmpty);
+
+      slowToken.complete('a-token');
+      async.flushMicrotasks();
+      expect(slowApp.of<StudioConnectMessage>(), hasLength(1));
+
+      async.elapse(const Duration(seconds: 11));
+      expect(result, StudioHandshakeResult.silent);
+      slowApp.dispose();
+    });
+  });
+
+  test('reports the probe never asked for are not answers', () async {
+    final result = runStudioHandshake(app, timeout: const Duration(seconds: 5));
+    await pumpEventQueue();
+
+    app.say(const RouteChangedMessage('/ad/123'));
+    app.say(const LocaleChangedMessage('ru'));
+    app.say(const SessionChangedMessage(StudioSessionState.signedOut));
+    await pumpEventQueue();
+
+    app.say(const ConnectRefusedMessage());
+    expect(await result, StudioHandshakeResult.rejected);
+  });
+
+  test('the channel is left for its owner to dispose', () async {
+    await probe(() => app.say(manifestAnswer));
+    expect(app.disposed, isFalse);
+  });
+}

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -320,7 +320,7 @@ packages:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.7.1"
+    version: "0.8.0"
   dbus:
     dependency: transitive
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
 
   dartway_serverpod_core_flutter: ^0.7.0
 
-  dartway_studio_bridge: ^0.7.0
+  dartway_studio_bridge: ^0.8.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Two halves of one gap, so they travel together. The bridge could not be asked
whether it recognises you without building a live preview, and it could not tell
you that it heard you and said no. Both arrive as the same thing: an empty
frame.

## Part 1 — `probeStudioBridge`, one handshake and nothing else

```dart
switch (await probeStudioBridge(appUrl: url, accessToken: supplier)) {
  StudioHandshakeResult.accepted => 'connected',
  StudioHandshakeResult.rejected => 'the signature was refused',
  StudioHandshakeResult.silent   => 'no answer',
}
```

The frame is opened and removed inside the call — nothing to render, nothing to
know about. That is the whole point. `StudioFrameController` hands out a
*platform view*, so its iframe is not in the document until the embedder lays it
out, and a detached iframe never fetches its `src`: no layout means no load
means no handshake. Asking this question through the preview's own machinery
therefore forced the embedding side to keep a 1×1 frame parked in a corner of
the screen, which could be neither hidden (`display:none` may skip the fetch)
nor moved off the viewport. The probe appends a hidden container of its own to
the document, outside the Flutter tree, where "has the widget been laid out yet"
does not arise — we own the element.

The other missing half was semantic: `StudioBridgeClient` is built for a
long-lived preview (a subscription plus a periodic retry timer), with no
one-shot "ask once, tell me the answer" anywhere, so every caller had to invent
its own timeout and its own moment to give up.

**Split in two, or there would be nothing to test.** `runStudioHandshake` is the
state machine over any `StudioMessageChannel` — accepted / rejected / silent —
and `StudioProbeFrame` is the thin web element lifecycle. The first is covered
by ordinary tests with a fake channel, all three outcomes included, plus the
awkward cases: the token is asked for once, a supplier that throws leaves the
question unasked rather than blaming the app, the connect is re-sent on
`appReady` (the ordinary case is racing a frame that has not finished loading),
and the timeout clock starts when the question is asked, not when the supplier
is called. Only the DOM is uncovered, as with the two existing transports.

`silent` is honestly several outcomes at once — no bridge in the build, a page
that never loaded, a deployment that forbids being framed, an older app refusing
in silence. Cross-origin those are one silence and always will be. The doc
comment says so outright and points at the checks that *do* separate them (is
the page served? does it permit `frame-ancestors`?), as steps before the probe —
otherwise the next reader waits for `silent` to grow more precise.

## Part 2 — the host answers a refusal, in both implementations

New app → Studio message: `connectRefused`. It is sent **only when the presented
token parses as a signed Studio token** (`looksLikeStudioBridgeToken` — shape
only, no key, no clock) and then fails the check. An empty, garbled or absent
token keeps its silence, so a stranger who guessed the preview's URL does not
learn there is a bridge on this page. Studio signs correctly by construction, so
a refusal it can read means "your signature is stale or your key is wrong" — a
different repair from "this build has no bridge", which is the distinction that
did not exist before. The zero-config local-dev mode accepts everyone and
therefore refuses nobody.

**The protocol version stays 4, deliberately.** It is checked strictly on decode
(`studio_bridge_message.dart:38`, `messages.ts:225`), so 4→5 would silence every
build in the field in *both* directions the moment it shipped. A new *type* is
additive: an unknown one is dropped by the decoder and falls through the
dispatcher's `default:`. An old app never sends `connectRefused`, so a probe
against it returns `silent` — exactly what it returned before this existed — and
a new one hands back a diagnosis. Soft degradation. Both `version` constants now
carry that rule in their doc comments, so the next reader does not "fix" it.

Implemented in both halves of the contract. They share no schema, only golden
wire strings, so both test suites now pin the same literal, character for
character:

```
{"dartwayStudioBridge":4,"type":"connectRefused","payload":{}}
```

plus, on each side, a test that the host answers a well-formed-but-invalid token
and stays silent on garbage.

## Incidentally

The Studio-side web channel (`window` message filtering, origin *and* source
check) moved out of `studio_frame_controller_web.dart` into
`studio_client_web_channel.dart`, shared with the probe frame. Two copies would
have been two chances to forget the source check, and the copy that forgot would
accept messages from any page sitting on the app's origin.

## Synchronisation law

- `dartway_studio_bridge` 0.7.1 → **0.8.0** + CHANGELOG.
- `@dartway/studio-bridge` 0.1.0 → **0.2.0** + CHANGELOG (and the lockfile).
- `docs/6-studio/studio-bridge.md` — the probe and the refusal.
- `example/` and `template/` carry `studio_bridge_binding` but touch none of the
  changed API. Their carets on `dartway_studio_bridge` moved `^0.7.0` → `^0.8.0`
  — the trap #58 documented: the `dependency_overrides` block means pub never
  reads that constraint here, so a stranger's tree is the first place it is
  evaluated for real. Both build for web (which is what compiles the new
  conditional-import files at all).
- `toolkit/` mentions none of this API; nothing to update there.

## Sixth mirror — the Studio side, not touched

The contract has two sides and the other one lives in `dartway/dartway_studio`.
The protocol is extended additively, so **Studio keeps working with no changes
at all**. What it gains is the ability to stop working around this: that
repository currently carries
`app/projects/settings/widgets/bridge_probe_frame.dart` — a 1×1
`HtmlElementView` whose own doc comment describes precisely the problem this PR
removes ("an iframe that is not in the document does not load its address") —
driven by `bridge_probe_session.dart`. Both can go, and "not connected" can
become "the signature was refused" where that is what happened. I have not
reached into that repository.

Verified: `dart analyze --fatal-infos` clean over the tree (3 pre-existing
issues, all in serverpod-generated or serverpod-owned code, none in this diff);
`flutter test` 87/87 in `dartway_studio_bridge`; `npm run check` (typecheck +
69 tests + build) in `js/studio-bridge`; `flutter build web` green for both
example and template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
