### PR TITLE
fix(core)!: a delivery that failed reaches the caller, not just the zone

### DIFF
--- a/docs/2-core/crud-configs.md
+++ b/docs/2-core/crud-configs.md
@@ -98,7 +98,7 @@ The order, exactly as `DwSaveConfig.save` runs it:
 | 3 | `beforeSaveTransaction` | `Future<String?>` | **inside** the transaction |
 | 4 | *insert / update* | — | inside the transaction |
 | 5 | `afterSaveTransaction` | `Future<String?>` | inside the transaction |
-| 6 | `afterSaveTransform` | `Future<void>` | after commit |
+| 6 | `afterSaveTransform` | `Future<String?>` | after commit |
 | 7 | `afterSaveSideEffects` | `Future<void>` | after commit, not awaited |
 
 All seven share one signature — `(Session session, DwSaveContext<T> saveContext)`. There is no
@@ -107,10 +107,28 @@ All seven share one signature — `(Session session, DwSaveContext<T> saveContex
 extra models the client should refresh.
 
 **Rejecting.** `allowSave` returning anything but `true` produces `DwApiResponse.forbidden()` — the
-fixed text `Not enough permissions`. The three `String?` hooks reject by returning the message,
-which reaches the user verbatim; returning `null` lets the save proceed. Rejection from inside the
+fixed text `Not enough permissions`. The four `String?` hooks reject by returning the message, which
+reaches the user verbatim; returning `null` lets the save proceed. Rejection from inside the
 transaction rolls it back, including from `afterSaveTransaction` — a rule discovered after the write
 still undoes it.
+
+`afterSaveTransform` is the exception, and the one place where rejecting and undoing come apart: it
+runs after the commit, so its message reaches the caller while **the row stays written**. That is
+the intended trade — deleting a committed row to report a failed email is worse — and it is why a
+hook there should be written so that a retry is harmless. Rejecting there does stop what follows:
+step 7 does not run and `broadcastTo` sends nothing, since announcing a change to other screens
+while answering the caller with an error would be the less coherent of the two.
+
+**Steps 6 and 7 differ by audience, not by timing.** Both run after the commit; only step 6 is
+awaited, and only step 6 can answer. Nothing that happens in `afterSaveSideEffects` can reach the
+caller, its failure included: by the time it throws, the response has been built and says `isOk`.
+The throw is reported to `DwAlerts` with the model's name and the stack trace, so the operator hears
+it — and that is the whole of its audience.
+
+So the question to ask is who needs to know. A push notification nobody misses if it is late →
+step 7. A verification code, a payment handed to a provider, anything whose failure changes what the
+user should do next → step 6, where the failure comes back as an error. The price is real and worth
+naming: step 6 makes the caller wait for whatever it calls out to.
 
 **Why three rejection points and not one.** Steps 1–2 run *before* the transaction opens, against
 the database as it was a moment ago. A rule that guards a shared count — seats left, stock on hand,

--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.8.0
+  dartway_serverpod_core_client: ^0.9.0
 
   # The client half of the optional push module. Required because the generated
   # protocol imports it — the server consumes the module, so its `Caller` shows

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -306,21 +306,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_studio_bridge:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.8.0
+  dartway_serverpod_core_flutter: ^0.9.0
 
   dartway_studio_bridge: ^0.8.0
 

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -134,14 +134,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   ffi:
     dependency: transitive
     description:

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.8.0
+  dartway_serverpod_core_server: ^0.9.0
 
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.

--- a/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
+++ b/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
@@ -1,0 +1,202 @@
+import 'package:dartway_example_server/src/generated/protocol.dart';
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+const _identifier = '+70000000042';
+
+/// The core this suite booted. The example app keeps its own `dw` handle, set
+/// by `initDartwayCore`; these tests build the core themselves to control the
+/// sender, so they hold their own.
+late DwCore<UserProfile> _dw;
+
+/// The sender the booted config delegates to. `DwCore` is a singleton and
+/// refuses a second initialisation, so a test swaps the sender here rather than
+/// by rebooting the core.
+late Future<void> Function(String verificationCode) _sendVerificationCode;
+
+/// What the sign-in response says when delivery fails.
+///
+/// Sending the code is the only thing the caller asked for, so a delivery that
+/// did not happen has to travel back with the response. For a long time it did
+/// not: the send hung in `afterSaveSideEffects`, which nobody awaits, so the
+/// screen said "code sent" for a code nobody sent.
+void main() {
+  withServerpod(
+    'Given a verification code sender',
+    (sessionBuilder, endpoints) {
+      late Session session;
+
+      setUpAll(_bootDartway);
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        await _wipeAuthTables(session);
+        await UserProfile.db.insertRow(
+          session,
+          UserProfile(
+            userIdentifier: _identifier,
+            phone: _identifier,
+            firstName: 'Delivery',
+            agreedForMarketingCommunications: false,
+            conditionsAcceptedAt: DateTime.now().toUtc(),
+          ),
+        );
+      });
+
+      tearDown(() async => _wipeAuthTables(session));
+
+      test('one that delivers leaves the sign-in ok', () async {
+        var sent = 0;
+        _sendVerificationCode = (code) async => sent++;
+
+        final response = await _openLoginRequest(session);
+
+        expect(response.isOk, isTrue);
+        expect(sent, 1);
+      });
+
+      test('one that throws turns the sign-in into an error response', () async {
+        _sendVerificationCode = (code) async =>
+            throw StateError('550 sender address is not verified');
+
+        final response = await _openLoginRequest(session);
+
+        expect(response.isOk, isFalse);
+      });
+
+      test('the failure message is one a sign-in screen can show', () async {
+        _sendVerificationCode = (code) async =>
+            throw StateError('550 sender address is not verified');
+
+        final response = await _openLoginRequest(session);
+
+        // Not the generic "Unexpected error during saveModel DwAuthRequest" a
+        // thrown hook produces, and not the provider's complaint either — that
+        // one names the delivery configuration, and this endpoint answers
+        // anonymous callers.
+        expect(response.error, isNotNull);
+        expect(response.error, isNot(contains('Unexpected error')));
+        expect(response.error, isNot(contains('DwAuthRequest')));
+        expect(response.error, isNot(contains('550')));
+        expect(response.error, contains('verification code'));
+        expect(response.error, contains('try again'));
+      });
+
+      test(
+        'the request stays saved after a failed delivery, and the retry issues '
+        'a fresh code',
+        () async {
+          // The documented trade: the transaction commits before delivery is
+          // attempted, so the row survives an error response. Harmless because
+          // the retry mints a new code — asserted here rather than left to be
+          // inferred by the next reader.
+          _sendVerificationCode = (code) async =>
+              throw StateError('550 sender address is not verified');
+
+          final failed = await _openLoginRequest(session);
+          expect(failed.isOk, isFalse);
+
+          final afterFailure = await DwAuthRequest.db.find(session);
+          expect(afterFailure, hasLength(1));
+          expect(afterFailure.single.verificationHash, isNotNull);
+
+          final delivered = <String>[];
+          _sendVerificationCode = (code) async => delivered.add(code);
+
+          final retried = await _openLoginRequest(session);
+
+          expect(retried.isOk, isTrue);
+          expect(delivered, hasLength(1));
+
+          final stored = await DwAuthRequest.db.find(session);
+          expect(stored, hasLength(2));
+          expect(
+            stored.map((request) => request.verificationHash).toSet(),
+            hasLength(2),
+            reason: 'the retry must not reuse the undelivered code',
+          );
+        },
+      );
+    },
+    runMode: 'test',
+    applyMigrations: true,
+    // The auth flow commits its own transactions; cleanup is explicit.
+    rollbackDatabase: RollbackDatabase.disabled,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// Boots DartWay with a sender that delegates to [_sendVerificationCode], in
+/// place of the example's console logger. `withServerpod` never calls `run`, so
+/// the core is initialised here.
+void _bootDartway() {
+  _dw = DwCore.init<UserProfile>(
+    userProfileTable: UserProfile.t,
+    crudConfigurations: const [],
+    dtoConfigurations: const [],
+    channelConfigurations: const [],
+    userProfileConstructor: (session, {required registrationRequest}) async =>
+        throw UnsupportedError('Registration is outside this test suite'),
+    dwAlerts: DwAlerts.init(),
+    dwAuthConfig: DwAuthConfig<UserProfile>(
+      passwords: const {
+        'dwVerificationCodeSalt': 'test-verification-code-salt',
+        'dwAuthKeySalt': 'test-auth-key-salt',
+      },
+      sendVerificationCodeMethod:
+          (
+            session, {
+            required DwAuthRequest verificationRequest,
+            required String verificationCode,
+          }) => _sendVerificationCode(verificationCode),
+    ),
+  );
+}
+
+/// Opens a login request through the real save pipeline — the same config
+/// lookup `DwCrudEndpoint.saveModel` performs — and hands back the response
+/// rather than the model, because the response is what is under test.
+Future<DwApiResponse<DwModelWrapper>> _openLoginRequest(Session session) async {
+  final model = DwAuthRequest(
+    createdAt: DateTime.now().toUtc(),
+    requestType: DwAuthRequestType.login,
+    authProvider: DwAuthProvider.phone,
+    userIdentifier: _identifier,
+    status: DwAuthRequestStatus.created,
+  );
+  final className = DwModelWrapper(object: model).dwMappingClassname;
+
+  // The auth models live under DartWay's internal API, not the app's default.
+  final saveConfig =
+      (_dw.getCrudConfig(className) ??
+              _dw.getCrudConfig(
+                className,
+                api: DwCoreConst.dartwayInternalApi,
+              ))
+          ?.saveConfig;
+
+  if (saveConfig == null) {
+    throw StateError('No save config for $className');
+  }
+
+  return saveConfig.save(session, model);
+}
+
+Future<void> _wipeAuthTables(Session session) async {
+  await DwAuthVerification.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
+  await DwAuthRequest.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
+  await DwAuthKey.db.deleteWhere(session, where: (t) => Constant.bool(true));
+  await UserProfile.db.deleteWhere(session, where: (t) => Constant.bool(true));
+}

--- a/example/dartway_example_server/test/integration/dw_save_config_integration_test.dart
+++ b/example/dartway_example_server/test/integration/dw_save_config_integration_test.dart
@@ -72,6 +72,7 @@ void main() {
             },
             afterSaveTransform: (session, context) async {
               callbackOrder.add('transform');
+              return null;
             },
           ).save(session, stored.copyWith(settingValue: 'updated'));
 
@@ -322,6 +323,79 @@ void main() {
           expect(response.error, 'Database error during save');
           expect(response.error, isNot(contains('app_setting_key_unique_idx')));
           expect(response.error, isNot(contains(conflictingKey)));
+        },
+      );
+
+      test(
+        'a rejecting afterSaveTransform answers with its text and leaves the '
+        'row written',
+        () async {
+          final session = sessionBuilder.build();
+          final stored = await AppSetting.db.insertRow(
+            session,
+            AppSetting(
+              settingKey: '${_testKeyPrefix}transform_rejects',
+              settingValue: 'initial',
+            ),
+          );
+
+          var sideEffectsRan = false;
+
+          final response = await DwSaveConfig<AppSetting>(
+            allowSave: (session, context) async => true,
+            afterSaveTransform: (session, context) async =>
+                'Could not notify the provider. Please try again.',
+            afterSaveSideEffects: (session, context) async =>
+                sideEffectsRan = true,
+          ).save(session, stored.copyWith(settingValue: 'updated'));
+
+          expect(response.isOk, isFalse);
+          expect(
+            response.error,
+            'Could not notify the provider. Please try again.',
+          );
+          // A rejection stops what follows — documented on the hook.
+          expect(sideEffectsRan, isFalse);
+          // The hook runs after the commit, so rejecting cannot undo the write.
+          // Documented on `afterSaveTransform`, and pinned here.
+          expect(
+            (await AppSetting.db.findById(session, stored.id!))?.settingValue,
+            'updated',
+          );
+        },
+      );
+
+      test(
+        'a throwing afterSaveSideEffects neither fails the save nor escapes',
+        () async {
+          final session = sessionBuilder.build();
+          final threw = Completer<void>();
+
+          final response = await DwSaveConfig<AppSetting>(
+            allowSave: (session, context) async => true,
+            afterSaveSideEffects: (session, context) async {
+              threw.complete();
+              throw StateError('the mail provider refused the sender address');
+            },
+          ).save(
+            session,
+            AppSetting(
+              settingKey: '${_testKeyPrefix}side_effect_throws',
+              settingValue: 'inserted',
+            ),
+          );
+
+          // Nobody waits for the hook, so its failure must not touch the
+          // response — the contract is unchanged.
+          expect(response.isOk, isTrue);
+          await threw.future;
+
+          // And it must not escape either: unawaited, the throw used to reach
+          // the zone's error handler, which in this suite means an unhandled
+          // async error failing whichever test happened to be running. The
+          // failure goes to DwAlerts now, so letting the microtask queue drain
+          // here has to stay quiet.
+          await Future<void>.delayed(const Duration(milliseconds: 50));
         },
       );
     },

--- a/packages/dartway_push/dartway_push_client/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_client/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   # wrapper types. Inside the workspace this resolved without being declared,
   # which is exactly the kind of dependency that only fails once the package is
   # published and somebody else resolves it.
-  dartway_serverpod_core_client: ^0.8.0
+  dartway_serverpod_core_client: ^0.9.0

--- a/packages/dartway_push/dartway_push_flutter/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_flutter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   # app half talks to the server half through the generated protocol, not
   # through an endpoint of its own.
   dartway_push_client: ^0.2.0
-  dartway_serverpod_core_flutter: ^0.8.0
+  dartway_serverpod_core_flutter: ^0.9.0
 
   flutter_riverpod: ^3.0.0
 

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_server: ^0.8.0
+  dartway_serverpod_core_server: ^0.9.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.9.0 is the
+server side making a failed side effect audible: `afterSaveTransform` is now `Future<String?>` and
+can reject a save (breaking, one `return null;` per hook), a throw in `afterSaveSideEffects` is
+reported to `DwAlerts` instead of vanishing, and a verification code that could not be sent comes
+back as an error rather than a silent success. See the changelog of `dartway_serverpod_core_server`.
+
 ## 0.8.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.8.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.9.0 is the
+server side making a failed side effect audible: `afterSaveTransform` is now `Future<String?>` and
+can reject a save (breaking, one `return null;` per hook), a throw in `afterSaveSideEffects` is
+reported to `DwAlerts` instead of vanishing, and a verification code that could not be sent comes
+back as an error rather than a silent success. See the changelog of `dartway_serverpod_core_server`.
+
 ## 0.8.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.8.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -19,8 +19,8 @@ dependencies:
   serverpod_client: ^3.4.11
 
   dartway_flutter: ^0.5.0
-  dartway_serverpod_core_client: ^0.8.0
-  dartway_serverpod_core_shared: ^0.8.0
+  dartway_serverpod_core_client: ^0.9.0
+  dartway_serverpod_core_shared: ^0.9.0
 
   collection: ^1.19.1
   flutter_riverpod: ^3.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## 0.9.0
+
+**The sign-in response now waits for your SMS or mail provider, and reports it when the provider
+says no.** Until now the verification code was sent from a hook nobody awaited: the response was
+already built and said `isOk`, so a failed delivery reached neither the user nor the operator. The
+screen said "code sent" and no code was sent. If your delivery is flaky, applications that were
+quietly succeeding will start showing errors — that is the point of the change, not a side effect
+of it, and the failures were always happening.
+
+- **Breaking: `afterSaveTransform` returns `Future<String?>` instead of `Future<void>`.** A non-null
+  string rejects the save and becomes the error text in the response, exactly as with `validateSave`
+  and `beforeSaveTransaction`. Migration is one line per hook: add `return null;` at the end.
+
+  ```dart
+  // before
+  afterSaveTransform: (session, ctx) async {
+    ctx.currentModel = await enrich(session, ctx.currentModel);
+  },
+
+  // after
+  afterSaveTransform: (session, ctx) async {
+    ctx.currentModel = await enrich(session, ctx.currentModel);
+    return null;
+  },
+  ```
+
+  The analyzer catches every site (`body_might_complete_normally_nullable`), so nothing migrates
+  silently.
+
+  **A rejection here does not undo the write** — the transaction committed two steps earlier, so
+  the row stays saved and only the response says no. Undoing it would mean deleting a committed
+  row to report a failed email, which is worse. Write the hook so that a retry is harmless. A
+  rejection does stop what follows: `afterSaveSideEffects` does not run and `broadcastTo` sends
+  nothing.
+
+- **The hook's contract is stated honestly now.** It was documented as "enrich the model, outside
+  the transaction", which is what sent the verification code to `afterSaveSideEffects`, where it
+  could not be heard. It is the place for **any expected work after the write that the caller is
+  entitled to hear about** — enrichment, a payment handed to a provider, a code sent. The name is
+  unchanged: `docs/DESIGN.md` asks for one way to do a thing, and a second post-commit hook would
+  have been the second way.
+
+- **Fixed: a failure in `afterSaveSideEffects` reached nobody.** Its contract is unchanged — still
+  not awaited, still unable to fail the save — but a throw is now reported to `DwAlerts` with the
+  model's name and the stack trace instead of vanishing into the zone's error handler. Same fix for
+  `DwDtoActionConfig.afterSaveSideEffects`, which had the identical hole.
+
+  So the two hooks now differ by audience rather than by timing: what the user must be told goes in
+  `afterSaveTransform`, what only the operator needs goes in `afterSaveSideEffects`.
+
+- **The built-in auth request config sends the verification code from `afterSaveTransform`.** A
+  delivery failure comes back as "Could not send the verification code. Please try again." while
+  the provider's actual complaint — unverified sender domain, expired key, rejected recipient —
+  goes to the operator through `DwAlerts`. The two are deliberately separate: the sign-in endpoint
+  answers anonymous callers, and the provider's message names the delivery configuration.
+
+  The auth request row survives a failed delivery. That is harmless: the retry issues a fresh code,
+  and the abandoned request expires on its own.
+
 ## 0.8.0
 
 **`scope=serverOnly` did not hold, in either direction. Worth upgrading now rather than at your

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/crud/dw_auth_request_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/crud/dw_auth_request_config.dart
@@ -127,14 +127,41 @@ final dwAuthRequestConfig = DwCrudConfig<DwAuthRequest>(
     afterSaveTransaction:
         (Session session, DwSaveContext<DwAuthRequest> saveContext) async =>
             null,
-    afterSaveSideEffects: (session, saveContext) async {
-      if (saveContext.extras[verificationCodeKey] != null) {
+    // Awaited on purpose, and this is the hook the caller hears about. The
+    // sign-in screen's whole answer is "a code is on its way", so a delivery
+    // that failed has to travel back with the response — from
+    // `afterSaveSideEffects` nobody was waiting for it, and the user was shown
+    // "code sent" for a code that was never sent. The price is that the
+    // sign-in response now waits for the SMS or mail provider.
+    //
+    // The request row stays saved either way: the transaction committed before
+    // this runs. That is fine here — the user retries, the retry issues a new
+    // code, and the abandoned request expires on its own.
+    afterSaveTransform: (session, saveContext) async {
+      final verificationCode = saveContext.extras[verificationCodeKey];
+      if (verificationCode == null) return null;
+
+      try {
         await dw.auth!.config.sendVerificationCodeMethod?.call(
           session,
           verificationRequest: saveContext.currentModel,
-          verificationCode: saveContext.extras[verificationCodeKey] as String,
+          verificationCode: verificationCode as String,
         );
+      } catch (exception, stackTrace) {
+        // Split audience: the operator gets the provider's actual complaint —
+        // an unverified sender domain, an expired key, a rejected recipient —
+        // and the user gets a sentence they can act on. Handing the provider's
+        // message to the client would leak the delivery configuration to an
+        // endpoint that is open to anonymous callers.
+        dw.alerts.reportError(
+          'Failed to send the verification code for '
+          '${saveContext.currentModel.userIdentifier}',
+          exception: exception,
+          stackTrace: stackTrace,
+        );
+        return 'Could not send the verification code. Please try again.';
       }
+      return null;
     },
   ),
 );

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
@@ -29,6 +29,14 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
   )
   actionProcessing;
 
+  /// Side effects once the action's transaction has committed. Runs
+  /// **outside** it, non-blocking.
+  ///
+  /// **Nobody waits for this hook, so nothing it does can reach the caller —
+  /// including its failure.** The response has already been built and says
+  /// `isOk`. A throw is reported to [DwAlerts] with the DTO's name and the
+  /// stack trace, which reaches the operator and nobody else. Anything the
+  /// caller must be told about belongs in [actionProcessing].
   final Future<void> Function(
     Session session,
     DTO dto,
@@ -60,7 +68,7 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
 
     // --- afterSideEffects (outside the transaction, non-blocking) ---
     if (afterSaveSideEffects != null) {
-      unawaited(afterSaveSideEffects!(session, dto, updatedModels));
+      unawaited(_runSideEffects(session, dto, updatedModels));
     }
 
     return DwApiResponse(
@@ -68,5 +76,27 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
       value: DwModelWrapper(object: dto),
       updatedModels: updatedModels,
     );
+  }
+
+  /// Runs [afterSaveSideEffects] with nobody waiting for it, and makes sure a
+  /// failure still lands somewhere — unawaited, it would otherwise go to the
+  /// zone's error handler and reach neither the caller nor the operator.
+  ///
+  /// The call is made inside the try, so a hook that throws before its first
+  /// suspension point is caught too.
+  Future<void> _runSideEffects(
+    Session session,
+    DTO dto,
+    List<DwModelWrapper> updatedModels,
+  ) async {
+    try {
+      await afterSaveSideEffects!(session, dto, updatedModels);
+    } catch (exception, stackTrace) {
+      dw.alerts.reportError(
+        'Side effect failed after the ${DTO.toString()} action',
+        exception: exception,
+        stackTrace: stackTrace,
+      );
+    }
   }
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
@@ -15,8 +15,10 @@ import '../../../private/dw_singleton.dart';
 /// 3. [beforeSaveTransaction] — prepare the model (inside the transaction)
 /// 4. insert/update           — the write itself
 /// 5. [afterSaveTransaction]  — further database work (inside the transaction)
-/// 6. [afterSaveTransform]    — enrich the model, outside the transaction
-/// 7. [afterSaveSideEffects]  — notifications, async tasks, outside as well
+/// 6. [afterSaveTransform]    — expected work after the write, outside the
+///                              transaction; the caller waits for it
+/// 7. [afterSaveSideEffects]  — notifications, async tasks, outside as well;
+///                              the caller does not wait for it
 ///
 /// Carries a rejection out of the transaction callback: throwing is the only
 /// way to roll a Serverpod transaction back. Private on purpose — it never
@@ -84,13 +86,49 @@ class DwSaveConfig<T extends TableRow> {
   final Future<String?> Function(Session session, DwSaveContext<T> saveContext)?
   afterSaveTransaction;
 
-  /// Enriches the saved model before it is returned. Runs **outside** the
-  /// transaction and may be slow.
-  final Future<void> Function(Session session, DwSaveContext<T> saveContext)?
+  /// The work that is expected to happen once the model is written, and that
+  /// the caller is entitled to hear about: enriching the model before it is
+  /// returned, and equally any step whose failure the caller must be told of —
+  /// sending a verification code, handing a payment to a provider, calling out
+  /// to a system the answer depends on. Runs **outside** the transaction, is
+  /// awaited, and may be slow.
+  ///
+  /// Return the error text to turn the save into an error response, or null to
+  /// let it through — the same contract as [validateSave] and
+  /// [beforeSaveTransaction]. Throwing also reaches the caller, as the generic
+  /// "unexpected error" message; returning the text is how the caller gets one
+  /// worth showing.
+  ///
+  /// **A rejection here does not undo the write.** The transaction committed
+  /// two steps ago, so the row stays saved and only the response says no. That
+  /// is the intended trade: the alternative — deleting a committed row to
+  /// report a failed email — is worse. Write the hook so that the caller
+  /// retrying is harmless, and say in the error text that retrying is what
+  /// they should do.
+  ///
+  /// **A rejection stops the two steps that follow**: [afterSaveSideEffects]
+  /// does not run and [broadcastTo] sends nothing. Announcing a change to
+  /// other users' screens while answering the caller with an error would be
+  /// the less coherent of the two, and the row is still there for the next
+  /// read.
+  ///
+  /// Anything the caller need not wait for belongs in [afterSaveSideEffects]
+  /// instead — a slow step here is a slow response.
+  final Future<String?> Function(Session session, DwSaveContext<T> saveContext)?
   afterSaveTransform;
 
   /// Side effects: notifications, async tasks, anything the caller need not
   /// wait for. Runs **outside** the transaction, non-blocking.
+  ///
+  /// **Nobody waits for this hook, so nothing it does can reach the caller —
+  /// including its failure.** A throw here does not fail the save: the response
+  /// has already been built and says `isOk`. The failure is reported to
+  /// [DwAlerts] with the model's name and the stack trace, so it reaches the
+  /// operator, and that is the whole of its audience.
+  ///
+  /// Which makes the choice between the two hooks a question about the user,
+  /// not about timing: anything they must be told went wrong goes in
+  /// [afterSaveTransform], which is awaited and can reject.
   final Future<void> Function(Session session, DwSaveContext<T> saveContext)?
   afterSaveSideEffects;
 
@@ -396,14 +434,20 @@ class DwSaveConfig<T extends TableRow> {
     Session session,
     DwSaveContext<T> saveContext,
   ) async {
-    // --- afterTransform (outside the transaction) ---
+    // --- afterTransform (outside the transaction, awaited) ---
+    // A rejection here cannot roll anything back — the transaction committed
+    // before this method was called — so the row stays written and only the
+    // response says no. See [afterSaveTransform].
     if (afterSaveTransform != null) {
-      await afterSaveTransform!(session, saveContext);
+      final error = await afterSaveTransform!(session, saveContext);
+      if (error != null) {
+        return DwApiResponse(isOk: false, value: null, error: error);
+      }
     }
 
     // --- afterSideEffects (outside the transaction, non-blocking) ---
     if (afterSaveSideEffects != null) {
-      unawaited(afterSaveSideEffects!(session, saveContext));
+      unawaited(_runSideEffects(session, saveContext));
     }
 
     // Collect everything the client should refresh.
@@ -427,6 +471,33 @@ class DwSaveConfig<T extends TableRow> {
       value: DwModelWrapper(object: saveContext.currentModel),
       updatedModels: updatedModels,
     );
+  }
+
+  /// Runs [afterSaveSideEffects] with nobody waiting for it, and makes sure a
+  /// failure still lands somewhere.
+  ///
+  /// Unawaited, an exception thrown in here goes to the zone's error handler
+  /// and no further: the caller already has its `isOk` response and cannot be
+  /// told, and without this the operator was not told either — a misconfigured
+  /// mail sender failed on every save and the only symptom was users not
+  /// receiving anything.
+  ///
+  /// The call is made **inside** the try rather than awaited from outside it,
+  /// so a hook that throws before its first suspension point is caught too;
+  /// handed a future, this would have missed exactly those.
+  Future<void> _runSideEffects(
+    Session session,
+    DwSaveContext<T> saveContext,
+  ) async {
+    try {
+      await afterSaveSideEffects!(session, saveContext);
+    } catch (exception, stackTrace) {
+      dw.alerts.reportError(
+        'Side effect failed after saving ${T.toString()}',
+        exception: exception,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   DwApiResponse<DwModelWrapper> _notFoundResponse(int id) => DwApiResponse(

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_shared: ^0.8.0
+  dartway_serverpod_core_shared: ^0.9.0
 
   collection: ^1.19.1
   crypto: ^3.0.6

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.9.0 is the
+server side making a failed side effect audible: `afterSaveTransform` is now `Future<String?>` and
+can reject a save (breaking, one `return null;` per hook), a throw in `afterSaveSideEffects` is
+reported to `DwAlerts` instead of vanishing, and a verification code that could not be sent comes
+back as an error rather than a silent success. See the changelog of `dartway_serverpod_core_server`.
+
 ## 0.8.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.8.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/template/dartway_starter_client/pubspec.yaml
+++ b/template/dartway_starter_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.8.0
+  dartway_serverpod_core_client: ^0.9.0
 
 # Inside the monorepo — a local build. `dartway create` removes this block.
 dependency_overrides:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -292,21 +292,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_starter_client:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.8.0
+  dartway_serverpod_core_flutter: ^0.9.0
 
   dartway_studio_bridge: ^0.8.0
 

--- a/template/dartway_starter_server/pubspec.lock
+++ b/template/dartway_starter_server/pubspec.lock
@@ -127,14 +127,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   ffi:
     dependency: transitive
     description:

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.8.0
+  dartway_serverpod_core_server: ^0.9.0
 
   http: ^1.5.0
 

--- a/toolkit/skills/dartway-clean-code/SKILL.md
+++ b/toolkit/skills/dartway-clean-code/SKILL.md
@@ -8,7 +8,9 @@ description: >-
   widget-returning methods, no ref.invalidate, no GlobalKey tree lookups, no
   outer padding/margin inside a widget, no private widget classes in public
   feature files, a Serverpod model rebuilt with copyWith and never by listing
-  its fields; plus SOLID, KISS, DRY, YAGNI, Law of Demeter, composition over
+  its fields, no default for a setting whose value belongs to the environment
+  (sender address, provider key, admin identifier);
+  plus SOLID, KISS, DRY, YAGNI, Law of Demeter, composition over
   inheritance, separation of concerns, fail-fast, tell-don't-ask, single source
   of truth, and tests for complex features / non-trivial bugfixes.
 ---
@@ -443,6 +445,40 @@ or an `if`/`else if` chain over the same values gives you nothing.
 
 ---
 
+## 1.11 A setting whose value belongs to the environment has no default
+
+Sender address, provider key, webhook URL, bucket name, the identifier of the first administrator —
+these are not preferences with a sensible starting point. Each one is a **credential of this
+deployment**, and the only correct value is the one this deployment was given.
+
+Give such a setting a default and an unfilled key stops being an error. It becomes quiet work with
+somebody else's credentials: mail leaves from an address the project does not own, a webhook posts
+to a stranger's endpoint, and nothing anywhere says so. The failure is not that it breaks — it is
+that it *works*, plausibly, pointing at the wrong place.
+
+```dart
+// ❌ the project that forgets to configure this sends mail as someone else
+final senderAddress = passwords['senderAddress'] ?? 'noreply@example.com';
+
+// ✅ unset is unset, and it says so where it is read
+final senderAddress = passwords['senderAddress'] ??
+    (throw StateError('senderAddress missing in passwords'));
+```
+
+Empty and an explicit error beats a plausible foreign value. Read the setting at the point of use
+and fail there, or check it on boot — either is fine; what is not fine is a fallback that hides the
+gap.
+
+The framework's own template follows this: `bootstrapAdminIdentifier` is deliberately left without
+a default. A default administrator in a public template would mean every project that forgot to
+change it has an administrator whose channel a stranger controls.
+
+Preferences with a genuine neutral value — a page size, a timeout, a retry count — are not this
+rule. The test is whether the value is *about this deployment*. If a wrong value would point the
+system at somebody else, there is no default to give.
+
+---
+
 # Part 2. Clean code principles
 
 Well-known principles. Here — how they look in Dart/Flutter and what to avoid.
@@ -692,6 +728,7 @@ class ItemsListPage extends ConsumerWidget {
 - [ ] **No** `Expanded`/`SizedBox(…: double.infinity)` at the root of `build` — the parent gives the widget its space (§1.7a).
 - [ ] **No** private widget classes (`_Foo`) in public feature files.
 - [ ] **A Serverpod model is rebuilt with `copyWith`**, never by listing its fields in the constructor — a field with `default=` or a nullable one is optional, so a forgotten one is a silent default, not an error. Clearing a nullable field is `copyWith(field: null)` (§1.10). An unavoidable enumeration is driven by `Enum.values` or an exhaustive `switch`, not written out by hand.
+- [ ] **A setting whose value belongs to the environment has no default** — sender address, provider key, webhook URL, admin identifier. An unfilled key must be an error, not quiet work with somebody else's credentials (§1.11).
 - [ ] **A building block** — a widget with no product behaviour to describe — lives in `lib/shared/` with a doc comment, not in a zone with an empty `DwFeatureSpec`.
 - [ ] **Imports:** own internals and sibling features are relative and no deeper than two `../`; `core`/`data`/`domain`/`shared`/`ui_kit`/another zone are `package:` (§1.2a).
 - [ ] **The provider is the first thing in its file** (or lives in the feature's root file), not appended after the notifier that implements it.

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -118,9 +118,34 @@ Execution order and signatures:
 1. `allowSave` → `Future<bool>` — permissions, **required**
 2. `validateSave` → `Future<String?>` — the error text or null
 3. **the transaction opens:** `beforeSaveTransaction` → `Future<String?>` → insert/update → `afterSaveTransaction` → `Future<String?>`
-4. outside the transaction: `afterSaveTransform` → `Future<void>` (enrichment), then `afterSaveSideEffects` → `Future<void>` (non-blocking)
+4. outside the transaction: `afterSaveTransform` → `Future<String?>` (awaited, can reject), then `afterSaveSideEffects` → `Future<void>` (non-blocking)
 
 **Both in-transaction hooks return `String?` — just like `validateSave`.** Returned text → the save is rejected, the transaction is rolled back, the text reaches the client; returned `null` → we move on. This is precisely how you reject on a rule that is only visible inside the transaction.
+
+**Nobody waits for `afterSaveSideEffects`, so nothing it does can reach the caller — its failure included.** By the time it throws, the response has been built and says `isOk`. The framework reports the throw to `DwAlerts`, so the operator hears it, and that is the whole of its audience. **Anything the user has to be told about goes in the awaited hook**, `afterSaveTransform`: it returns `String?` like the rejecting hooks above, and its text becomes the error in the response.
+
+The question is who needs to know, not when the work happens. A push notification nobody misses if it is late → `afterSaveSideEffects`. A verification code, a payment handed to a provider, an invitation the whole feature is about → `afterSaveTransform`, and the caller waits for it.
+
+One consequence to write into the hook: `afterSaveTransform` runs **after** the commit, so rejecting there does not undo the write. The row stays saved and only the response says no. Write the hook so that a retry is harmless, and say in the error text that retrying is what to do.
+
+```dart
+afterSaveTransform: (session, saveContext) async {
+  try {
+    await sendInvitationEmail(session, saveContext.currentModel);
+  } catch (exception, stackTrace) {
+    // The operator gets the provider's actual complaint, the user gets a
+    // sentence they can act on. Do not hand the provider's message to the
+    // client — it names your delivery configuration.
+    dw.alerts.reportError(
+      'Failed to send the invitation',
+      exception: exception,
+      stackTrace: stackTrace,
+    );
+    return 'Could not send the invitation. Please try again.';
+  }
+  return null;
+},
+```
 
 **Why this and not `validateSave`:** steps 1–2 run BEFORE the transaction, so a rule guarding a shared counter (seats, stock, limits) is evaluated there — two parallel saves would both get a "yes". Check such a rule in `beforeSaveTransaction`, taking a **row lock** in the same transaction: `findById(..., transaction:, lockMode: LockMode.forUpdate)` — a single call both locks the row (`SELECT ... FOR UPDATE`) and returns it. `validateSave` checks the model, `beforeSaveTransaction` checks the world around it.
 


### PR DESCRIPTION
## The bug

The verification code was sent from `afterSaveSideEffects`:

```dart
if (afterSaveSideEffects != null) {
  unawaited(afterSaveSideEffects!(session, saveContext));
}
```

Nobody awaits that, so by the time it throws the response has been built and
says `isOk`. The exception went to the zone's error handler and no further — not
to the caller, not to the operator. The sign-in screen said "code sent" and no
code was sent. Every misconfiguration of delivery behaves this way: an
unverified sender domain, a sender address the project does not own, an expired
provider key.

## Part A — the side effect's failure has an audience

The hook's contract is unchanged: still not awaited, still unable to fail the
save. But a throw is now reported to `dw.alerts.reportError` with the model's
name and the stack trace, the way `_databaseErrorResponse` and `returnError`
already do. The call is made inside the `try` rather than awaited from outside
it, so a hook that throws before its first suspension point is caught too.

`DwDtoActionConfig.afterSaveSideEffects` had the identical hole one file over
and gets the identical fix. Slightly outside the brief, and left in on purpose:
fixing one and leaving the other would have been the odd choice.

The doc comment now says what it did not: nothing this hook does can reach the
caller, its failure included.

## Part B — the send moves to the awaited hook

`afterSaveTransform` is awaited in `_finishSave`, so a failure there reaches
`DwCrudEndpoint.saveModel` and becomes an error response. The user sees "could
not send the code, try again" instead of waiting for a code that will not
arrive.

**The price, and it belongs in the first line rather than a footnote:** the
sign-in response now waits for the SMS or mail provider, and applications with
flaky delivery will start seeing errors where they had quiet successes. That is
the change working, not a side effect of it — the failures were always
happening.

### Decision 1 — the hook is not renamed

`afterSaveTransform` was documented as "enrich the model, outside the
transaction", and that phrasing is what sent the code delivery to the hook where
it could not be heard. Its real contract is *expected work after the write that
the caller is entitled to hear about*, and the doc comment says so now, as does
the lifecycle list in the file header.

**The fork, named rather than resolved silently:** the name does now describe
less than the hook does. "Transform" reads as mutating the model, and handing a
payment to a provider is not a transform. I did not rename it, on two grounds —
`docs/DESIGN.md` asks for a minimal contract and one way to do a thing, so a
second post-commit hook was out; and a rename would be a second breaking change
in the same PR for a cosmetic gain. If you would rather it were
`afterSaveCompleted` or `afterCommit`, that is a one-line follow-up while the
signature change is already forcing every call site to be visited — this is the
cheapest moment it will ever have. Say the word and I will do it here instead.

### Decision 2 — the signature changes (breaking)

`Future<void>` → `Future<String?>`, like `beforeSaveTransaction`. A non-null
string becomes the error text in the response.

Without it the only way to report a failure is to throw, and the caller gets
`Unexpected error during saveModel DwAuthRequest` — not a sentence to put on a
sign-in screen. Migration is one line per hook:

```dart
afterSaveTransform: (session, ctx) async {
  ctx.currentModel = await enrich(session, ctx.currentModel);
  return null;   // <- added
},
```

The analyzer flags every site (`body_might_complete_normally_nullable`), so
nothing migrates silently. One call site existed in this repository, in an
`example/` test.

The auth config splits the audience: the operator gets the provider's actual
complaint through `DwAlerts`, the user gets a sentence they can act on. Handing
the provider's message to the client would leak the delivery configuration from
an endpoint that answers anonymous callers.

### What is now true and non-obvious, so it is written down

The transaction commits before either hook runs, so a rejection from
`afterSaveTransform` **does not undo the write**. The auth request stays saved,
the user gets an error and retries, and the retry issues a fresh code. The
alternative — deleting a committed row to report a failed email — is worse. A
rejection does stop what follows: `afterSaveSideEffects` does not run and
`broadcastTo` sends nothing, since announcing a change to other screens while
answering the caller with an error is the less coherent of the two.

All of it is on the hook's doc comment, in `docs/2-core/crud-configs.md`, and
pinned by tests.

## Tests

New file `example/dartway_example_server/test/integration/auth_code_delivery_test.dart`,
driving the real `dwAuthRequestConfig` through the same config lookup the CRUD
endpoint performs:

- a sender that delivers → `isOk`, called exactly once;
- a sender that throws → not `isOk`;
- the message is one a sign-in screen can show — not the generic
  "Unexpected error", not the provider's `550`;
- the request survives the failed delivery and the retry issues a *different*
  code.

Added to `dw_save_config_integration_test.dart`:

- a rejecting `afterSaveTransform` answers with its own text, leaves the row
  written, and stops the side effects;
- a throwing `afterSaveSideEffects` neither fails the save nor escapes — under
  `package:test` an unhandled async error would fail the run, so this one is
  self-proving.

## Toolkit — two rules

1. `dartway-crud-config`: nobody waits for `afterSaveSideEffects`, so its
   failure reaches only the error pipeline. What the user must be told goes in
   the awaited hook. With the `try`/`reportError`/`return` shape written out.
2. `dartway-clean-code` §1.11 — deliberately *not* in the CRUD skill, since it
   is not about hooks: a setting whose value belongs to the environment (sender
   address, provider key, webhook URL, admin identifier) has no default. A
   default turns an unfilled key into quiet work with somebody else's
   credentials. Cites `bootstrapAdminIdentifier` in the template, which is
   deliberately left blank for exactly this reason.

I did not add "validate delivery configuration at boot". After A and B the
failure is visible to both the operator and the user, which makes that a
preference rather than a law, and the skills do not need the extra line.

## Sync law

- Versions: the four `dartway_serverpod_core_*` packages 0.8.0 → 0.9.0 in
  lockstep. Carets raised in `example/`, `template/` and `dartway_push_*` — for
  a `0.x` major, `^0.8.0` does not admit `0.9.0`, and `dependency_overrides`
  hides that until `dartway create` strips them.
- CHANGELOG in all four; the breaking change and its migration are called out
  separately, the wait-for-the-provider cost is the opening line.
- `docs/2-core/crud-configs.md`: the signature in the lifecycle table, and why
  steps 6 and 7 differ by audience rather than by timing.
- `example/` and `template/` both analyze clean; `example` server suite 50/50,
  core server 50, core shared 9, `dartway_flutter` 36, `core_flutter` 38,
  template and example Flutter analyze with no issues.
- Studio bridge untouched.

## Note for whoever merges

Branched from `master` at `17eeb75`, which already carries #60 — the other
consumer of these four version numbers. No conflict expected; if another branch
lands a core bump first, this one's `0.9.0` and its four CHANGELOG entries are
what will need rebasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
