### PR TITLE
chore: the tall style, applied once, everywhere it had not been

### DIFF
--- a/example/dartway_example_client/lib/src/protocol/chat/chat_channel.dart
+++ b/example/dartway_example_client/lib/src/protocol/chat/chat_channel.dart
@@ -13,11 +13,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 abstract class ChatChannel implements _i1.SerializableModel {
-  ChatChannel._({
-    this.id,
-    required this.title,
-    required this.createdAt,
-  });
+  ChatChannel._({this.id, required this.title, required this.createdAt});
 
   factory ChatChannel({
     int? id,
@@ -47,11 +43,7 @@ abstract class ChatChannel implements _i1.SerializableModel {
   /// Returns a shallow copy of this [ChatChannel]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  ChatChannel copyWith({
-    int? id,
-    String? title,
-    DateTime? createdAt,
-  });
+  ChatChannel copyWith({int? id, String? title, DateTime? createdAt});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -75,11 +67,7 @@ class _ChatChannelImpl extends ChatChannel {
     int? id,
     required String title,
     required DateTime createdAt,
-  }) : super._(
-         id: id,
-         title: title,
-         createdAt: createdAt,
-       );
+  }) : super._(id: id, title: title, createdAt: createdAt);
 
   /// Returns a shallow copy of this [ChatChannel]
   /// with some or all fields replaced by the given arguments.

--- a/example/dartway_example_client/lib/src/protocol/client.dart
+++ b/example/dartway_example_client/lib/src/protocol/client.dart
@@ -37,12 +37,7 @@ class Client extends _i3.ServerpodClientShared {
     super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
-    Function(
-      _i3.MethodCallContext,
-      Object,
-      StackTrace,
-    )?
-    onFailedCall,
+    Function(_i3.MethodCallContext, Object, StackTrace)? onFailedCall,
     Function(_i3.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(

--- a/example/dartway_example_client/lib/src/protocol/protocol.dart
+++ b/example/dartway_example_client/lib/src/protocol/protocol.dart
@@ -54,10 +54,7 @@ class Protocol extends _i1.SerializationManager {
   }
 
   @override
-  T deserialize<T>(
-    dynamic data, [
-    Type? t,
-  ]) {
+  T deserialize<T>(dynamic data, [Type? t]) {
     t ??= T;
 
     final dataClassName = getClassNameFromObjectJson(data);

--- a/example/dartway_example_client/lib/src/protocol/settings/app_setting.dart
+++ b/example/dartway_example_client/lib/src/protocol/settings/app_setting.dart
@@ -13,11 +13,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 abstract class AppSetting implements _i1.SerializableModel {
-  AppSetting._({
-    this.id,
-    required this.settingKey,
-    required this.settingValue,
-  });
+  AppSetting._({this.id, required this.settingKey, required this.settingValue});
 
   factory AppSetting({
     int? id,
@@ -45,11 +41,7 @@ abstract class AppSetting implements _i1.SerializableModel {
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  AppSetting copyWith({
-    int? id,
-    String? settingKey,
-    String? settingValue,
-  });
+  AppSetting copyWith({int? id, String? settingKey, String? settingValue});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -73,11 +65,7 @@ class _AppSettingImpl extends AppSetting {
     int? id,
     required String settingKey,
     required String settingValue,
-  }) : super._(
-         id: id,
-         settingKey: settingKey,
-         settingValue: settingValue,
-       );
+  }) : super._(id: id, settingKey: settingKey, settingValue: settingValue);
 
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.

--- a/example/dartway_example_flutter/lib/app/schedule/widgets/schedule_app_bar.dart
+++ b/example/dartway_example_flutter/lib/app/schedule/widgets/schedule_app_bar.dart
@@ -14,10 +14,7 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
       title: AppText.title(
         context.l10n.helloUser(ref.watchUserProfile.firstName),
       ),
-      actions: const [
-        ConnectionStatusIndicator(),
-        TestErrorButton(),
-      ],
+      actions: const [ConnectionStatusIndicator(), TestErrorButton()],
     );
   }
 

--- a/example/dartway_example_server/bin/seed_dev.dart
+++ b/example/dartway_example_server/bin/seed_dev.dart
@@ -44,10 +44,18 @@ Future<void> main(List<String> args) async {
 }
 
 Future<void> _seed(Session session) async {
-  final admin = await _ensureProfile(session, _adminPhone, 'Alex',
-      role: UserRole.admin);
-  final coach = await _ensureProfile(session, _coachPhone, 'Maria',
-      role: UserRole.staff);
+  final admin = await _ensureProfile(
+    session,
+    _adminPhone,
+    'Alex',
+    role: UserRole.admin,
+  );
+  final coach = await _ensureProfile(
+    session,
+    _coachPhone,
+    'Maria',
+    role: UserRole.staff,
+  );
   await _ensureProfile(session, _clientPhone, 'Ivan', role: UserRole.client);
 
   final services = <ClubService>[];
@@ -56,9 +64,11 @@ Future<void> _seed(Session session) async {
     ('Yoga class', 'Morning yoga for everyone', 90, 1100, 8),
     ('Personal training', 'One-on-one with a coach', 60, 2500, 1),
   ]) {
-    var service = (await ClubService.db.find(session,
-            where: (t) => t.title.equals(title), limit: 1))
-        .firstOrNull;
+    var service = (await ClubService.db.find(
+      session,
+      where: (t) => t.title.equals(title),
+      limit: 1,
+    )).firstOrNull;
     service ??= await ClubService.db.insertRow(
       session,
       ClubService(
@@ -74,10 +84,12 @@ Future<void> _seed(Session session) async {
     final startHour = 9 + services.length * 2;
     for (var day = 1; day <= 7; day++) {
       final now = DateTime.now();
-      final startsAt =
-          DateTime(now.year, now.month, now.day, startHour).add(
-        Duration(days: day),
-      );
+      final startsAt = DateTime(
+        now.year,
+        now.month,
+        now.day,
+        startHour,
+      ).add(Duration(days: day));
       final existing = await ClubSession.db.count(
         session,
         where: (t) =>
@@ -112,7 +124,8 @@ Future<void> _seed(Session session) async {
       NewsPost(
         authorProfileId: admin.id!,
         title: 'Welcome to DartWay Fitness!',
-        text: 'Our new app is live: browse the schedule, book sessions '
+        text:
+            'Our new app is live: browse the schedule, book sessions '
             'and follow club news right here.',
         createdAt: DateTime.now(),
       ),
@@ -139,9 +152,11 @@ Future<UserProfile> _ensureProfile(
   // Seeded users are the Studio demo personas, so they carry a fixed test code.
   String? testVerificationCode = '000000',
 }) async {
-  final existing = (await UserProfile.db.find(session,
-          where: (t) => t.userIdentifier.equals(phone), limit: 1))
-      .firstOrNull;
+  final existing = (await UserProfile.db.find(
+    session,
+    where: (t) => t.userIdentifier.equals(phone),
+    limit: 1,
+  )).firstOrNull;
   if (existing != null) {
     if (existing.testVerificationCode != testVerificationCode) {
       existing.testVerificationCode = testVerificationCode;

--- a/example/dartway_example_server/lib/server.dart
+++ b/example/dartway_example_server/lib/server.dart
@@ -1,10 +1,7 @@
 import 'dart:io';
 
 import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart'
-    show
-        DwOrphanedAuthKeyCleanup,
-        DwRecurringJobs,
-        dwAuthenticationHandler;
+    show DwOrphanedAuthKeyCleanup, DwRecurringJobs, dwAuthenticationHandler;
 import 'package:dartway_example_server/src/web/routes/root.dart';
 import 'package:serverpod/serverpod.dart';
 

--- a/example/dartway_example_server/lib/src/crud/app_setting_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/app_setting_crud_config.dart
@@ -6,14 +6,12 @@ import 'package:dartway_example_server/src/generated/protocol.dart';
 /// Everyone reads settings; only the admin writes, nobody deletes.
 final appSettingCrudConfig = DwCrudConfig<AppSetting>(
   table: AppSetting.t,
-  getListConfig: DwGetModelListConfig(
-    accessFilter: (session) async => null,
-  ),
+  getListConfig: DwGetModelListConfig(accessFilter: (session) async => null),
   saveConfig: DwSaveConfig<AppSetting>(
     allowSave: (session, saveContext) async => session.isClubAdmin,
     validateSave: (session, saveContext) async =>
         saveContext.currentModel.settingKey.trim().isEmpty
-            ? 'Setting key is required'
-            : null,
+        ? 'Setting key is required'
+        : null,
   ),
 );

--- a/example/dartway_example_server/lib/src/crud/chat_channel_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/chat_channel_crud_config.dart
@@ -7,14 +7,12 @@ import 'package:dartway_example_server/src/generated/protocol.dart';
 /// access filter line, not scattered UI checks.
 final chatChannelCrudConfig = DwCrudConfig<ChatChannel>(
   table: ChatChannel.t,
-  getListConfig: DwGetModelListConfig(
-    accessFilter: staffOnlyAccessFilter,
-  ),
+  getListConfig: DwGetModelListConfig(accessFilter: staffOnlyAccessFilter),
   saveConfig: DwSaveConfig<ChatChannel>(
     allowSave: (session, saveContext) async => session.isClubAdmin,
     validateSave: (session, saveContext) async =>
         saveContext.currentModel.title.trim().isEmpty
-            ? 'Title is required'
-            : null,
+        ? 'Title is required'
+        : null,
   ),
 );

--- a/example/dartway_example_server/lib/src/crud/chat_message_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/chat_message_crud_config.dart
@@ -21,8 +21,8 @@ final chatMessageCrudConfig = DwCrudConfig<ChatMessage>(
         session.isUser(saveContext.currentModel.authorProfileId),
     validateSave: (session, saveContext) async =>
         saveContext.currentModel.messageText.trim().isEmpty
-            ? 'Message cannot be empty'
-            : null,
+        ? 'Message cannot be empty'
+        : null,
     beforeSaveTransaction: (session, saveContext) async {
       if (saveContext.isInsert) {
         saveContext.currentModel = saveContext.currentModel.copyWith(

--- a/example/dartway_example_server/lib/src/crud/club_service_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/club_service_crud_config.dart
@@ -6,9 +6,7 @@ import 'package:dartway_example_server/src/generated/protocol.dart';
 /// Anyone signed in can browse services; only the admin manages them.
 final clubServiceCrudConfig = DwCrudConfig<ClubService>(
   table: ClubService.t,
-  getListConfig: DwGetModelListConfig(
-    accessFilter: (session) async => null,
-  ),
+  getListConfig: DwGetModelListConfig(accessFilter: (session) async => null),
   saveConfig: DwSaveConfig<ClubService>(
     allowSave: (session, saveContext) async => session.isClubAdmin,
     validateSave: (session, saveContext) async {

--- a/example/dartway_example_server/lib/src/crud/news_post_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/news_post_crud_config.dart
@@ -56,16 +56,25 @@ final newsPostCrudConfig = DwCrudConfig<NewsPost>(
       final post = saveContext.currentModel;
       await dwPushDispatcher?.sendToEveryone(
         session,
-        page: (session, {required afterId, required limit, required transaction}) async {
-          final profiles = await UserProfile.db.find(
-            session,
-            where: afterId == null ? null : (table) => table.id > afterId,
-            orderBy: (table) => table.id,
-            limit: limit,
-            transaction: transaction,
-          );
-          return profiles.map((profile) => profile.id).whereType<int>().toList();
-        },
+        page:
+            (
+              session, {
+              required afterId,
+              required limit,
+              required transaction,
+            }) async {
+              final profiles = await UserProfile.db.find(
+                session,
+                where: afterId == null ? null : (table) => table.id > afterId,
+                orderBy: (table) => table.id,
+                limit: limit,
+                transaction: transaction,
+              );
+              return profiles
+                  .map((profile) => profile.id)
+                  .whereType<int>()
+                  .toList();
+            },
         category: ExamplePushCategories.newsPost,
         title: post.title,
         body: post.text,

--- a/example/dartway_example_server/lib/src/crud/session_booking_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/session_booking_crud_config.dart
@@ -31,8 +31,10 @@ final sessionBookingCrudConfig = DwCrudConfig<SessionBooking>(
         session.isUser(saveContext.currentModel.clientProfileId),
     validateSave: (session, saveContext) async {
       final booking = saveContext.currentModel;
-      final clubSession =
-          await ClubSession.db.findById(session, booking.clubSessionId);
+      final clubSession = await ClubSession.db.findById(
+        session,
+        booking.clubSessionId,
+      );
       if (clubSession == null) {
         return 'Session not found';
       }

--- a/example/dartway_example_server/lib/src/crud/session_review_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/session_review_crud_config.dart
@@ -15,8 +15,10 @@ final sessionReviewCrudConfig = DwCrudConfig<SessionReview>(
   ),
   saveConfig: DwSaveConfig<SessionReview>(
     allowSave: (session, saveContext) async {
-      final booking = await SessionBooking.db
-          .findById(session, saveContext.currentModel.bookingId);
+      final booking = await SessionBooking.db.findById(
+        session,
+        saveContext.currentModel.bookingId,
+      );
       return session.isUser(booking?.clientProfileId ?? -1);
     },
     validateSave: (session, saveContext) async {
@@ -24,8 +26,10 @@ final sessionReviewCrudConfig = DwCrudConfig<SessionReview>(
       if (review.rating < 1 || review.rating > 5) {
         return 'Rating must be between 1 and 5';
       }
-      final booking =
-          await SessionBooking.db.findById(session, review.bookingId);
+      final booking = await SessionBooking.db.findById(
+        session,
+        review.bookingId,
+      );
       if (booking?.status != BookingStatus.attended) {
         return 'You can only review a session you attended';
       }

--- a/example/dartway_example_server/lib/src/crud/user_profile_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/user_profile_crud_config.dart
@@ -7,9 +7,7 @@ final userProfileCrudConfig = DwCrudConfig<UserProfile>(
   table: UserProfile.t,
   // Only the admin lists all profiles (the admin users table). Everyone else
   // sees nothing here — secure-by-default, mirroring staffOnlyAccessFilter.
-  getListConfig: DwGetModelListConfig(
-    accessFilter: adminOnlyAccessFilter,
-  ),
+  getListConfig: DwGetModelListConfig(accessFilter: adminOnlyAccessFilter),
   saveConfig: DwSaveConfig<UserProfile>(
     // A signed-in user saves only their own profile; the admin saves anyone's.
     allowSave: (session, saveContext) async =>

--- a/example/dartway_example_server/lib/src/dartway/dartway_core.dart
+++ b/example/dartway_example_server/lib/src/dartway/dartway_core.dart
@@ -120,32 +120,30 @@ void initDartwayCore({
       // (UserProfile.testVerificationCode, serverOnly — never sent to clients);
       // everyone else gets a fresh random code. Works in any run mode, so store
       // reviewers can sign in, while real users are never handed a fixed code.
-      generateVerificationCodeMethod: (
-        session, {
-        required DwAuthRequest verificationRequest,
-      }) async {
-        final profile = await UserProfile.db.findFirstRow(
-          session,
-          where: (t) =>
-              t.userIdentifier.equals(verificationRequest.userIdentifier),
-        );
-        return profile?.testVerificationCode ?? _randomVerificationCode();
-      },
+      generateVerificationCodeMethod:
+          (session, {required DwAuthRequest verificationRequest}) async {
+            final profile = await UserProfile.db.findFirstRow(
+              session,
+              where: (t) =>
+                  t.userIdentifier.equals(verificationRequest.userIdentifier),
+            );
+            return profile?.testVerificationCode ?? _randomVerificationCode();
+          },
       // Dev: log the code to the server console instead of sending an SMS.
       // Wire a real SMS/email sender here for production.
-      sendVerificationCodeMethod: (
-        session, {
-        required DwAuthRequest verificationRequest,
-        required String verificationCode,
-      }) async {
-        session.log(
-          'Verification code for ${verificationRequest.userIdentifier}: '
-          '$verificationCode',
-        );
-      },
+      sendVerificationCodeMethod:
+          (
+            session, {
+            required DwAuthRequest verificationRequest,
+            required String verificationCode,
+          }) async {
+            session.log(
+              'Verification code for ${verificationRequest.userIdentifier}: '
+              '$verificationCode',
+            );
+          },
     ),
   );
-
 }
 
 /// Builds the optional push delivery engine from provider credentials.
@@ -156,7 +154,9 @@ void initDartwayCore({
 DwPush? _buildDwPush(Map<String, String> passwords) {
   final fcmConfig = DwFcmPushProviderConfig.fromPasswords(passwords);
   final ruStoreConfig = DwRuStorePushProviderConfig.fromPasswords(passwords);
-  final fcm = fcmConfig.isConfigured ? DwFcmPushProvider(config: fcmConfig) : null;
+  final fcm = fcmConfig.isConfigured
+      ? DwFcmPushProvider(config: fcmConfig)
+      : null;
   final ruStore = ruStoreConfig.isConfigured
       ? DwRuStorePushProvider(config: ruStoreConfig)
       : null;

--- a/example/dartway_example_server/lib/src/generated/booking/session_booking.dart
+++ b/example/dartway_example_server/lib/src/generated/booking/session_booking.dart
@@ -215,51 +215,28 @@ class _SessionBookingImpl extends SessionBooking {
 class SessionBookingUpdateTable extends _i1.UpdateTable<SessionBookingTable> {
   SessionBookingUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> clubSessionId(int value) => _i1.ColumnValue(
-    table.clubSessionId,
-    value,
-  );
+  _i1.ColumnValue<int, int> clubSessionId(int value) =>
+      _i1.ColumnValue(table.clubSessionId, value);
 
-  _i1.ColumnValue<int, int> clientProfileId(int value) => _i1.ColumnValue(
-    table.clientProfileId,
-    value,
-  );
+  _i1.ColumnValue<int, int> clientProfileId(int value) =>
+      _i1.ColumnValue(table.clientProfileId, value);
 
   _i1.ColumnValue<_i4.BookingStatus, _i4.BookingStatus> status(
     _i4.BookingStatus value,
-  ) => _i1.ColumnValue(
-    table.status,
-    value,
-  );
+  ) => _i1.ColumnValue(table.status, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 }
 
 class SessionBookingTable extends _i1.Table<int?> {
   SessionBookingTable({super.tableRelation})
     : super(tableName: 'session_booking') {
     updateTable = SessionBookingUpdateTable(this);
-    clubSessionId = _i1.ColumnInt(
-      'clubSessionId',
-      this,
-    );
-    clientProfileId = _i1.ColumnInt(
-      'clientProfileId',
-      this,
-    );
-    status = _i1.ColumnEnum(
-      'status',
-      this,
-      _i1.EnumSerialization.byName,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
+    clubSessionId = _i1.ColumnInt('clubSessionId', this);
+    clientProfileId = _i1.ColumnInt('clientProfileId', this);
+    status = _i1.ColumnEnum('status', this, _i1.EnumSerialization.byName);
+    createdAt = _i1.ColumnDateTime('createdAt', this);
   }
 
   late final SessionBookingUpdateTable updateTable;
@@ -511,10 +488,7 @@ class SessionBookingRepository {
     SessionBooking row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<SessionBooking>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<SessionBooking>(row, transaction: transaction);
   }
 
   /// Updates all [SessionBooking]s in the list and returns the updated rows. If
@@ -599,10 +573,7 @@ class SessionBookingRepository {
     List<SessionBooking> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<SessionBooking>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<SessionBooking>(rows, transaction: transaction);
   }
 
   /// Deletes a single [SessionBooking].
@@ -611,10 +582,7 @@ class SessionBookingRepository {
     SessionBooking row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<SessionBooking>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<SessionBooking>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/booking/session_review.dart
+++ b/example/dartway_example_server/lib/src/generated/booking/session_review.dart
@@ -186,48 +186,27 @@ class _SessionReviewImpl extends SessionReview {
 class SessionReviewUpdateTable extends _i1.UpdateTable<SessionReviewTable> {
   SessionReviewUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> bookingId(int value) => _i1.ColumnValue(
-    table.bookingId,
-    value,
-  );
+  _i1.ColumnValue<int, int> bookingId(int value) =>
+      _i1.ColumnValue(table.bookingId, value);
 
-  _i1.ColumnValue<int, int> rating(int value) => _i1.ColumnValue(
-    table.rating,
-    value,
-  );
+  _i1.ColumnValue<int, int> rating(int value) =>
+      _i1.ColumnValue(table.rating, value);
 
-  _i1.ColumnValue<String, String> reviewText(String? value) => _i1.ColumnValue(
-    table.reviewText,
-    value,
-  );
+  _i1.ColumnValue<String, String> reviewText(String? value) =>
+      _i1.ColumnValue(table.reviewText, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 }
 
 class SessionReviewTable extends _i1.Table<int?> {
   SessionReviewTable({super.tableRelation})
     : super(tableName: 'session_review') {
     updateTable = SessionReviewUpdateTable(this);
-    bookingId = _i1.ColumnInt(
-      'bookingId',
-      this,
-    );
-    rating = _i1.ColumnInt(
-      'rating',
-      this,
-    );
-    reviewText = _i1.ColumnString(
-      'reviewText',
-      this,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
+    bookingId = _i1.ColumnInt('bookingId', this);
+    rating = _i1.ColumnInt('rating', this);
+    reviewText = _i1.ColumnString('reviewText', this);
+    createdAt = _i1.ColumnDateTime('createdAt', this);
   }
 
   late final SessionReviewUpdateTable updateTable;
@@ -452,10 +431,7 @@ class SessionReviewRepository {
     SessionReview row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<SessionReview>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<SessionReview>(row, transaction: transaction);
   }
 
   /// Updates all [SessionReview]s in the list and returns the updated rows. If
@@ -540,10 +516,7 @@ class SessionReviewRepository {
     List<SessionReview> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<SessionReview>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<SessionReview>(rows, transaction: transaction);
   }
 
   /// Deletes a single [SessionReview].
@@ -552,10 +525,7 @@ class SessionReviewRepository {
     SessionReview row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<SessionReview>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<SessionReview>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/chat/chat_channel.dart
+++ b/example/dartway_example_server/lib/src/generated/chat/chat_channel.dart
@@ -14,11 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class ChatChannel
     implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
-  ChatChannel._({
-    this.id,
-    required this.title,
-    required this.createdAt,
-  });
+  ChatChannel._({this.id, required this.title, required this.createdAt});
 
   factory ChatChannel({
     int? id,
@@ -53,11 +49,7 @@ abstract class ChatChannel
   /// Returns a shallow copy of this [ChatChannel]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  ChatChannel copyWith({
-    int? id,
-    String? title,
-    DateTime? createdAt,
-  });
+  ChatChannel copyWith({int? id, String? title, DateTime? createdAt});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -115,11 +107,7 @@ class _ChatChannelImpl extends ChatChannel {
     int? id,
     required String title,
     required DateTime createdAt,
-  }) : super._(
-         id: id,
-         title: title,
-         createdAt: createdAt,
-       );
+  }) : super._(id: id, title: title, createdAt: createdAt);
 
   /// Returns a shallow copy of this [ChatChannel]
   /// with some or all fields replaced by the given arguments.
@@ -141,29 +129,18 @@ class _ChatChannelImpl extends ChatChannel {
 class ChatChannelUpdateTable extends _i1.UpdateTable<ChatChannelTable> {
   ChatChannelUpdateTable(super.table);
 
-  _i1.ColumnValue<String, String> title(String value) => _i1.ColumnValue(
-    table.title,
-    value,
-  );
+  _i1.ColumnValue<String, String> title(String value) =>
+      _i1.ColumnValue(table.title, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 }
 
 class ChatChannelTable extends _i1.Table<int?> {
   ChatChannelTable({super.tableRelation}) : super(tableName: 'chat_channel') {
     updateTable = ChatChannelUpdateTable(this);
-    title = _i1.ColumnString(
-      'title',
-      this,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
+    title = _i1.ColumnString('title', this);
+    createdAt = _i1.ColumnDateTime('createdAt', this);
   }
 
   late final ChatChannelUpdateTable updateTable;
@@ -173,11 +150,7 @@ class ChatChannelTable extends _i1.Table<int?> {
   late final _i1.ColumnDateTime createdAt;
 
   @override
-  List<_i1.Column> get columns => [
-    id,
-    title,
-    createdAt,
-  ];
+  List<_i1.Column> get columns => [id, title, createdAt];
 }
 
 class ChatChannelInclude extends _i1.IncludeObject {
@@ -347,10 +320,7 @@ class ChatChannelRepository {
     ChatChannel row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<ChatChannel>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<ChatChannel>(row, transaction: transaction);
   }
 
   /// Updates all [ChatChannel]s in the list and returns the updated rows. If
@@ -435,10 +405,7 @@ class ChatChannelRepository {
     List<ChatChannel> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<ChatChannel>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<ChatChannel>(rows, transaction: transaction);
   }
 
   /// Deletes a single [ChatChannel].
@@ -447,10 +414,7 @@ class ChatChannelRepository {
     ChatChannel row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<ChatChannel>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<ChatChannel>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/chat/chat_message.dart
+++ b/example/dartway_example_server/lib/src/generated/chat/chat_message.dart
@@ -127,10 +127,7 @@ abstract class ChatMessage
     _i2.ChatChannelInclude? channel,
     _i3.UserProfileInclude? authorProfile,
   }) {
-    return ChatMessageInclude._(
-      channel: channel,
-      authorProfile: authorProfile,
-    );
+    return ChatMessageInclude._(channel: channel, authorProfile: authorProfile);
   }
 
   static ChatMessageIncludeList includeList({
@@ -210,47 +207,26 @@ class _ChatMessageImpl extends ChatMessage {
 class ChatMessageUpdateTable extends _i1.UpdateTable<ChatMessageTable> {
   ChatMessageUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> channelId(int value) => _i1.ColumnValue(
-    table.channelId,
-    value,
-  );
+  _i1.ColumnValue<int, int> channelId(int value) =>
+      _i1.ColumnValue(table.channelId, value);
 
-  _i1.ColumnValue<int, int> authorProfileId(int value) => _i1.ColumnValue(
-    table.authorProfileId,
-    value,
-  );
+  _i1.ColumnValue<int, int> authorProfileId(int value) =>
+      _i1.ColumnValue(table.authorProfileId, value);
 
-  _i1.ColumnValue<String, String> messageText(String value) => _i1.ColumnValue(
-    table.messageText,
-    value,
-  );
+  _i1.ColumnValue<String, String> messageText(String value) =>
+      _i1.ColumnValue(table.messageText, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 }
 
 class ChatMessageTable extends _i1.Table<int?> {
   ChatMessageTable({super.tableRelation}) : super(tableName: 'chat_message') {
     updateTable = ChatMessageUpdateTable(this);
-    channelId = _i1.ColumnInt(
-      'channelId',
-      this,
-    );
-    authorProfileId = _i1.ColumnInt(
-      'authorProfileId',
-      this,
-    );
-    messageText = _i1.ColumnString(
-      'messageText',
-      this,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
+    channelId = _i1.ColumnInt('channelId', this);
+    authorProfileId = _i1.ColumnInt('authorProfileId', this);
+    messageText = _i1.ColumnString('messageText', this);
+    createdAt = _i1.ColumnDateTime('createdAt', this);
   }
 
   late final ChatMessageUpdateTable updateTable;
@@ -502,10 +478,7 @@ class ChatMessageRepository {
     ChatMessage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<ChatMessage>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<ChatMessage>(row, transaction: transaction);
   }
 
   /// Updates all [ChatMessage]s in the list and returns the updated rows. If
@@ -590,10 +563,7 @@ class ChatMessageRepository {
     List<ChatMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<ChatMessage>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<ChatMessage>(rows, transaction: transaction);
   }
 
   /// Deletes a single [ChatMessage].
@@ -602,10 +572,7 @@ class ChatMessageRepository {
     ChatMessage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<ChatMessage>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<ChatMessage>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/news/news_post.dart
+++ b/example/dartway_example_server/lib/src/generated/news/news_post.dart
@@ -187,47 +187,26 @@ class _NewsPostImpl extends NewsPost {
 class NewsPostUpdateTable extends _i1.UpdateTable<NewsPostTable> {
   NewsPostUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> authorProfileId(int value) => _i1.ColumnValue(
-    table.authorProfileId,
-    value,
-  );
+  _i1.ColumnValue<int, int> authorProfileId(int value) =>
+      _i1.ColumnValue(table.authorProfileId, value);
 
-  _i1.ColumnValue<String, String> title(String value) => _i1.ColumnValue(
-    table.title,
-    value,
-  );
+  _i1.ColumnValue<String, String> title(String value) =>
+      _i1.ColumnValue(table.title, value);
 
-  _i1.ColumnValue<String, String> text(String value) => _i1.ColumnValue(
-    table.text,
-    value,
-  );
+  _i1.ColumnValue<String, String> text(String value) =>
+      _i1.ColumnValue(table.text, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 }
 
 class NewsPostTable extends _i1.Table<int?> {
   NewsPostTable({super.tableRelation}) : super(tableName: 'news_post') {
     updateTable = NewsPostUpdateTable(this);
-    authorProfileId = _i1.ColumnInt(
-      'authorProfileId',
-      this,
-    );
-    title = _i1.ColumnString(
-      'title',
-      this,
-    );
-    text = _i1.ColumnString(
-      'text',
-      this,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
+    authorProfileId = _i1.ColumnInt('authorProfileId', this);
+    title = _i1.ColumnString('title', this);
+    text = _i1.ColumnString('text', this);
+    createdAt = _i1.ColumnDateTime('createdAt', this);
   }
 
   late final NewsPostUpdateTable updateTable;
@@ -256,13 +235,7 @@ class NewsPostTable extends _i1.Table<int?> {
   }
 
   @override
-  List<_i1.Column> get columns => [
-    id,
-    authorProfileId,
-    title,
-    text,
-    createdAt,
-  ];
+  List<_i1.Column> get columns => [id, authorProfileId, title, text, createdAt];
 
   @override
   _i1.Table? getRelationTable(String relationField) {
@@ -452,10 +425,7 @@ class NewsPostRepository {
     NewsPost row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<NewsPost>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<NewsPost>(row, transaction: transaction);
   }
 
   /// Updates all [NewsPost]s in the list and returns the updated rows. If
@@ -540,10 +510,7 @@ class NewsPostRepository {
     List<NewsPost> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<NewsPost>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<NewsPost>(rows, transaction: transaction);
   }
 
   /// Deletes a single [NewsPost].
@@ -552,10 +519,7 @@ class NewsPostRepository {
     NewsPost row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<NewsPost>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<NewsPost>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/protocol.dart
+++ b/example/dartway_example_server/lib/src/generated/protocol.dart
@@ -681,10 +681,7 @@ class Protocol extends _i1.SerializationManagerServer {
   }
 
   @override
-  T deserialize<T>(
-    dynamic data, [
-    Type? t,
-  ]) {
+  T deserialize<T>(dynamic data, [Type? t]) {
     t ??= T;
 
     final dataClassName = getClassNameFromObjectJson(data);

--- a/example/dartway_example_server/lib/src/generated/schedule/club_service.dart
+++ b/example/dartway_example_server/lib/src/generated/schedule/club_service.dart
@@ -175,55 +175,30 @@ class _ClubServiceImpl extends ClubService {
 class ClubServiceUpdateTable extends _i1.UpdateTable<ClubServiceTable> {
   ClubServiceUpdateTable(super.table);
 
-  _i1.ColumnValue<String, String> title(String value) => _i1.ColumnValue(
-    table.title,
-    value,
-  );
+  _i1.ColumnValue<String, String> title(String value) =>
+      _i1.ColumnValue(table.title, value);
 
-  _i1.ColumnValue<String, String> description(String value) => _i1.ColumnValue(
-    table.description,
-    value,
-  );
+  _i1.ColumnValue<String, String> description(String value) =>
+      _i1.ColumnValue(table.description, value);
 
-  _i1.ColumnValue<int, int> durationMinutes(int value) => _i1.ColumnValue(
-    table.durationMinutes,
-    value,
-  );
+  _i1.ColumnValue<int, int> durationMinutes(int value) =>
+      _i1.ColumnValue(table.durationMinutes, value);
 
-  _i1.ColumnValue<int, int> price(int value) => _i1.ColumnValue(
-    table.price,
-    value,
-  );
+  _i1.ColumnValue<int, int> price(int value) =>
+      _i1.ColumnValue(table.price, value);
 
-  _i1.ColumnValue<String, String> imageUrl(String? value) => _i1.ColumnValue(
-    table.imageUrl,
-    value,
-  );
+  _i1.ColumnValue<String, String> imageUrl(String? value) =>
+      _i1.ColumnValue(table.imageUrl, value);
 }
 
 class ClubServiceTable extends _i1.Table<int?> {
   ClubServiceTable({super.tableRelation}) : super(tableName: 'club_service') {
     updateTable = ClubServiceUpdateTable(this);
-    title = _i1.ColumnString(
-      'title',
-      this,
-    );
-    description = _i1.ColumnString(
-      'description',
-      this,
-    );
-    durationMinutes = _i1.ColumnInt(
-      'durationMinutes',
-      this,
-    );
-    price = _i1.ColumnInt(
-      'price',
-      this,
-    );
-    imageUrl = _i1.ColumnString(
-      'imageUrl',
-      this,
-    );
+    title = _i1.ColumnString('title', this);
+    description = _i1.ColumnString('description', this);
+    durationMinutes = _i1.ColumnInt('durationMinutes', this);
+    price = _i1.ColumnInt('price', this);
+    imageUrl = _i1.ColumnString('imageUrl', this);
   }
 
   late final ClubServiceUpdateTable updateTable;
@@ -416,10 +391,7 @@ class ClubServiceRepository {
     ClubService row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<ClubService>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<ClubService>(row, transaction: transaction);
   }
 
   /// Updates all [ClubService]s in the list and returns the updated rows. If
@@ -504,10 +476,7 @@ class ClubServiceRepository {
     List<ClubService> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<ClubService>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<ClubService>(rows, transaction: transaction);
   }
 
   /// Deletes a single [ClubService].
@@ -516,10 +485,7 @@ class ClubServiceRepository {
     ClubService row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<ClubService>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<ClubService>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/schedule/club_session.dart
+++ b/example/dartway_example_server/lib/src/generated/schedule/club_session.dart
@@ -127,10 +127,7 @@ abstract class ClubSession
     _i2.ClubServiceInclude? service,
     _i3.UserProfileInclude? coachProfile,
   }) {
-    return ClubSessionInclude._(
-      service: service,
-      coachProfile: coachProfile,
-    );
+    return ClubSessionInclude._(service: service, coachProfile: coachProfile);
   }
 
   static ClubSessionIncludeList includeList({
@@ -210,47 +207,26 @@ class _ClubSessionImpl extends ClubSession {
 class ClubSessionUpdateTable extends _i1.UpdateTable<ClubSessionTable> {
   ClubSessionUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> serviceId(int value) => _i1.ColumnValue(
-    table.serviceId,
-    value,
-  );
+  _i1.ColumnValue<int, int> serviceId(int value) =>
+      _i1.ColumnValue(table.serviceId, value);
 
-  _i1.ColumnValue<int, int> coachProfileId(int value) => _i1.ColumnValue(
-    table.coachProfileId,
-    value,
-  );
+  _i1.ColumnValue<int, int> coachProfileId(int value) =>
+      _i1.ColumnValue(table.coachProfileId, value);
 
   _i1.ColumnValue<DateTime, DateTime> startsAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.startsAt,
-        value,
-      );
+      _i1.ColumnValue(table.startsAt, value);
 
-  _i1.ColumnValue<int, int> capacity(int value) => _i1.ColumnValue(
-    table.capacity,
-    value,
-  );
+  _i1.ColumnValue<int, int> capacity(int value) =>
+      _i1.ColumnValue(table.capacity, value);
 }
 
 class ClubSessionTable extends _i1.Table<int?> {
   ClubSessionTable({super.tableRelation}) : super(tableName: 'club_session') {
     updateTable = ClubSessionUpdateTable(this);
-    serviceId = _i1.ColumnInt(
-      'serviceId',
-      this,
-    );
-    coachProfileId = _i1.ColumnInt(
-      'coachProfileId',
-      this,
-    );
-    startsAt = _i1.ColumnDateTime(
-      'startsAt',
-      this,
-    );
-    capacity = _i1.ColumnInt(
-      'capacity',
-      this,
-    );
+    serviceId = _i1.ColumnInt('serviceId', this);
+    coachProfileId = _i1.ColumnInt('coachProfileId', this);
+    startsAt = _i1.ColumnDateTime('startsAt', this);
+    capacity = _i1.ColumnInt('capacity', this);
   }
 
   late final ClubSessionUpdateTable updateTable;
@@ -502,10 +478,7 @@ class ClubSessionRepository {
     ClubSession row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<ClubSession>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<ClubSession>(row, transaction: transaction);
   }
 
   /// Updates all [ClubSession]s in the list and returns the updated rows. If
@@ -590,10 +563,7 @@ class ClubSessionRepository {
     List<ClubSession> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<ClubSession>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<ClubSession>(rows, transaction: transaction);
   }
 
   /// Deletes a single [ClubSession].
@@ -602,10 +572,7 @@ class ClubSessionRepository {
     ClubSession row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<ClubSession>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<ClubSession>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/settings/app_setting.dart
+++ b/example/dartway_example_server/lib/src/generated/settings/app_setting.dart
@@ -14,11 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class AppSetting
     implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
-  AppSetting._({
-    this.id,
-    required this.settingKey,
-    required this.settingValue,
-  });
+  AppSetting._({this.id, required this.settingKey, required this.settingValue});
 
   factory AppSetting({
     int? id,
@@ -51,11 +47,7 @@ abstract class AppSetting
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  AppSetting copyWith({
-    int? id,
-    String? settingKey,
-    String? settingValue,
-  });
+  AppSetting copyWith({int? id, String? settingKey, String? settingValue});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -113,11 +105,7 @@ class _AppSettingImpl extends AppSetting {
     int? id,
     required String settingKey,
     required String settingValue,
-  }) : super._(
-         id: id,
-         settingKey: settingKey,
-         settingValue: settingValue,
-       );
+  }) : super._(id: id, settingKey: settingKey, settingValue: settingValue);
 
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.
@@ -139,28 +127,18 @@ class _AppSettingImpl extends AppSetting {
 class AppSettingUpdateTable extends _i1.UpdateTable<AppSettingTable> {
   AppSettingUpdateTable(super.table);
 
-  _i1.ColumnValue<String, String> settingKey(String value) => _i1.ColumnValue(
-    table.settingKey,
-    value,
-  );
+  _i1.ColumnValue<String, String> settingKey(String value) =>
+      _i1.ColumnValue(table.settingKey, value);
 
-  _i1.ColumnValue<String, String> settingValue(String value) => _i1.ColumnValue(
-    table.settingValue,
-    value,
-  );
+  _i1.ColumnValue<String, String> settingValue(String value) =>
+      _i1.ColumnValue(table.settingValue, value);
 }
 
 class AppSettingTable extends _i1.Table<int?> {
   AppSettingTable({super.tableRelation}) : super(tableName: 'app_setting') {
     updateTable = AppSettingUpdateTable(this);
-    settingKey = _i1.ColumnString(
-      'settingKey',
-      this,
-    );
-    settingValue = _i1.ColumnString(
-      'settingValue',
-      this,
-    );
+    settingKey = _i1.ColumnString('settingKey', this);
+    settingValue = _i1.ColumnString('settingValue', this);
   }
 
   late final AppSettingUpdateTable updateTable;
@@ -170,11 +148,7 @@ class AppSettingTable extends _i1.Table<int?> {
   late final _i1.ColumnString settingValue;
 
   @override
-  List<_i1.Column> get columns => [
-    id,
-    settingKey,
-    settingValue,
-  ];
+  List<_i1.Column> get columns => [id, settingKey, settingValue];
 }
 
 class AppSettingInclude extends _i1.IncludeObject {
@@ -344,10 +318,7 @@ class AppSettingRepository {
     AppSetting row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<AppSetting>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<AppSetting>(row, transaction: transaction);
   }
 
   /// Updates all [AppSetting]s in the list and returns the updated rows. If
@@ -432,10 +403,7 @@ class AppSettingRepository {
     List<AppSetting> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<AppSetting>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<AppSetting>(rows, transaction: transaction);
   }
 
   /// Deletes a single [AppSetting].
@@ -444,10 +412,7 @@ class AppSettingRepository {
     AppSetting row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<AppSetting>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<AppSetting>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/lib/src/generated/user_profile/user_profile.dart
+++ b/example/dartway_example_server/lib/src/generated/user_profile/user_profile.dart
@@ -251,109 +251,58 @@ class UserProfileUpdateTable extends _i1.UpdateTable<UserProfileTable> {
   UserProfileUpdateTable(super.table);
 
   _i1.ColumnValue<String, String> userIdentifier(String value) =>
-      _i1.ColumnValue(
-        table.userIdentifier,
-        value,
-      );
+      _i1.ColumnValue(table.userIdentifier, value);
 
-  _i1.ColumnValue<String, String> phone(String value) => _i1.ColumnValue(
-    table.phone,
-    value,
-  );
+  _i1.ColumnValue<String, String> phone(String value) =>
+      _i1.ColumnValue(table.phone, value);
 
   _i1.ColumnValue<bool, bool> agreedForMarketingCommunications(bool value) =>
-      _i1.ColumnValue(
-        table.agreedForMarketingCommunications,
-        value,
-      );
+      _i1.ColumnValue(table.agreedForMarketingCommunications, value);
 
   _i1.ColumnValue<DateTime, DateTime> conditionsAcceptedAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.conditionsAcceptedAt,
-        value,
-      );
+      _i1.ColumnValue(table.conditionsAcceptedAt, value);
 
-  _i1.ColumnValue<String, String> firstName(String value) => _i1.ColumnValue(
-    table.firstName,
-    value,
-  );
+  _i1.ColumnValue<String, String> firstName(String value) =>
+      _i1.ColumnValue(table.firstName, value);
 
-  _i1.ColumnValue<String, String> lastName(String? value) => _i1.ColumnValue(
-    table.lastName,
-    value,
-  );
+  _i1.ColumnValue<String, String> lastName(String? value) =>
+      _i1.ColumnValue(table.lastName, value);
 
-  _i1.ColumnValue<String, String> imageUrl(String? value) => _i1.ColumnValue(
-    table.imageUrl,
-    value,
-  );
+  _i1.ColumnValue<String, String> imageUrl(String? value) =>
+      _i1.ColumnValue(table.imageUrl, value);
 
   _i1.ColumnValue<_i3.UserGender, _i3.UserGender> gender(
     _i3.UserGender? value,
-  ) => _i1.ColumnValue(
-    table.gender,
-    value,
-  );
+  ) => _i1.ColumnValue(table.gender, value);
 
   _i1.ColumnValue<_i2.UserRole, _i2.UserRole> role(_i2.UserRole value) =>
-      _i1.ColumnValue(
-        table.role,
-        value,
-      );
+      _i1.ColumnValue(table.role, value);
 
   _i1.ColumnValue<String, String> testVerificationCode(String? value) =>
-      _i1.ColumnValue(
-        table.testVerificationCode,
-        value,
-      );
+      _i1.ColumnValue(table.testVerificationCode, value);
 }
 
 class UserProfileTable extends _i1.Table<int?> {
   UserProfileTable({super.tableRelation}) : super(tableName: 'user_profile') {
     updateTable = UserProfileUpdateTable(this);
-    userIdentifier = _i1.ColumnString(
-      'userIdentifier',
-      this,
-    );
-    phone = _i1.ColumnString(
-      'phone',
-      this,
-    );
+    userIdentifier = _i1.ColumnString('userIdentifier', this);
+    phone = _i1.ColumnString('phone', this);
     agreedForMarketingCommunications = _i1.ColumnBool(
       'agreedForMarketingCommunications',
       this,
     );
-    conditionsAcceptedAt = _i1.ColumnDateTime(
-      'conditionsAcceptedAt',
-      this,
-    );
-    firstName = _i1.ColumnString(
-      'firstName',
-      this,
-    );
-    lastName = _i1.ColumnString(
-      'lastName',
-      this,
-    );
-    imageUrl = _i1.ColumnString(
-      'imageUrl',
-      this,
-    );
-    gender = _i1.ColumnEnum(
-      'gender',
-      this,
-      _i1.EnumSerialization.byName,
-    );
+    conditionsAcceptedAt = _i1.ColumnDateTime('conditionsAcceptedAt', this);
+    firstName = _i1.ColumnString('firstName', this);
+    lastName = _i1.ColumnString('lastName', this);
+    imageUrl = _i1.ColumnString('imageUrl', this);
+    gender = _i1.ColumnEnum('gender', this, _i1.EnumSerialization.byName);
     role = _i1.ColumnEnum(
       'role',
       this,
       _i1.EnumSerialization.byName,
       hasDefault: true,
     );
-    testVerificationCode = _i1.ColumnString(
-      'testVerificationCode',
-      this,
-    );
+    testVerificationCode = _i1.ColumnString('testVerificationCode', this);
   }
 
   late final UserProfileUpdateTable updateTable;
@@ -561,10 +510,7 @@ class UserProfileRepository {
     UserProfile row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<UserProfile>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<UserProfile>(row, transaction: transaction);
   }
 
   /// Updates all [UserProfile]s in the list and returns the updated rows. If
@@ -649,10 +595,7 @@ class UserProfileRepository {
     List<UserProfile> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<UserProfile>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<UserProfile>(rows, transaction: transaction);
   }
 
   /// Deletes a single [UserProfile].
@@ -661,10 +604,7 @@ class UserProfileRepository {
     UserProfile row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<UserProfile>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<UserProfile>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
+++ b/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
@@ -58,14 +58,17 @@ void main() {
         expect(sent, 1);
       });
 
-      test('one that throws turns the sign-in into an error response', () async {
-        _sendVerificationCode = (code) async =>
-            throw StateError('550 sender address is not verified');
+      test(
+        'one that throws turns the sign-in into an error response',
+        () async {
+          _sendVerificationCode = (code) async =>
+              throw StateError('550 sender address is not verified');
 
-        final response = await _openLoginRequest(session);
+          final response = await _openLoginRequest(session);
 
-        expect(response.isOk, isFalse);
-      });
+          expect(response.isOk, isFalse);
+        },
+      );
 
       test('the failure message is one a sign-in screen can show', () async {
         _sendVerificationCode = (code) async =>
@@ -175,10 +178,7 @@ Future<DwApiResponse<DwModelWrapper>> _openLoginRequest(Session session) async {
   // The auth models live under DartWay's internal API, not the app's default.
   final saveConfig =
       (_dw.getCrudConfig(className) ??
-              _dw.getCrudConfig(
-                className,
-                api: DwCoreConst.dartwayInternalApi,
-              ))
+              _dw.getCrudConfig(className, api: DwCoreConst.dartwayInternalApi))
           ?.saveConfig;
 
   if (saveConfig == null) {

--- a/example/dartway_example_server/test/integration/auth_limits_test.dart
+++ b/example/dartway_example_server/test/integration/auth_limits_test.dart
@@ -72,9 +72,10 @@ void main() {
             verification.failReason,
             DwAuthFailReason.invalidVerificationCode,
           );
-          expect(await _statusOf(session, request), isNot(
-            DwAuthRequestStatus.failed,
-          ));
+          expect(
+            await _statusOf(session, request),
+            isNot(DwAuthRequestStatus.failed),
+          );
         });
 
         test(
@@ -87,7 +88,10 @@ void main() {
               await _verify(session, request, _wrongCode);
             }
 
-            expect(await _statusOf(session, request), DwAuthRequestStatus.failed);
+            expect(
+              await _statusOf(session, request),
+              DwAuthRequestStatus.failed,
+            );
 
             final afterBurn = await _verify(session, request, _knownCode);
             expect(afterBurn.failReason, DwAuthFailReason.tooManyAttempts);
@@ -95,40 +99,41 @@ void main() {
           },
         );
 
-        test(
-          'parallel guesses cannot outrun the attempt limit',
-          () async {
-            final request = await _openLoginRequest(session);
+        test('parallel guesses cannot outrun the attempt limit', () async {
+          final request = await _openLoginRequest(session);
 
-            // The regression this guards: the limit used to be a read-then-write
-            // decision (count previous attempts, compare, proceed). Fired in
-            // parallel under READ COMMITTED, every attempt read "0 previous" and
-            // every attempt got to guess — the brute-force protection came off
-            // with a bit of concurrency. Twenty guesses at once must still buy
-            // no more than the configured five.
-            //
-            // What matters is how many actually got to *check the code*: an
-            // attempt that could not take the lock is refused outright
-            // (rateLimited) and learns nothing.
-            final verifications = await Future.wait([
-              for (var i = 0; i < 20; i++) _verify(session, request, _wrongCode),
-            ]);
+          // The regression this guards: the limit used to be a read-then-write
+          // decision (count previous attempts, compare, proceed). Fired in
+          // parallel under READ COMMITTED, every attempt read "0 previous" and
+          // every attempt got to guess — the brute-force protection came off
+          // with a bit of concurrency. Twenty guesses at once must still buy
+          // no more than the configured five.
+          //
+          // What matters is how many actually got to *check the code*: an
+          // attempt that could not take the lock is refused outright
+          // (rateLimited) and learns nothing.
+          final verifications = await Future.wait([
+            for (var i = 0; i < 20; i++) _verify(session, request, _wrongCode),
+          ]);
 
-            final guessesEvaluated = verifications
-                .where(
-                  (v) => v.failReason == DwAuthFailReason.invalidVerificationCode,
-                )
-                .length;
+          final guessesEvaluated = verifications
+              .where(
+                (v) => v.failReason == DwAuthFailReason.invalidVerificationCode,
+              )
+              .length;
 
-            expect(guessesEvaluated, lessThanOrEqualTo(_maxVerificationAttempts));
-          },
-        );
+          expect(guessesEvaluated, lessThanOrEqualTo(_maxVerificationAttempts));
+        });
       });
 
       group('access token', () {
         test('is single use', () async {
           final request = await _openLoginRequest(session);
-          final token = (await _verify(session, request, _knownCode)).accessToken!;
+          final token = (await _verify(
+            session,
+            request,
+            _knownCode,
+          )).accessToken!;
 
           final first = await _redeem(session, token);
           expect(first.status, DwAuthRequestStatus.verified);
@@ -138,28 +143,28 @@ void main() {
           expect(second.failReason, DwAuthFailReason.invalidAccessToken);
         });
 
-        test(
-          'two parallel redemptions sign in exactly once',
-          () async {
-            final request = await _openLoginRequest(session);
-            final token =
-                (await _verify(session, request, _knownCode)).accessToken!;
+        test('two parallel redemptions sign in exactly once', () async {
+          final request = await _openLoginRequest(session);
+          final token = (await _verify(
+            session,
+            request,
+            _knownCode,
+          )).accessToken!;
 
-            // Same regression, sharper stakes: both redemptions used to read
-            // `verified` and both were signed in, so a "single-use" token handed
-            // out two sessions.
-            final results = await Future.wait([
-              _redeem(session, token),
-              _redeem(session, token),
-            ]);
+          // Same regression, sharper stakes: both redemptions used to read
+          // `verified` and both were signed in, so a "single-use" token handed
+          // out two sessions.
+          final results = await Future.wait([
+            _redeem(session, token),
+            _redeem(session, token),
+          ]);
 
-            final signedIn = results
-                .where((r) => r.status == DwAuthRequestStatus.verified)
-                .length;
+          final signedIn = results
+              .where((r) => r.status == DwAuthRequestStatus.verified)
+              .length;
 
-            expect(signedIn, 1);
-          },
-        );
+          expect(signedIn, 1);
+        });
       });
 
       group('request rate limit', () {
@@ -212,10 +217,7 @@ Future<T> _save<T extends TableRow>(Session session, T model) async {
   // default one — the same lookup the CRUD endpoint performs.
   final saveConfig =
       (dw.getCrudConfig(className) ??
-              dw.getCrudConfig(
-                className,
-                api: DwCoreConst.dartwayInternalApi,
-              ))
+              dw.getCrudConfig(className, api: DwCoreConst.dartwayInternalApi))
           ?.saveConfig;
 
   if (saveConfig == null) {
@@ -277,8 +279,14 @@ Future<DwAuthRequestStatus> _statusOf(
 }
 
 Future<void> _wipeAuthTables(Session session) async {
-  await DwAuthVerification.db.deleteWhere(session, where: (t) => Constant.bool(true));
-  await DwAuthRequest.db.deleteWhere(session, where: (t) => Constant.bool(true));
+  await DwAuthVerification.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
+  await DwAuthRequest.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
   await DwAuthKey.db.deleteWhere(session, where: (t) => Constant.bool(true));
   await UserProfile.db.deleteWhere(session, where: (t) => Constant.bool(true));
 }

--- a/example/dartway_example_server/test/integration/booking_capacity_test.dart
+++ b/example/dartway_example_server/test/integration/booking_capacity_test.dart
@@ -114,7 +114,11 @@ void main() {
           expect(response.isOk, isTrue);
         }
 
-        final overflow = await _bookRaw(session, clubSession, clients[_capacity]);
+        final overflow = await _bookRaw(
+          session,
+          clubSession,
+          clients[_capacity],
+        );
 
         expect(overflow.isOk, isFalse);
         expect(overflow.error, 'No spots left for this session');
@@ -198,7 +202,10 @@ Future<List<UserProfile>> _seedClients(Session session, int count) async {
 }
 
 Future<void> _wipeTables(Session session) async {
-  await SessionBooking.db.deleteWhere(session, where: (t) => Constant.bool(true));
+  await SessionBooking.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
   await ClubSession.db.deleteWhere(session, where: (t) => Constant.bool(true));
   await UserProfile.db.deleteWhere(session, where: (t) => Constant.bool(true));
 }

--- a/example/dartway_example_server/test/integration/dw_core_profile_transaction_test.dart
+++ b/example/dartway_example_server/test/integration/dw_core_profile_transaction_test.dart
@@ -64,40 +64,41 @@ void main() {
           UserProfile? byId;
           UserProfile? byIdentifier;
 
-          final response = await DwSaveConfig<AppSetting>(
-            allowSave: (session, saveContext) async => true,
-            beforeSaveTransaction: (session, saveContext) async {
-              final transaction = saveContext.transaction;
-              current = await dw.currentUserProfile(
-                session,
-                transaction: transaction,
+          final response =
+              await DwSaveConfig<AppSetting>(
+                allowSave: (session, saveContext) async => true,
+                beforeSaveTransaction: (session, saveContext) async {
+                  final transaction = saveContext.transaction;
+                  current = await dw.currentUserProfile(
+                    session,
+                    transaction: transaction,
+                  );
+                  byId = await dw.getUserProfile(
+                    session,
+                    saveContext.currentUserId!,
+                    transaction: transaction,
+                  );
+                  byIdentifier = await dw.getUserProfileByIdentifier(
+                    session,
+                    _identifier,
+                    transaction: transaction,
+                  );
+                  return null;
+                },
+                // The same read after the write, still inside the transaction: the
+                // second hook is where an audit row or a counter would be updated,
+                // and it hits the same wall.
+                afterSaveTransaction: (session, saveContext) async {
+                  final seen = await dw.currentUserProfile(
+                    session,
+                    transaction: saveContext.transaction,
+                  );
+                  return seen == null ? 'The author vanished mid-save' : null;
+                },
+              ).save(
+                authored,
+                AppSetting(settingKey: _settingKey, settingValue: 'stamped'),
               );
-              byId = await dw.getUserProfile(
-                session,
-                saveContext.currentUserId!,
-                transaction: transaction,
-              );
-              byIdentifier = await dw.getUserProfileByIdentifier(
-                session,
-                _identifier,
-                transaction: transaction,
-              );
-              return null;
-            },
-            // The same read after the write, still inside the transaction: the
-            // second hook is where an audit row or a counter would be updated,
-            // and it hits the same wall.
-            afterSaveTransaction: (session, saveContext) async {
-              final seen = await dw.currentUserProfile(
-                session,
-                transaction: saveContext.transaction,
-              );
-              return seen == null ? 'The author vanished mid-save' : null;
-            },
-          ).save(
-            authored,
-            AppSetting(settingKey: _settingKey, settingValue: 'stamped'),
-          );
 
           expect(response.isOk, isTrue, reason: response.error);
           expect(current?.id, author.id);
@@ -110,36 +111,39 @@ void main() {
         'a hook sees a profile the same transaction has not committed yet',
         () async {
           final session = sessionBuilder.build();
-          final settled = await DwSaveConfig<AppSetting>(
-            allowSave: (session, saveContext) async => true,
-            beforeSaveTransaction: (session, saveContext) async {
-              // Written inside the save transaction and invisible to anything
-              // reading around it — which is the other half of why the reads
-              // take a transaction, and the half that also bites in production.
-              final latecomer = await UserProfile.db.insertRow(
-                session,
-                UserProfile(
-                  userIdentifier: _latecomerIdentifier,
-                  phone: _latecomerIdentifier,
-                  firstName: 'Latecomer',
-                  role: UserRole.client,
-                  agreedForMarketingCommunications: false,
-                  conditionsAcceptedAt: DateTime.now().toUtc(),
-                ),
-                transaction: saveContext.transaction,
-              );
+          final settled =
+              await DwSaveConfig<AppSetting>(
+                allowSave: (session, saveContext) async => true,
+                beforeSaveTransaction: (session, saveContext) async {
+                  // Written inside the save transaction and invisible to anything
+                  // reading around it — which is the other half of why the reads
+                  // take a transaction, and the half that also bites in production.
+                  final latecomer = await UserProfile.db.insertRow(
+                    session,
+                    UserProfile(
+                      userIdentifier: _latecomerIdentifier,
+                      phone: _latecomerIdentifier,
+                      firstName: 'Latecomer',
+                      role: UserRole.client,
+                      agreedForMarketingCommunications: false,
+                      conditionsAcceptedAt: DateTime.now().toUtc(),
+                    ),
+                    transaction: saveContext.transaction,
+                  );
 
-              final read = await dw.getUserProfile(
+                  final read = await dw.getUserProfile(
+                    session,
+                    latecomer.id!,
+                    transaction: saveContext.transaction,
+                  );
+                  return read == null
+                      ? 'Uncommitted profile not visible'
+                      : null;
+                },
+              ).save(
                 session,
-                latecomer.id!,
-                transaction: saveContext.transaction,
+                AppSetting(settingKey: _latecomerKey, settingValue: 'stamped'),
               );
-              return read == null ? 'Uncommitted profile not visible' : null;
-            },
-          ).save(
-            session,
-            AppSetting(settingKey: _latecomerKey, settingValue: 'stamped'),
-          );
 
           expect(settled.isOk, isTrue, reason: settled.error);
         },

--- a/example/dartway_example_server/test/integration/dw_db_test.dart
+++ b/example/dartway_example_server/test/integration/dw_db_test.dart
@@ -25,77 +25,91 @@ void main() {
         );
       });
 
-      test('the five operations round-trip a row of an unknown model', () async {
-        final session = sessionBuilder.build();
+      test(
+        'the five operations round-trip a row of an unknown model',
+        () async {
+          final session = sessionBuilder.build();
 
-        final inserted = await dw
-            .db(session)
-            .insertRow<AppSetting>(
-              AppSetting(settingKey: _settingKey, settingValue: 'initial'),
-            );
-        expect(inserted.id, isNotNull);
-
-        final updated = await dw
-            .db(session)
-            .updateRow<AppSetting>(inserted.copyWith(settingValue: 'updated'));
-        expect(updated.settingValue, 'updated');
-
-        final found = await dw
-            .db(session)
-            .find<AppSetting>(
-              where: AppSetting.t.settingKey.equals(_settingKey),
-            );
-        expect(found.single.settingValue, 'updated');
-
-        expect(
-          await dw
+          final inserted = await dw
               .db(session)
-              .count<AppSetting>(
+              .insertRow<AppSetting>(
+                AppSetting(settingKey: _settingKey, settingValue: 'initial'),
+              );
+          expect(inserted.id, isNotNull);
+
+          final updated = await dw
+              .db(session)
+              .updateRow<AppSetting>(
+                inserted.copyWith(settingValue: 'updated'),
+              );
+          expect(updated.settingValue, 'updated');
+
+          final found = await dw
+              .db(session)
+              .find<AppSetting>(
                 where: AppSetting.t.settingKey.equals(_settingKey),
-              ),
-          1,
-        );
+              );
+          expect(found.single.settingValue, 'updated');
 
-        await dw.db(session).deleteRow<AppSetting>(updated);
-        expect(
+          expect(
+            await dw
+                .db(session)
+                .count<AppSetting>(
+                  where: AppSetting.t.settingKey.equals(_settingKey),
+                ),
+            1,
+          );
+
+          await dw.db(session).deleteRow<AppSetting>(updated);
+          expect(
+            await dw
+                .db(session)
+                .count<AppSetting>(
+                  where: AppSetting.t.settingKey.equals(_settingKey),
+                ),
+            0,
+          );
+        },
+      );
+
+      test(
+        'a caller that does not know the model still gets its rows',
+        () async {
+          final session = sessionBuilder.build();
           await dw
               .db(session)
-              .count<AppSetting>(
-                where: AppSetting.t.settingKey.equals(_settingKey),
-              ),
-          0,
-        );
-      });
-
-      test('a caller that does not know the model still gets its rows', () async {
-        final session = sessionBuilder.build();
-        await dw
-            .db(session)
-            .insertRow<AppSetting>(
-              AppSetting(settingKey: '${_sweepPrefix}a', settingValue: 'stale'),
-            );
-        await dw
-            .db(session)
-            .insertRow<AppSetting>(
-              AppSetting(settingKey: '${_sweepPrefix}b', settingValue: 'stale'),
-            );
-
-        expect(
-          await _sweep<AppSetting>(
-            session,
-            where: AppSetting.t.settingValue.equals('stale'),
-          ),
-          2,
-        );
-        expect(
+              .insertRow<AppSetting>(
+                AppSetting(
+                  settingKey: '${_sweepPrefix}a',
+                  settingValue: 'stale',
+                ),
+              );
           await dw
               .db(session)
-              .count<AppSetting>(
-                where: AppSetting.t.settingValue.equals('stale'),
-              ),
-          0,
-        );
-      });
+              .insertRow<AppSetting>(
+                AppSetting(
+                  settingKey: '${_sweepPrefix}b',
+                  settingValue: 'stale',
+                ),
+              );
+
+          expect(
+            await _sweep<AppSetting>(
+              session,
+              where: AppSetting.t.settingValue.equals('stale'),
+            ),
+            2,
+          );
+          expect(
+            await dw
+                .db(session)
+                .count<AppSetting>(
+                  where: AppSetting.t.settingValue.equals('stale'),
+                ),
+            0,
+          );
+        },
+      );
 
       test('every operation can be pinned to an open transaction', () async {
         final session = sessionBuilder.build();

--- a/example/dartway_example_server/test/integration/dw_save_config_integration_test.dart
+++ b/example/dartway_example_server/test/integration/dw_save_config_integration_test.dart
@@ -371,19 +371,22 @@ void main() {
           final session = sessionBuilder.build();
           final threw = Completer<void>();
 
-          final response = await DwSaveConfig<AppSetting>(
-            allowSave: (session, context) async => true,
-            afterSaveSideEffects: (session, context) async {
-              threw.complete();
-              throw StateError('the mail provider refused the sender address');
-            },
-          ).save(
-            session,
-            AppSetting(
-              settingKey: '${_testKeyPrefix}side_effect_throws',
-              settingValue: 'inserted',
-            ),
-          );
+          final response =
+              await DwSaveConfig<AppSetting>(
+                allowSave: (session, context) async => true,
+                afterSaveSideEffects: (session, context) async {
+                  threw.complete();
+                  throw StateError(
+                    'the mail provider refused the sender address',
+                  );
+                },
+              ).save(
+                session,
+                AppSetting(
+                  settingKey: '${_testKeyPrefix}side_effect_throws',
+                  settingValue: 'inserted',
+                ),
+              );
 
           // Nobody waits for the hook, so its failure must not touch the
           // response — the contract is unchanged.

--- a/example/dartway_example_server/test/integration/dw_save_config_server_only_test.dart
+++ b/example/dartway_example_server/test/integration/dw_save_config_server_only_test.dart
@@ -21,281 +21,293 @@ const _testIdentifierPrefix = 'dw_server_only_test_';
 /// abstract: it is the fixed sign-in code for reviewer and demo accounts.
 /// Leaking it hands over a login; blanking it locks those accounts out.
 void main() {
-  withServerpod('DwSaveConfig and scope=serverOnly', (
-    sessionBuilder,
-    endpoints,
-  ) {
-    setUp(() => _clearTestProfiles(sessionBuilder.build()));
-    tearDown(() => _clearTestProfiles(sessionBuilder.build()));
+  withServerpod(
+    'DwSaveConfig and scope=serverOnly',
+    (sessionBuilder, endpoints) {
+      setUp(() => _clearTestProfiles(sessionBuilder.build()));
+      tearDown(() => _clearTestProfiles(sessionBuilder.build()));
 
-    /// A stored profile that has a server-side code, so a save has something to
-    /// destroy and a response has something to leak.
-    Future<UserProfile> storedProfile(
-      Session session, {
-      required String suffix,
-      String? testVerificationCode = 'THE-CODE',
-    }) => UserProfile.db.insertRow(
-      session,
-      UserProfile(
-        userIdentifier: '$_testIdentifierPrefix$suffix',
-        phone: '$_testIdentifierPrefix$suffix',
-        agreedForMarketingCommunications: false,
-        conditionsAcceptedAt: DateTime.now().toUtc(),
-        firstName: 'Ada',
-        testVerificationCode: testVerificationCode,
-      ),
-    );
-
-    /// The model as it comes back from a client.
-    ///
-    /// Round-tripped through `toJsonForProtocol` on purpose rather than by
-    /// setting the field to null by hand: that map *is* what the client was
-    /// given, so what survives the trip is exactly what a client is able to
-    /// send back. The `serverOnly` field is not omitted by this helper — it is
-    /// missing because the wire form never carried it.
-    UserProfile asReturnedByClient(UserProfile stored) =>
-        UserProfile.fromJson(stored.toJsonForProtocol());
-
-    test('the wire form a client sends back has no serverOnly field', () {
-      // The premise of every test below. If this stopped holding, they would
-      // all keep passing while testing nothing.
-      final profile = UserProfile(
-        userIdentifier: 'x',
-        phone: 'x',
-        agreedForMarketingCommunications: false,
-        conditionsAcceptedAt: DateTime.now().toUtc(),
-        firstName: 'Ada',
-        testVerificationCode: 'THE-CODE',
-      );
-
-      expect(profile.toJson(), contains('testVerificationCode'));
-      expect(profile.toJsonForProtocol(), isNot(contains('testVerificationCode')));
-      expect(asReturnedByClient(profile).testVerificationCode, isNull);
-    });
-
-    test('a client save leaves the serverOnly column as it was', () async {
-      final session = sessionBuilder.build();
-      final stored = await storedProfile(session, suffix: 'plain_save');
-
-      final response = await DwSaveConfig<UserProfile>(
-        allowSave: (session, context) async => true,
-      ).save(
-        session,
-        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
-      );
-
-      expect(response.isOk, isTrue);
-      final reloaded = await UserProfile.db.findById(session, stored.id!);
-      // The edit the client actually made goes through...
-      expect(reloaded?.firstName, 'Grace');
-      // ...and the column it could not see is untouched.
-      expect(reloaded?.testVerificationCode, 'THE-CODE');
-    });
-
-    test('the locked update path protects the column too', () async {
-      // A separate entry point into the same write, and the one a config with
-      // state-dependent rules uses. Worth its own test: a fix applied to only
-      // one of the two paths would look complete.
-      final session = sessionBuilder.build();
-      final stored = await storedProfile(session, suffix: 'locked_save');
-
-      final response = await DwSaveConfig<UserProfile>(
-        lockInitialModelForUpdate: true,
-        allowSave: (session, context) async => true,
-      ).save(
-        session,
-        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
-      );
-
-      expect(response.isOk, isTrue);
-      final reloaded = await UserProfile.db.findById(session, stored.id!);
-      expect(reloaded?.firstName, 'Grace');
-      expect(reloaded?.testVerificationCode, 'THE-CODE');
-    });
-
-    test('a hook that assigns a serverOnly value writes it', () async {
-      // The legitimate case the narrow rule exists to keep working: the server
-      // computes the value itself, so it is not null on the way in and is
-      // written like any other column.
-      final session = sessionBuilder.build();
-      final stored = await storedProfile(session, suffix: 'hook_assigns');
-
-      final response = await DwSaveConfig<UserProfile>(
-        allowSave: (session, context) async => true,
-        beforeSaveTransaction: (session, context) async {
-          context.currentModel = context.currentModel.copyWith(
-            testVerificationCode: 'ROTATED',
-          );
-          return null;
-        },
-      ).save(session, asReturnedByClient(stored));
-
-      expect(response.isOk, isTrue);
-      expect(
-        (await UserProfile.db.findById(
-          session,
-          stored.id!,
-        ))?.testVerificationCode,
-        'ROTATED',
-      );
-    });
-
-    test('a hook cannot clear the column without the opt-out', () async {
-      // The one case the narrow rule costs, stated as a test so it is a known
-      // trade-off rather than a surprise.
-      final session = sessionBuilder.build();
-      final stored = await storedProfile(session, suffix: 'hook_clears');
-
-      await DwSaveConfig<UserProfile>(
-        allowSave: (session, context) async => true,
-        beforeSaveTransaction: (session, context) async {
-          context.currentModel = context.currentModel.copyWith(
-            testVerificationCode: null,
-          );
-          return null;
-        },
-      ).save(session, asReturnedByClient(stored));
-
-      expect(
-        (await UserProfile.db.findById(
-          session,
-          stored.id!,
-        ))?.testVerificationCode,
-        'THE-CODE',
-      );
-    });
-
-    test('allowServerOnlyOverwrite lets the column be cleared', () async {
-      final session = sessionBuilder.build();
-      final stored = await storedProfile(session, suffix: 'opt_out');
-
-      final response = await DwSaveConfig<UserProfile>(
-        allowServerOnlyOverwrite: true,
-        allowSave: (session, context) async => true,
-      ).save(session, asReturnedByClient(stored));
-
-      expect(response.isOk, isTrue);
-      expect(
-        (await UserProfile.db.findById(
-          session,
-          stored.id!,
-        ))?.testVerificationCode,
-        isNull,
-      );
-    });
-
-    test('an insert still writes the serverOnly value', () async {
-      // Inserts are outside the guard entirely — there is no stored row to
-      // protect, and a skipped column here would silently drop the value.
-      final session = sessionBuilder.build();
-
-      final response = await DwSaveConfig<UserProfile>(
-        allowSave: (session, context) async => true,
-      ).save(
+      /// A stored profile that has a server-side code, so a save has something to
+      /// destroy and a response has something to leak.
+      Future<UserProfile> storedProfile(
+        Session session, {
+        required String suffix,
+        String? testVerificationCode = 'THE-CODE',
+      }) => UserProfile.db.insertRow(
         session,
         UserProfile(
-          userIdentifier: '${_testIdentifierPrefix}insert',
-          phone: '${_testIdentifierPrefix}insert',
+          userIdentifier: '$_testIdentifierPrefix$suffix',
+          phone: '$_testIdentifierPrefix$suffix',
           agreedForMarketingCommunications: false,
           conditionsAcceptedAt: DateTime.now().toUtc(),
           firstName: 'Ada',
-          testVerificationCode: 'FRESH',
+          testVerificationCode: testVerificationCode,
         ),
       );
 
-      expect(response.isOk, isTrue);
-      final inserted = await UserProfile.db.findFirstRow(
-        session,
-        where: (t) =>
-            t.userIdentifier.equals('${_testIdentifierPrefix}insert'),
-      );
-      expect(inserted?.testVerificationCode, 'FRESH');
-    });
+      /// The model as it comes back from a client.
+      ///
+      /// Round-tripped through `toJsonForProtocol` on purpose rather than by
+      /// setting the field to null by hand: that map *is* what the client was
+      /// given, so what survives the trip is exactly what a client is able to
+      /// send back. The `serverOnly` field is not omitted by this helper — it is
+      /// missing because the wire form never carried it.
+      UserProfile asReturnedByClient(UserProfile stored) =>
+          UserProfile.fromJson(stored.toJsonForProtocol());
 
-    test('a save leaves an unrelated row alone', () async {
-      // The column list is built per row. A bug that built it once and reused
-      // it would show up as a neighbour losing its code.
-      final session = sessionBuilder.build();
-      final mine = await storedProfile(session, suffix: 'mine');
-      final neighbour = await storedProfile(
-        session,
-        suffix: 'neighbour',
-        testVerificationCode: 'NEIGHBOUR-CODE',
-      );
+      test('the wire form a client sends back has no serverOnly field', () {
+        // The premise of every test below. If this stopped holding, they would
+        // all keep passing while testing nothing.
+        final profile = UserProfile(
+          userIdentifier: 'x',
+          phone: 'x',
+          agreedForMarketingCommunications: false,
+          conditionsAcceptedAt: DateTime.now().toUtc(),
+          firstName: 'Ada',
+          testVerificationCode: 'THE-CODE',
+        );
 
-      await DwSaveConfig<UserProfile>(
-        allowSave: (session, context) async => true,
-      ).save(session, asReturnedByClient(mine).copyWith(firstName: 'Grace'));
+        expect(profile.toJson(), contains('testVerificationCode'));
+        expect(
+          profile.toJsonForProtocol(),
+          isNot(contains('testVerificationCode')),
+        );
+        expect(asReturnedByClient(profile).testVerificationCode, isNull);
+      });
 
-      expect(
-        (await UserProfile.db.findById(
+      test('a client save leaves the serverOnly column as it was', () async {
+        final session = sessionBuilder.build();
+        final stored = await storedProfile(session, suffix: 'plain_save');
+
+        final response =
+            await DwSaveConfig<UserProfile>(
+              allowSave: (session, context) async => true,
+            ).save(
+              session,
+              asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+            );
+
+        expect(response.isOk, isTrue);
+        final reloaded = await UserProfile.db.findById(session, stored.id!);
+        // The edit the client actually made goes through...
+        expect(reloaded?.firstName, 'Grace');
+        // ...and the column it could not see is untouched.
+        expect(reloaded?.testVerificationCode, 'THE-CODE');
+      });
+
+      test('the locked update path protects the column too', () async {
+        // A separate entry point into the same write, and the one a config with
+        // state-dependent rules uses. Worth its own test: a fix applied to only
+        // one of the two paths would look complete.
+        final session = sessionBuilder.build();
+        final stored = await storedProfile(session, suffix: 'locked_save');
+
+        final response =
+            await DwSaveConfig<UserProfile>(
+              lockInitialModelForUpdate: true,
+              allowSave: (session, context) async => true,
+            ).save(
+              session,
+              asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+            );
+
+        expect(response.isOk, isTrue);
+        final reloaded = await UserProfile.db.findById(session, stored.id!);
+        expect(reloaded?.firstName, 'Grace');
+        expect(reloaded?.testVerificationCode, 'THE-CODE');
+      });
+
+      test('a hook that assigns a serverOnly value writes it', () async {
+        // The legitimate case the narrow rule exists to keep working: the server
+        // computes the value itself, so it is not null on the way in and is
+        // written like any other column.
+        final session = sessionBuilder.build();
+        final stored = await storedProfile(session, suffix: 'hook_assigns');
+
+        final response = await DwSaveConfig<UserProfile>(
+          allowSave: (session, context) async => true,
+          beforeSaveTransaction: (session, context) async {
+            context.currentModel = context.currentModel.copyWith(
+              testVerificationCode: 'ROTATED',
+            );
+            return null;
+          },
+        ).save(session, asReturnedByClient(stored));
+
+        expect(response.isOk, isTrue);
+        expect(
+          (await UserProfile.db.findById(
+            session,
+            stored.id!,
+          ))?.testVerificationCode,
+          'ROTATED',
+        );
+      });
+
+      test('a hook cannot clear the column without the opt-out', () async {
+        // The one case the narrow rule costs, stated as a test so it is a known
+        // trade-off rather than a surprise.
+        final session = sessionBuilder.build();
+        final stored = await storedProfile(session, suffix: 'hook_clears');
+
+        await DwSaveConfig<UserProfile>(
+          allowSave: (session, context) async => true,
+          beforeSaveTransaction: (session, context) async {
+            context.currentModel = context.currentModel.copyWith(
+              testVerificationCode: null,
+            );
+            return null;
+          },
+        ).save(session, asReturnedByClient(stored));
+
+        expect(
+          (await UserProfile.db.findById(
+            session,
+            stored.id!,
+          ))?.testVerificationCode,
+          'THE-CODE',
+        );
+      });
+
+      test('allowServerOnlyOverwrite lets the column be cleared', () async {
+        final session = sessionBuilder.build();
+        final stored = await storedProfile(session, suffix: 'opt_out');
+
+        final response = await DwSaveConfig<UserProfile>(
+          allowServerOnlyOverwrite: true,
+          allowSave: (session, context) async => true,
+        ).save(session, asReturnedByClient(stored));
+
+        expect(response.isOk, isTrue);
+        expect(
+          (await UserProfile.db.findById(
+            session,
+            stored.id!,
+          ))?.testVerificationCode,
+          isNull,
+        );
+      });
+
+      test('an insert still writes the serverOnly value', () async {
+        // Inserts are outside the guard entirely — there is no stored row to
+        // protect, and a skipped column here would silently drop the value.
+        final session = sessionBuilder.build();
+
+        final response =
+            await DwSaveConfig<UserProfile>(
+              allowSave: (session, context) async => true,
+            ).save(
+              session,
+              UserProfile(
+                userIdentifier: '${_testIdentifierPrefix}insert',
+                phone: '${_testIdentifierPrefix}insert',
+                agreedForMarketingCommunications: false,
+                conditionsAcceptedAt: DateTime.now().toUtc(),
+                firstName: 'Ada',
+                testVerificationCode: 'FRESH',
+              ),
+            );
+
+        expect(response.isOk, isTrue);
+        final inserted = await UserProfile.db.findFirstRow(
           session,
-          neighbour.id!,
-        ))?.testVerificationCode,
-        'NEIGHBOUR-CODE',
-      );
-    });
+          where: (t) =>
+              t.userIdentifier.equals('${_testIdentifierPrefix}insert'),
+        );
+        expect(inserted?.testVerificationCode, 'FRESH');
+      });
 
-    test('a row whose serverOnly column is null saves normally', () async {
-      // The gate that skips the work compares map sizes, and a null column is
-      // missing from both maps — so this row takes the cheap path. It must
-      // still save everything else.
-      final session = sessionBuilder.build();
-      final stored = await storedProfile(
-        session,
-        suffix: 'null_code',
-        testVerificationCode: null,
-      );
+      test('a save leaves an unrelated row alone', () async {
+        // The column list is built per row. A bug that built it once and reused
+        // it would show up as a neighbour losing its code.
+        final session = sessionBuilder.build();
+        final mine = await storedProfile(session, suffix: 'mine');
+        final neighbour = await storedProfile(
+          session,
+          suffix: 'neighbour',
+          testVerificationCode: 'NEIGHBOUR-CODE',
+        );
 
-      final response = await DwSaveConfig<UserProfile>(
-        allowSave: (session, context) async => true,
-      ).save(
-        session,
-        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
-      );
+        await DwSaveConfig<UserProfile>(
+          allowSave: (session, context) async => true,
+        ).save(session, asReturnedByClient(mine).copyWith(firstName: 'Grace'));
 
-      expect(response.isOk, isTrue);
-      final reloaded = await UserProfile.db.findById(session, stored.id!);
-      expect(reloaded?.firstName, 'Grace');
-      expect(reloaded?.testVerificationCode, isNull);
-    });
+        expect(
+          (await UserProfile.db.findById(
+            session,
+            neighbour.id!,
+          ))?.testVerificationCode,
+          'NEIGHBOUR-CODE',
+        );
+      });
 
-    test('the save response does not carry the serverOnly column', () async {
-      // The outbound half, end to end and through the real envelope:
-      // DwApiResponse -> DwModelWrapper -> model. Only reachable with a booted
-      // server, because the wrapper resolves its class name through
-      // `Serverpod.instance` — which is why the unit suite in core_server stops
-      // one level short of this.
-      final session = sessionBuilder.build();
-      final stored = await storedProfile(session, suffix: 'response');
+      test('a row whose serverOnly column is null saves normally', () async {
+        // The gate that skips the work compares map sizes, and a null column is
+        // missing from both maps — so this row takes the cheap path. It must
+        // still save everything else.
+        final session = sessionBuilder.build();
+        final stored = await storedProfile(
+          session,
+          suffix: 'null_code',
+          testVerificationCode: null,
+        );
 
-      final response = await DwSaveConfig<UserProfile>(
-        allowSave: (session, context) async => true,
-      ).save(
-        session,
-        asReturnedByClient(stored).copyWith(firstName: 'Grace'),
-      );
+        final response =
+            await DwSaveConfig<UserProfile>(
+              allowSave: (session, context) async => true,
+            ).save(
+              session,
+              asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+            );
 
-      final wire = response.toJsonForProtocol();
-      expect(wire['value']['data'], isNot(contains('testVerificationCode')));
-      for (final updated in wire['updatedModels'] as List) {
-        expect(updated['data'], isNot(contains('testVerificationCode')));
-      }
-      // The encoder Serverpod actually runs over the result, as the last word:
-      // no assertion about maps can rule out the string on the socket.
-      expect(
-        SerializationManager.encodeForProtocol(response),
-        isNot(contains('testVerificationCode')),
-      );
-    });
-  }, rollbackDatabase: RollbackDatabase.disabled);
+        expect(response.isOk, isTrue);
+        final reloaded = await UserProfile.db.findById(session, stored.id!);
+        expect(reloaded?.firstName, 'Grace');
+        expect(reloaded?.testVerificationCode, isNull);
+      });
+
+      test('the save response does not carry the serverOnly column', () async {
+        // The outbound half, end to end and through the real envelope:
+        // DwApiResponse -> DwModelWrapper -> model. Only reachable with a booted
+        // server, because the wrapper resolves its class name through
+        // `Serverpod.instance` — which is why the unit suite in core_server stops
+        // one level short of this.
+        final session = sessionBuilder.build();
+        final stored = await storedProfile(session, suffix: 'response');
+
+        final response =
+            await DwSaveConfig<UserProfile>(
+              allowSave: (session, context) async => true,
+            ).save(
+              session,
+              asReturnedByClient(stored).copyWith(firstName: 'Grace'),
+            );
+
+        final wire = response.toJsonForProtocol();
+        expect(wire['value']['data'], isNot(contains('testVerificationCode')));
+        for (final updated in wire['updatedModels'] as List) {
+          expect(updated['data'], isNot(contains('testVerificationCode')));
+        }
+        // The encoder Serverpod actually runs over the result, as the last word:
+        // no assertion about maps can rule out the string on the socket.
+        expect(
+          SerializationManager.encodeForProtocol(response),
+          isNot(contains('testVerificationCode')),
+        );
+      });
+    },
+    rollbackDatabase: RollbackDatabase.disabled,
+  );
 }
 
 Future<void> _clearTestProfiles(Session session) async {
-  await session.db.unsafeExecute('''
+  await session.db.unsafeExecute(
+    '''
 DELETE FROM "user_profile"
 WHERE "userIdentifier" LIKE @identifierPrefix
-''', parameters: QueryParameters.named({
-    'identifierPrefix': '$_testIdentifierPrefix%',
-  }));
+''',
+    parameters: QueryParameters.named({
+      'identifierPrefix': '$_testIdentifierPrefix%',
+    }),
+  );
 }

--- a/example/dartway_example_server/test/integration/password_hashing_test.dart
+++ b/example/dartway_example_server/test/integration/password_hashing_test.dart
@@ -65,28 +65,43 @@ void main() {
       tearDown(() async => _wipeTables(session));
 
       test('the old password signs them in', () async {
-        await _seedHash(session, userId, _LegacySha256Verifier.hashOf(_password));
+        await _seedHash(
+          session,
+          userId,
+          _LegacySha256Verifier.hashOf(_password),
+        );
 
         final request = await _signIn(session, _password);
 
         expect(request.status, DwAuthRequestStatus.verified);
       });
 
-      test('signing in rewrites the hash in bcrypt — once, and for good', () async {
-        await _seedHash(session, userId, _LegacySha256Verifier.hashOf(_password));
+      test(
+        'signing in rewrites the hash in bcrypt — once, and for good',
+        () async {
+          await _seedHash(
+            session,
+            userId,
+            _LegacySha256Verifier.hashOf(_password),
+          );
 
-        await _signIn(session, _password);
+          await _signIn(session, _password);
 
-        // The plaintext exists only during a sign-in, so this is the only moment
-        // the hash could be migrated at all.
-        final stored = await _storedHash(session, userId);
-        expect(stored, startsWith(r'$2'), reason: 'the hash should now be bcrypt');
+          // The plaintext exists only during a sign-in, so this is the only moment
+          // the hash could be migrated at all.
+          final stored = await _storedHash(session, userId);
+          expect(
+            stored,
+            startsWith(r'$2'),
+            reason: 'the hash should now be bcrypt',
+          );
 
-        // And the upgraded row is readable by the active hasher: the second
-        // sign-in never touches the legacy path.
-        final again = await _signIn(session, _password);
-        expect(again.status, DwAuthRequestStatus.verified);
-      });
+          // And the upgraded row is readable by the active hasher: the second
+          // sign-in never touches the legacy path.
+          final again = await _signIn(session, _password);
+          expect(again.status, DwAuthRequestStatus.verified);
+        },
+      );
 
       test('a wrong password is rejected and the hash is left alone', () async {
         final legacyHash = _LegacySha256Verifier.hashOf(_password);
@@ -99,30 +114,40 @@ void main() {
         expect(await _storedHash(session, userId), legacyHash);
       });
 
-      test('a hash nobody can read fails the login instead of crashing it', () async {
-        // The format of some third system, never registered as a verifier. Before
-        // the strategies existed this reached BCrypt.checkpw and threw, turning a
-        // failed login into a 500.
-        await _seedHash(session, userId, 'argon2id\$v=19\$m=65536,t=3,p=4\$deadbeef');
+      test(
+        'a hash nobody can read fails the login instead of crashing it',
+        () async {
+          // The format of some third system, never registered as a verifier. Before
+          // the strategies existed this reached BCrypt.checkpw and threw, turning a
+          // failed login into a 500.
+          await _seedHash(
+            session,
+            userId,
+            'argon2id\$v=19\$m=65536,t=3,p=4\$deadbeef',
+          );
 
-        final request = await _signIn(session, _password);
+          final request = await _signIn(session, _password);
 
-        expect(request.status, DwAuthRequestStatus.failed);
-        expect(request.failReason, DwAuthFailReason.invalidPassword);
-      });
+          expect(request.status, DwAuthRequestStatus.failed);
+          expect(request.failReason, DwAuthFailReason.invalidPassword);
+        },
+      );
 
-      test('a bcrypt password still works — the default path is untouched', () async {
-        await dw.auth!.setUserPassword(
-          session,
-          userId: userId,
-          newPassword: _password,
-        );
+      test(
+        'a bcrypt password still works — the default path is untouched',
+        () async {
+          await dw.auth!.setUserPassword(
+            session,
+            userId: userId,
+            newPassword: _password,
+          );
 
-        final request = await _signIn(session, _password);
+          final request = await _signIn(session, _password);
 
-        expect(request.status, DwAuthRequestStatus.verified);
-        expect(await _storedHash(session, userId), startsWith(r'$2'));
-      });
+          expect(request.status, DwAuthRequestStatus.verified);
+          expect(await _storedHash(session, userId), startsWith(r'$2'));
+        },
+      );
     },
     runMode: 'test',
     applyMigrations: true,
@@ -138,11 +163,7 @@ void main() {
 
 /// Seeds a hash the way a migration does: import what you cannot reverse.
 Future<void> _seedHash(Session session, int userId, String hash) =>
-    dw.auth!.setUserPassword(
-      session,
-      userId: userId,
-      newPasswordHash: hash,
-    );
+    dw.auth!.setUserPassword(session, userId: userId, newPasswordHash: hash);
 
 Future<String> _storedHash(Session session, int userId) async {
   final row = await DwUserPassword.db.findFirstRow(
@@ -174,10 +195,7 @@ Future<T> _save<T extends TableRow>(Session session, T model) async {
 
   final saveConfig =
       (dw.getCrudConfig(className) ??
-              dw.getCrudConfig(
-                className,
-                api: DwCoreConst.dartwayInternalApi,
-              ))
+              dw.getCrudConfig(className, api: DwCoreConst.dartwayInternalApi))
           ?.saveConfig;
 
   if (saveConfig == null) {
@@ -194,7 +212,10 @@ Future<T> _save<T extends TableRow>(Session session, T model) async {
 }
 
 Future<void> _wipeTables(Session session) async {
-  await DwUserPassword.db.deleteWhere(session, where: (t) => Constant.bool(true));
+  await DwUserPassword.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
   await DwAuthKey.db.deleteWhere(session, where: (t) => Constant.bool(true));
   await UserProfile.db.deleteWhere(session, where: (t) => Constant.bool(true));
 }

--- a/packages/dartway_cli/lib/src/checker/dw_layout.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_layout.dart
@@ -118,10 +118,7 @@ class DwLayoutInspector {
     );
 
     for (final zone in dwFlutterZones.followedBy(const ['shared'])) {
-      _checkNoNestedTopLevelName(
-        Directory(p.join(libDir.path, zone)),
-        libDir,
-      );
+      _checkNoNestedTopLevelName(Directory(p.join(libDir.path, zone)), libDir);
     }
   }
 
@@ -208,9 +205,7 @@ class DwLayoutInspector {
       final allowed = isFolder ? allowedFolders : allowedFiles;
       if (allowed.contains(name)) continue;
 
-      _findings.add(
-        '$label/$name is not part of the declared layout — $hint',
-      );
+      _findings.add('$label/$name is not part of the declared layout — $hint');
     }
 
     for (final required in requiredEntries) {

--- a/packages/dartway_cli/lib/src/checker/dw_unused_feature_files.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_unused_feature_files.dart
@@ -48,7 +48,8 @@ List<DwUnusedFeatureFile> findUnusedFeatureFiles(DwFeatureNode feature) {
     for (final file in [entry, ...internalFiles]) file.path: _strip(file),
   };
   final declarations = {
-    for (final file in internalFiles) file.path: _declaredNames(contents[file.path]!),
+    for (final file in internalFiles)
+      file.path: _declaredNames(contents[file.path]!),
   };
 
   final dead = <String>{};
@@ -154,9 +155,9 @@ Set<String> _declaredNames(String source) {
   return names;
 }
 
-bool _mentions(String source, String name) =>
-    RegExp('(?<![A-Za-z0-9_\$])${RegExp.escape(name)}(?![A-Za-z0-9_])')
-        .hasMatch(source);
+bool _mentions(String source, String name) => RegExp(
+  '(?<![A-Za-z0-9_\$])${RegExp.escape(name)}(?![A-Za-z0-9_])',
+).hasMatch(source);
 
 /// Every feature under [nodes], the nested ones included.
 Iterable<DwFeatureNode> featuresIn(List<DwFeatureNode> nodes) sync* {

--- a/packages/dartway_cli/lib/src/commands/check_command.dart
+++ b/packages/dartway_cli/lib/src/commands/check_command.dart
@@ -65,8 +65,7 @@ class CheckCommand extends Command<int> {
         : DwCheckSeverity.values.byName(levelArg);
 
     final layout = _detectLayout();
-    final flutterPackageDir =
-        layout?.flutterPackageDir ?? Directory.current;
+    final flutterPackageDir = layout?.flutterPackageDir ?? Directory.current;
     stdout.writeln('Checking ${flutterPackageDir.path} ...');
 
     var errorCount = 0;

--- a/packages/dartway_cli/test/framework_lock_test.dart
+++ b/packages/dartway_cli/test/framework_lock_test.dart
@@ -76,7 +76,10 @@ void main() {
       gitEntry('dartway_flutter', resolvedRef: 'abcdef1${'0' * 33}'),
     ]);
     writeLock('my_server', [
-      gitEntry('dartway_serverpod_core_server', resolvedRef: '9876543${'0' * 33}'),
+      gitEntry(
+        'dartway_serverpod_core_server',
+        resolvedRef: '9876543${'0' * 33}',
+      ),
     ]);
 
     final reported = findings();
@@ -158,9 +161,9 @@ void main() {
   test('a lock file that does not parse is nobody\'s finding', () {
     final dir = Directory(p.join(sandbox.path, 'my_flutter'))
       ..createSync(recursive: true);
-    File(p.join(dir.path, 'pubspec.lock')).writeAsStringSync(
-      'packages:\n  broken: [unclosed\n',
-    );
+    File(
+      p.join(dir.path, 'pubspec.lock'),
+    ).writeAsStringSync('packages:\n  broken: [unclosed\n');
 
     expect(findings, returnsNormally);
     expect(findings(), isEmpty);

--- a/packages/dartway_cli/test/layout_test.dart
+++ b/packages/dartway_cli/test/layout_test.dart
@@ -29,9 +29,9 @@ void main() {
   List<String> findingsFor(List<String> entries, {String name = 'my_flutter'}) {
     final packageDir = Directory(p.join(sandbox.path, name))
       ..createSync(recursive: true);
-    File(p.join(packageDir.path, 'pubspec.yaml')).writeAsStringSync(
-      'name: $name\n',
-    );
+    File(
+      p.join(packageDir.path, 'pubspec.yaml'),
+    ).writeAsStringSync('name: $name\n');
 
     for (final entry in entries) {
       final path = p.join(packageDir.path, 'lib', entry);
@@ -87,9 +87,7 @@ void main() {
 
   test('the wiring file carries the project name, and is required', () {
     expect(
-      findingsFor(
-        declaredLayout.where((e) => e != 'my_app.dart').toList(),
-      ),
+      findingsFor(declaredLayout.where((e) => e != 'my_app.dart').toList()),
       contains(contains('my_app.dart')),
     );
   });
@@ -97,7 +95,10 @@ void main() {
   test('a zone nested inside a zone is reported — `app/admin/`', () {
     final findings = findingsFor([...declaredLayout, 'app/admin/']);
     expect(findings, hasLength(1));
-    expect(findings.single, allOf(contains('lib/app/admin'), contains('/admin')));
+    expect(
+      findings.single,
+      allOf(contains('lib/app/admin'), contains('/admin')),
+    );
   });
 
   test('a nested zone is found at any depth', () {

--- a/packages/dartway_cli/test/unused_feature_files_test.dart
+++ b/packages/dartway_cli/test/unused_feature_files_test.dart
@@ -108,13 +108,14 @@ class AttachmentHandler {
   final settings = const AttachmentSettings();
 }
 ''',
-      'logic/attachment_settings.dart': 'class AttachmentSettings { const AttachmentSettings(); }',
+      'logic/attachment_settings.dart':
+          'class AttachmentSettings { const AttachmentSettings(); }',
     });
 
-    expect(
-      unusedNames(feature)..sort(),
-      ['attachment_handler.dart', 'attachment_settings.dart'],
-    );
+    expect(unusedNames(feature)..sort(), [
+      'attachment_handler.dart',
+      'attachment_settings.dart',
+    ]);
   });
 
   test('a name that only appears in a comment or a string is not a use', () {

--- a/packages/dartway_flutter/example/lib/main.dart
+++ b/packages/dartway_flutter/example/lib/main.dart
@@ -233,8 +233,7 @@ class _Section extends StatelessWidget implements DwFeature {
   final List<Widget> children;
 
   @override
-  DwFeatureSpec get dwFeature =>
-      DwFeatureSpec(id: title, title: title);
+  DwFeatureSpec get dwFeature => DwFeatureSpec(id: title, title: title);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/dartway_flutter/lib/src/core/dw_flutter.dart
+++ b/packages/dartway_flutter/lib/src/core/dw_flutter.dart
@@ -41,15 +41,16 @@ class DwFlutter {
     DwErrorSource source = DwErrorSource.manual,
     String? actionLabel,
     String? failedCall,
-  }) =>
-      dispatchReport(DwErrorReport(
-        error: error,
-        stackTrace: stackTrace,
-        source: source,
-        actionLabel: actionLabel,
-        failedCall: failedCall,
-        context: errorContext.capture(appVersion: _config.appVersion),
-      ));
+  }) => dispatchReport(
+    DwErrorReport(
+      error: error,
+      stackTrace: stackTrace,
+      source: source,
+      actionLabel: actionLabel,
+      failedCall: failedCall,
+      context: errorContext.capture(appVersion: _config.appVersion),
+    ),
+  );
 
   /// Dispatch point for every reported error. The base implementation runs the
   /// configured [DwConfig.onErrorReport] hook, or logs via `debugPrint` when
@@ -68,10 +69,7 @@ class DwFlutter {
   /// Shows a confirmation for [confirmation]: the app-supplied
   /// [DwConfig.confirmDialogBuilder] when set, the built-in [DwConfirmDialog]
   /// otherwise. Used by `DwUiAction(confirmation: ...)`.
-  Future<bool?> confirm(
-    BuildContext context,
-    DwUiConfirmation confirmation,
-  ) =>
+  Future<bool?> confirm(BuildContext context, DwUiConfirmation confirmation) =>
       (_config.confirmDialogBuilder ?? DwConfirmDialog.show)(
         context,
         confirmation,

--- a/packages/dartway_flutter/lib/src/core/logic/dw_config.dart
+++ b/packages/dartway_flutter/lib/src/core/logic/dw_config.dart
@@ -26,7 +26,8 @@ class DwConfig {
   final Future<bool?> Function(
     BuildContext context,
     DwUiConfirmation confirmation,
-  )? confirmDialogBuilder;
+  )?
+  confirmDialogBuilder;
 
   /// Returns a placeholder instance of any model `T` for skeleton loading
   /// states — the data layer wires this to its mock-model registry. When unset,

--- a/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
+++ b/packages/dartway_flutter/lib/src/diagnostics/dw_feature/dw_feature.dart
@@ -202,9 +202,11 @@ abstract interface class DwFeature {
     );
 
     var child = renderObject as RenderObject;
-    for (var ancestor = child.parent;
-        ancestor != null;
-        child = ancestor, ancestor = ancestor.parent) {
+    for (
+      var ancestor = child.parent;
+      ancestor != null;
+      child = ancestor, ancestor = ancestor.parent
+    ) {
       final clip = ancestor.describeApproximatePaintClip(child);
       if (clip == null) continue;
       rect = rect.intersect(

--- a/packages/dartway_flutter/test/dw_action_builder_test.dart
+++ b/packages/dartway_flutter/test/dw_action_builder_test.dart
@@ -51,10 +51,7 @@ void main() {
       // no log, nothing. The button was simply dead. Since the guard can now sit
       // under any widget, drifting out of the Form is easy — so it must be loud,
       // and loud *before* the first tap that would have done nothing.
-      await _pump(
-        tester,
-        child: _button(testDw.action((_) async {})),
-      );
+      await _pump(tester, child: _button(testDw.action((_) async {})));
 
       expect(tester.takeException(), isAssertionError);
     });

--- a/packages/dartway_flutter/test/dw_error_pipeline_test.dart
+++ b/packages/dartway_flutter/test/dw_error_pipeline_test.dart
@@ -8,8 +8,7 @@ class _FeatureBox extends StatelessWidget implements DwFeature {
   final String id;
 
   @override
-  DwFeatureSpec get dwFeature =>
-      DwFeatureSpec(id: id, title: id);
+  DwFeatureSpec get dwFeature => DwFeatureSpec(id: id, title: id);
 
   @override
   Widget build(BuildContext context) => const SizedBox.shrink();
@@ -20,10 +19,7 @@ void main() {
 
   // One DwFlutter per test process — the singleton forbids re-creation.
   final dwInstance = DwFlutter(
-    config: DwConfig(
-      appVersion: '1.2.3',
-      onErrorReport: reports.add,
-    ),
+    config: DwConfig(appVersion: '1.2.3', onErrorReport: reports.add),
   );
 
   setUp(() {
@@ -32,18 +28,21 @@ void main() {
   });
 
   group('error pipeline', () {
-    testWidgets('DwUiAction failure produces a full DwErrorReport',
-        (tester) async {
+    testWidgets('DwUiAction failure produces a full DwErrorReport', (
+      tester,
+    ) async {
       late BuildContext capturedContext;
       await tester.pumpWidget(
         MaterialApp(
           home: Column(
             children: [
               const _FeatureBox('feature-a'),
-              Builder(builder: (context) {
-                capturedContext = context;
-                return const SizedBox.shrink();
-              }),
+              Builder(
+                builder: (context) {
+                  capturedContext = context;
+                  return const SizedBox.shrink();
+                },
+              ),
             ],
           ),
         ),
@@ -66,8 +65,9 @@ void main() {
       expect(report.context.appVersion, '1.2.3');
     });
 
-    testWidgets('action label falls back to the notification text',
-        (tester) async {
+    testWidgets('action label falls back to the notification text', (
+      tester,
+    ) async {
       await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
       final context = tester.element(find.byType(SizedBox));
 

--- a/packages/dartway_flutter/test/dw_feature_test.dart
+++ b/packages/dartway_flutter/test/dw_feature_test.dart
@@ -51,22 +51,24 @@ DwFeatureSpec _spec(String id) =>
     DwFeatureSpec(id: id, title: id, behaviors: const ['does a thing']);
 
 void main() {
-  testWidgets('DwFeature.scanMounted collects mounted features, deduped by id',
-      (tester) async {
-    await tester.pumpWidget(
-      Column(
-        children: [
-          _FeatureBox(_spec('a')),
-          _FeatureBox(_spec('b')),
-          _FeatureBox(_spec('a')), // duplicate id — collapses to one
-        ],
-      ),
-    );
+  testWidgets(
+    'DwFeature.scanMounted collects mounted features, deduped by id',
+    (tester) async {
+      await tester.pumpWidget(
+        Column(
+          children: [
+            _FeatureBox(_spec('a')),
+            _FeatureBox(_spec('b')),
+            _FeatureBox(_spec('a')), // duplicate id — collapses to one
+          ],
+        ),
+      );
 
-    final ids = DwFeature.scanMounted().map((f) => f.id).toList();
-    expect(ids.toSet(), {'a', 'b'});
-    expect(ids.length, 2);
-  });
+      final ids = DwFeature.scanMounted().map((f) => f.id).toList();
+      expect(ids.toSet(), {'a', 'b'});
+      expect(ids.length, 2);
+    },
+  );
 
   // Deduplication is per id, not per subtree, and the walk never stops at a
   // feature it has already seen. It matters for a list of near-identical cards:
@@ -92,8 +94,9 @@ void main() {
     expect(ids.length, 2);
   });
 
-  testWidgets('DwFeature.scanMounted is empty with no DwFeature widgets',
-      (tester) async {
+  testWidgets('DwFeature.scanMounted is empty with no DwFeature widgets', (
+    tester,
+  ) async {
     await tester.pumpWidget(const SizedBox.shrink());
     expect(DwFeature.scanMounted(), isEmpty);
   });
@@ -102,17 +105,15 @@ void main() {
   // alive behind an IndexedStack, or a route under a pushed one, leaves those
   // subtrees mounted — and reporting them would claim every screen hosts the
   // whole app.
-  testWidgets('DwFeature.scanMounted skips unselected IndexedStack children',
-      (tester) async {
+  testWidgets('DwFeature.scanMounted skips unselected IndexedStack children', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: IndexedStack(
           index: 1,
-          children: [
-            _FeatureBox(_spec('behind')),
-            _FeatureBox(_spec('shown')),
-          ],
+          children: [_FeatureBox(_spec('behind')), _FeatureBox(_spec('shown'))],
         ),
       ),
     );
@@ -120,8 +121,9 @@ void main() {
     expect(DwFeature.scanMounted().map((f) => f.id), ['shown']);
   });
 
-  testWidgets('DwFeature.scanMounted skips an offstage subtree',
-      (tester) async {
+  testWidgets('DwFeature.scanMounted skips an offstage subtree', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       Column(
         children: [
@@ -134,8 +136,9 @@ void main() {
     expect(DwFeature.scanMounted().map((f) => f.id), ['shown']);
   });
 
-  testWidgets('DwFeature.scanMounted skips a disabled TickerMode subtree',
-      (tester) async {
+  testWidgets('DwFeature.scanMounted skips a disabled TickerMode subtree', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       Column(
         children: [
@@ -165,18 +168,16 @@ void main() {
       );
 
       Offset centerOf(String id) => tester.getCenter(
-            find.byWidgetPredicate(
-              (widget) => widget is _SizedFeature && widget.spec.id == id,
-            ),
-          );
+        find.byWidgetPredicate(
+          (widget) => widget is _SizedFeature && widget.spec.id == id,
+        ),
+      );
 
       expect(DwFeature.hitTest(centerOf('left'))?.id, 'left');
       expect(DwFeature.hitTest(centerOf('right'))?.id, 'right');
     });
 
-    testWidgets('is null over a point nothing declared covers', (
-      tester,
-    ) async {
+    testWidgets('is null over a point nothing declared covers', (tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -190,27 +191,26 @@ void main() {
     // A card and a "more actions" row it may or may not build can both cover
     // the same point — the tap landed on whichever is actually drawn there,
     // and that is the nested one.
-    testWidgets(
-      'returns the innermost feature when nested features overlap',
-      (tester) async {
-        await tester.pumpWidget(
-          Directionality(
-            textDirection: TextDirection.ltr,
-            child: _SizedFeature(
-              _spec('ad/card'),
-              child: _SizedFeature(_spec('ad/card/more-actions')),
-            ),
+    testWidgets('returns the innermost feature when nested features overlap', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: _SizedFeature(
+            _spec('ad/card'),
+            child: _SizedFeature(_spec('ad/card/more-actions')),
           ),
-        );
+        ),
+      );
 
-        final center = tester.getCenter(
-          find.byWidgetPredicate(
-            (widget) => widget is _SizedFeature && widget.spec.id == 'ad/card',
-          ),
-        );
-        expect(DwFeature.hitTest(center)?.id, 'ad/card/more-actions');
-      },
-    );
+      final center = tester.getCenter(
+        find.byWidgetPredicate(
+          (widget) => widget is _SizedFeature && widget.spec.id == 'ad/card',
+        ),
+      );
+      expect(DwFeature.hitTest(center)?.id, 'ad/card/more-actions');
+    });
 
     // hitTest bypasses Flutter's own hit-testing (it checks render bounds
     // directly), so it must repeat the offstage/invisible/disabled-ticker
@@ -229,8 +229,9 @@ void main() {
     // A scaled subtree draws smaller than it lays out. Matching on the
     // unscaled size would claim the empty space next to it — the case a
     // zoomable canvas or a running page transition puts on screen.
-    testWidgets('matches the scaled area, not the laid-out one',
-        (tester) async {
+    testWidgets('matches the scaled area, not the laid-out one', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -253,8 +254,9 @@ void main() {
     // A list item scrolled past the edge of its viewport keeps its layout
     // position and paints nothing. Being deeper in the tree it would win the
     // last-match-wins rule, so it has to be cut by the viewport's clip.
-    testWidgets('skips a feature clipped away by a scroll viewport',
-        (tester) async {
+    testWidgets('skips a feature clipped away by a scroll viewport', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,

--- a/packages/dartway_push/dartway_push_firebase/lib/src/dw_firebase_push.dart
+++ b/packages/dartway_push/dartway_push_firebase/lib/src/dw_firebase_push.dart
@@ -99,12 +99,11 @@ class DwFirebasePush extends DwPushClientProvider {
 
     _subscriptions.add(
       FirebaseMessaging.onMessageOpenedApp.listen(
-        (message) => callbacks.onOpened(
-          _dataOf(message),
-          DwPushOpenSource.background,
+        (message) =>
+            callbacks.onOpened(_dataOf(message), DwPushOpenSource.background),
+        onError: (Object error) => debugPrint(
+          'DwFirebasePush: opening from background failed: $error',
         ),
-        onError: (Object error) =>
-            debugPrint('DwFirebasePush: opening from background failed: $error'),
       ),
     );
 
@@ -184,10 +183,11 @@ class DwFirebasePush extends DwPushClientProvider {
   Map<String, String> _dataOf(RemoteMessage message) =>
       message.data.map((key, value) => MapEntry(key, value.toString()));
 
-  DwPushPermission _permissionOf(AuthorizationStatus status) => switch (status) {
-    AuthorizationStatus.authorized ||
-    AuthorizationStatus.provisional => DwPushPermission.granted,
-    AuthorizationStatus.denied => DwPushPermission.denied,
-    AuthorizationStatus.notDetermined => DwPushPermission.notDetermined,
-  };
+  DwPushPermission _permissionOf(AuthorizationStatus status) =>
+      switch (status) {
+        AuthorizationStatus.authorized ||
+        AuthorizationStatus.provisional => DwPushPermission.granted,
+        AuthorizationStatus.denied => DwPushPermission.denied,
+        AuthorizationStatus.notDetermined => DwPushPermission.notDetermined,
+      };
 }

--- a/packages/dartway_push/dartway_push_firebase/lib/src/web/dw_push_web_open_channel_web.dart
+++ b/packages/dartway_push/dartway_push_firebase/lib/src/web/dw_push_web_open_channel_web.dart
@@ -14,21 +14,20 @@ import 'package:web/web.dart' as web;
 /// Returns an unsubscribe function: the listener sits on `serviceWorker`, which
 /// outlives any widget, so whoever attached it has to detach it.
 void Function() listenWebPushOpen(void Function(String link) onPushOpened) {
-  final listener =
-      (web.MessageEvent event) {
-        final message = event.data;
-        if (message == null || !message.isA<JSObject>()) return;
+  final listener = (web.MessageEvent event) {
+    final message = event.data;
+    if (message == null || !message.isA<JSObject>()) return;
 
-        final data = message as JSObject;
-        final type = data.getProperty<JSString?>('type'.toJS)?.toDart;
-        if (type != 'dw-push-open') return;
+    final data = message as JSObject;
+    final type = data.getProperty<JSString?>('type'.toJS)?.toDart;
+    if (type != 'dw-push-open') return;
 
-        final link = data.getProperty<JSString?>('link'.toJS)?.toDart;
-        if (link == null || link.isEmpty) return;
+    final link = data.getProperty<JSString?>('link'.toJS)?.toDart;
+    if (link == null || link.isEmpty) return;
 
-        debugPrint('DwPush: the service worker asked to open $link');
-        onPushOpened(link);
-      }.toJS;
+    debugPrint('DwPush: the service worker asked to open $link');
+    onPushOpened(link);
+  }.toJS;
 
   web.window.navigator.serviceWorker.addEventListener('message', listener);
 

--- a/packages/dartway_push/dartway_push_flutter/lib/src/dw_push.dart
+++ b/packages/dartway_push/dartway_push_flutter/lib/src/dw_push.dart
@@ -257,11 +257,7 @@ class DwPush extends DwPlugin {
     required String provider,
   }) async {
     await const DwRepo().saveModel(
-      DwPushTokenRegistration(
-        token: token,
-        provider: provider,
-        revoke: false,
-      ),
+      DwPushTokenRegistration(token: token, provider: provider, revoke: false),
     );
     return true;
   }

--- a/packages/dartway_push/dartway_push_flutter/lib/src/dw_push_config.dart
+++ b/packages/dartway_push/dartway_push_flutter/lib/src/dw_push_config.dart
@@ -80,6 +80,9 @@ final class DwPushConfig {
   /// The default goes through the module's own CRUD action, which is what an
   /// app on `dartway_push_server` wants. Override it when the backend is
   /// somebody else's, or while migrating off an endpoint of your own.
-  final Future<bool> Function({required String token, required String provider})?
+  final Future<bool> Function({
+    required String token,
+    required String provider,
+  })?
   registerToken;
 }

--- a/packages/dartway_push/dartway_push_flutter/test/dw_push_test.dart
+++ b/packages/dartway_push/dartway_push_flutter/test/dw_push_test.dart
@@ -49,10 +49,7 @@ void main() {
 
     test('touches nothing when push is disabled for this build', () async {
       final firebase = _FakeProvider(id: DwPushProviderIds.fcm);
-      final push = _push(
-        providers: [firebase],
-        isEnabled: () async => false,
-      );
+      final push = _push(providers: [firebase], isEnabled: () async => false);
 
       await push.attach();
 
@@ -85,45 +82,49 @@ void main() {
       expect(firebase.permissionRequests, 1);
     });
 
-    test('keeps listening after a refusal, so a later yes still works',
-        () async {
-      final firebase = _FakeProvider(
-        id: DwPushProviderIds.fcm,
-        permission: DwPushPermission.denied,
-      );
-      final push = _push(providers: [firebase]);
+    test(
+      'keeps listening after a refusal, so a later yes still works',
+      () async {
+        final firebase = _FakeProvider(
+          id: DwPushProviderIds.fcm,
+          permission: DwPushPermission.denied,
+        );
+        final push = _push(providers: [firebase]);
 
-      await push.attach();
+        await push.attach();
 
-      expect(firebase.attached, isTrue);
-      expect(push.token.value, isNull);
+        expect(firebase.attached, isTrue);
+        expect(push.token.value, isNull);
 
-      firebase.permission = DwPushPermission.granted;
-      await push.requestPermission();
+        firebase.permission = DwPushPermission.granted;
+        await push.requestPermission();
 
-      expect(push.token.value, 'token-fcm');
-    });
+        expect(push.token.value, 'token-fcm');
+      },
+    );
   });
 
   group('DwPush notification taps', () {
-    test('holds the notification that started the app until it can be routed',
-        () async {
-      final opened = <DwPushOpened>[];
-      final firebase = _FakeProvider(
-        id: DwPushProviderIds.fcm,
-        initialPayload: {'type': 'new_post', 'post_id': '12'},
-      );
-      final push = _push(providers: [firebase], onOpened: opened.add);
+    test(
+      'holds the notification that started the app until it can be routed',
+      () async {
+        final opened = <DwPushOpened>[];
+        final firebase = _FakeProvider(
+          id: DwPushProviderIds.fcm,
+          initialPayload: {'type': 'new_post', 'post_id': '12'},
+        );
+        final push = _push(providers: [firebase], onOpened: opened.add);
 
-      await push.attach();
-      expect(opened, isEmpty, reason: 'nothing can route it yet');
+        await push.attach();
+        expect(opened, isEmpty, reason: 'nothing can route it yet');
 
-      push.markReadyForOpens((action) => action());
+        push.markReadyForOpens((action) => action());
 
-      expect(opened, hasLength(1));
-      expect(opened.single.source, DwPushOpenSource.coldStart);
-      expect(opened.single.data['post_id'], '12');
-    });
+        expect(opened, hasLength(1));
+        expect(opened.single.source, DwPushOpenSource.coldStart);
+        expect(opened.single.data['post_id'], '12');
+      },
+    );
 
     test('delivers a buffered tap exactly once', () async {
       final opened = <DwPushOpened>[];
@@ -156,8 +157,9 @@ void main() {
   });
 
   group('DwPush token registration', () {
-    testWidgets('registers once the session says who is signed in',
-        (tester) async {
+    testWidgets('registers once the session says who is signed in', (
+      tester,
+    ) async {
       final registrations = <(String, String)>[];
       final firebase = _FakeProvider(id: DwPushProviderIds.fcm);
       final push = _push(

--- a/packages/dartway_push/dartway_push_flutter/test/dw_push_token_sync_test.dart
+++ b/packages/dartway_push/dartway_push_flutter/test/dw_push_token_sync_test.dart
@@ -6,20 +6,23 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('DwPushTokenSync', () {
-    test('waits until there is both a token and somebody to attach it to', () async {
-      final registrar = _RecordingRegistrar();
-      final sync = DwPushTokenSync(register: registrar.call);
+    test(
+      'waits until there is both a token and somebody to attach it to',
+      () async {
+        final registrar = _RecordingRegistrar();
+        final sync = DwPushTokenSync(register: registrar.call);
 
-      await sync.sync(recipientId: 7);
-      expect(registrar.calls, isEmpty, reason: 'no token yet');
+        await sync.sync(recipientId: 7);
+        expect(registrar.calls, isEmpty, reason: 'no token yet');
 
-      sync.onToken(token: 'token-a', provider: DwPushProviderIds.fcm);
-      await sync.sync(recipientId: null);
-      expect(registrar.calls, isEmpty, reason: 'nobody signed in');
+        sync.onToken(token: 'token-a', provider: DwPushProviderIds.fcm);
+        await sync.sync(recipientId: null);
+        expect(registrar.calls, isEmpty, reason: 'nobody signed in');
 
-      await sync.sync(recipientId: 7);
-      expect(registrar.calls, [('token-a', DwPushProviderIds.fcm)]);
-    });
+        await sync.sync(recipientId: 7);
+        expect(registrar.calls, [('token-a', DwPushProviderIds.fcm)]);
+      },
+    );
 
     test('sends the same token to the same user only once', () async {
       final registrar = _RecordingRegistrar();

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_device_push_token_policy.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_device_push_token_policy.dart
@@ -16,9 +16,32 @@ abstract final class DwDevicePushTokenPolicy {
   /// canonical form. Kept as explicit code points (not a string literal of
   /// invisible characters) so the set is readable and reviewable.
   static const List<int> _canonicalTrimCodePointList = [
-    0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x0020, 0x0085, 0x00A0, 0x1680,
-    0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008,
-    0x2009, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000, 0xFEFF,
+    0x0009,
+    0x000A,
+    0x000B,
+    0x000C,
+    0x000D,
+    0x0020,
+    0x0085,
+    0x00A0,
+    0x1680,
+    0x2000,
+    0x2001,
+    0x2002,
+    0x2003,
+    0x2004,
+    0x2005,
+    0x2006,
+    0x2007,
+    0x2008,
+    0x2009,
+    0x200A,
+    0x2028,
+    0x2029,
+    0x202F,
+    0x205F,
+    0x3000,
+    0xFEFF,
   ];
 
   /// The same trim set as an SQL `U&'...'` literal, for `BTRIM` inside the
@@ -28,8 +51,8 @@ abstract final class DwDevicePushTokenPolicy {
       r"\2000\2001\2002\2003\2004\2005\2006\2007\2008\2009\200A"
       r"\2028\2029\202F\205F\3000\FEFF'";
 
-  static final Set<int> _canonicalTrimCodePoints =
-      _canonicalTrimCodePointList.toSet();
+  static final Set<int> _canonicalTrimCodePoints = _canonicalTrimCodePointList
+      .toSet();
 
   static String normalize(String token) {
     var start = 0;

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_device_push_token_store.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_device_push_token_store.dart
@@ -151,14 +151,11 @@ abstract final class DwDevicePushTokenStore {
     if (!DwDevicePushTokenPolicy.isValid(normalizedToken)) return;
 
     await _lockToken(session, normalizedToken, transaction: transaction);
-    final ownedRows =
-        (await findByNormalizedValue(
-              session,
-              normalizedToken,
-              transaction: transaction,
-            ))
-            .where((row) => row.recipientId == recipientId)
-            .toList(growable: false);
+    final ownedRows = (await findByNormalizedValue(
+      session,
+      normalizedToken,
+      transaction: transaction,
+    )).where((row) => row.recipientId == recipientId).toList(growable: false);
     if (ownedRows.isEmpty) return;
     await DwDevicePushToken.db.delete(
       session,

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
@@ -681,9 +681,7 @@ WHERE "id" = @deliveryId
     DwPushTransportResult result,
   ) {
     const equality = SetEquality<String>();
-    final expected = attempt.targets
-        .map((target) => target.token)
-        .toSet();
+    final expected = attempt.targets.map((target) => target.token).toSet();
     final actual = result.results.map((item) => item.target).toSet();
     if (!equality.equals(expected, actual)) {
       throw StateError(

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_backend_filter.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_backend_filter.dart
@@ -23,14 +23,14 @@ class DwBackendFilter<T> implements SerializableModel {
   final bool negate;
 
   const DwBackendFilter.and(this.children, {this.negate = false})
-      : fieldName = null,
-        type = DwBackendFilterType.and,
-        fieldValue = null;
+    : fieldName = null,
+      type = DwBackendFilterType.and,
+      fieldValue = null;
 
   const DwBackendFilter.or(this.children, {this.negate = false})
-      : fieldName = null,
-        type = DwBackendFilterType.or,
-        fieldValue = null;
+    : fieldName = null,
+      type = DwBackendFilterType.or,
+      fieldValue = null;
 
   const DwBackendFilter.value({
     required this.type,
@@ -47,8 +47,8 @@ class DwBackendFilter<T> implements SerializableModel {
       children: jsonSerialization['children'] == null
           ? null
           : (jsonSerialization['children'] as List)
-              .map((e) => DwBackendFilter.fromJson(e as Map<String, dynamic>))
-              .toList(),
+                .map((e) => DwBackendFilter.fromJson(e as Map<String, dynamic>))
+                .toList(),
       negate: jsonSerialization['negate'] as bool,
       // child: jsonSerialization['child'] == null
       //     ? null
@@ -71,21 +71,18 @@ class DwBackendFilter<T> implements SerializableModel {
 
       // Collect the children, carrying the negation down
       final expressions = children!.map(
-        (child) => child.filterUpdate(
-          jsonSerialization,
-          outerNegate: shouldNegate,
-        ),
+        (child) =>
+            child.filterUpdate(jsonSerialization, outerNegate: shouldNegate),
       );
 
       // OR when the filter says so, or when a negated AND turns into one
-      return expressions.reduce((a, b) =>
-          shouldNegate != (type == DwBackendFilterType.or) ? a || b : a && b);
+      return expressions.reduce(
+        (a, b) =>
+            shouldNegate != (type == DwBackendFilterType.or) ? a || b : a && b,
+      );
     }
 
-    return _valueExpression(
-      jsonSerialization,
-      negate: shouldNegate,
-    );
+    return _valueExpression(jsonSerialization, negate: shouldNegate);
   }
 
   bool _isType<T1, T2>(Type t) => t == T1 || t == T2;
@@ -102,8 +99,9 @@ class DwBackendFilter<T> implements SerializableModel {
         'explicit generic, e.g. DwBackendFilter<int>().',
       );
     }
-    final modelValue = DwCoreServerpodClient.protocol
-        .deserialize<T?>(jsonSerialization['data'][fieldName]);
+    final modelValue = DwCoreServerpodClient.protocol.deserialize<T?>(
+      jsonSerialization['data'][fieldName],
+    );
 
     if (type == DwBackendFilterType.equals) {
       return negate != (modelValue == fieldValue);
@@ -112,64 +110,81 @@ class DwBackendFilter<T> implements SerializableModel {
     if (_isNullableType(int)) {
       return negate !=
           switch (type) {
-            DwBackendFilterType.greaterThan => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as int) > (fieldValue as int))),
-            DwBackendFilterType.greaterThanOrEquals => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as int) >= (fieldValue as int))),
-            DwBackendFilterType.lessThan => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as int) < (fieldValue as int))),
-            DwBackendFilterType.lessThanOrEquals => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as int) <= (fieldValue as int))),
+            DwBackendFilterType.greaterThan =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as int) > (fieldValue as int))),
+            DwBackendFilterType.greaterThanOrEquals =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as int) >= (fieldValue as int))),
+            DwBackendFilterType.lessThan =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as int) < (fieldValue as int))),
+            DwBackendFilterType.lessThanOrEquals =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as int) <= (fieldValue as int))),
             _ => throw Exception('Unsupported filter type'),
           };
     } else if (_isNullableType(double)) {
       return negate !=
           switch (type) {
-            DwBackendFilterType.greaterThan => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as double) > (fieldValue as double))),
-            DwBackendFilterType.greaterThanOrEquals => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as double) >= (fieldValue as double))),
-            DwBackendFilterType.lessThan => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as double) < (fieldValue as double))),
-            DwBackendFilterType.lessThanOrEquals => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as double) <= (fieldValue as double))),
+            DwBackendFilterType.greaterThan =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as double) > (fieldValue as double))),
+            DwBackendFilterType.greaterThanOrEquals =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as double) >= (fieldValue as double))),
+            DwBackendFilterType.lessThan =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as double) < (fieldValue as double))),
+            DwBackendFilterType.lessThanOrEquals =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as double) <= (fieldValue as double))),
             _ => throw Exception('Unsupported filter type'),
           };
     } else if (_isNullableType(DateTime)) {
       return negate !=
           switch (type) {
-            DwBackendFilterType.greaterThan => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as DateTime)
-                        .isAfter((fieldValue as DateTime)))),
-            DwBackendFilterType.greaterThanOrEquals => fieldValue == null ||
-                (modelValue != null &&
-                    !(modelValue as DateTime)
-                        .isBefore((fieldValue as DateTime))),
-            DwBackendFilterType.lessThan => fieldValue == null ||
-                (modelValue != null &&
-                    ((modelValue as DateTime)
-                        .isBefore((fieldValue as DateTime)))),
-            DwBackendFilterType.lessThanOrEquals => fieldValue == null ||
-                (modelValue != null &&
-                    !(modelValue as DateTime)
-                        .isAfter((fieldValue as DateTime))),
+            DwBackendFilterType.greaterThan =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as DateTime).isAfter(
+                        (fieldValue as DateTime),
+                      ))),
+            DwBackendFilterType.greaterThanOrEquals =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      !(modelValue as DateTime).isBefore(
+                        (fieldValue as DateTime),
+                      )),
+            DwBackendFilterType.lessThan =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      ((modelValue as DateTime).isBefore(
+                        (fieldValue as DateTime),
+                      ))),
+            DwBackendFilterType.lessThanOrEquals =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      !(modelValue as DateTime).isAfter(
+                        (fieldValue as DateTime),
+                      )),
             _ => throw Exception('Unsupported filter type'),
           };
     } else if (_isNullableType(String)) {
       return negate !=
           switch (type) {
-            DwBackendFilterType.ilike => fieldValue == null ||
-                (modelValue != null &&
-                    _ilikeMatch(modelValue as String, fieldValue as String)),
+            DwBackendFilterType.ilike =>
+              fieldValue == null ||
+                  (modelValue != null &&
+                      _ilikeMatch(modelValue as String, fieldValue as String)),
             _ => throw Exception('Unsupported filter type'),
           };
     }
@@ -179,9 +194,9 @@ class DwBackendFilter<T> implements SerializableModel {
 
   bool _ilikeMatch(String value, String pattern) {
     // Escape the RegExp specials, but keep SQL's % and _ as placeholders
-    String escaped = RegExp.escape(pattern)
-        .replaceAll('%', '<<<PERCENT>>>')
-        .replaceAll('_', '<<<UNDERSCORE>>>');
+    String escaped = RegExp.escape(
+      pattern,
+    ).replaceAll('%', '<<<PERCENT>>>').replaceAll('_', '<<<UNDERSCORE>>>');
 
     // Turn the SQL wildcards into RegExp ones
     String regexPattern = escaped
@@ -189,8 +204,11 @@ class DwBackendFilter<T> implements SerializableModel {
         .replaceAll('<<<UNDERSCORE>>>', '.'); // _ → .
 
     // Anchor both ends: ILIKE matches the whole value, not a substring
-    RegExp regex =
-        RegExp('^$regexPattern\$', caseSensitive: false, dotAll: true);
+    RegExp regex = RegExp(
+      '^$regexPattern\$',
+      caseSensitive: false,
+      dotAll: true,
+    );
 
     return regex.hasMatch(value);
   }
@@ -224,11 +242,11 @@ class DwBackendFilter<T> implements SerializableModel {
 
   @override
   int get hashCode => Object.hash(
-        runtimeType,
-        type,
-        fieldName,
-        fieldValue,
-        _listEquality.hash(children),
-        negate,
-      );
+    runtimeType,
+    type,
+    fieldName,
+    fieldValue,
+    _listEquality.hash(children),
+    negate,
+  );
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_model_wrapper.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_model_wrapper.dart
@@ -7,17 +7,18 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
   }
 
   DwModelWrapper.wrap({required this.model})
-      : modelId = null,
-        this.foreignKeys = {},
-        className =
-            DwCoreServerpodClient.protocol.getClassNameForObject(model) ??
-                'unknown',
-        isDeleted = false,
-        jsonSerialization = {
-          'className':
-              DwCoreServerpodClient.protocol.getClassNameForObject(model),
-          'data': model.toJson(),
-        };
+    : modelId = null,
+      this.foreignKeys = {},
+      className =
+          DwCoreServerpodClient.protocol.getClassNameForObject(model) ??
+          'unknown',
+      isDeleted = false,
+      jsonSerialization = {
+        'className': DwCoreServerpodClient.protocol.getClassNameForObject(
+          model,
+        ),
+        'data': model.toJson(),
+      };
 
   DwModelWrapper._({
     required this.model,
@@ -26,8 +27,8 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
     required this.isDeleted,
     required this.jsonSerialization,
   }) : className =
-            DwCoreServerpodClient.protocol.getClassNameForObject(model) ??
-                'unknown';
+           DwCoreServerpodClient.protocol.getClassNameForObject(model) ??
+           'unknown';
 
   final String className;
   final SerializableModel model;
@@ -40,9 +41,7 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
 
   String get nitMappingClassname => className.split('.').last;
 
-  factory DwModelWrapper.fromJson(
-    Map<String, dynamic> jsonSerialization,
-  ) {
+  factory DwModelWrapper.fromJson(Map<String, dynamic> jsonSerialization) {
     final foreignKeys = <String, int>{};
 
     for (var key in (jsonSerialization['data'] as Map<String, dynamic>).keys) {
@@ -93,8 +92,9 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
       isDeleted: isDeleted,
       jsonSerialization: model != null
           ? {
-              'className':
-                  DwCoreServerpodClient.protocol.getClassNameForObject(newModel),
+              'className': DwCoreServerpodClient.protocol.getClassNameForObject(
+                newModel,
+              ),
               'data': newModel.toJson(),
             }
           : jsonSerialization,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_order_by.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_order_by.dart
@@ -1,18 +1,12 @@
 import 'package:serverpod_client/serverpod_client.dart';
 
 class DwOrderBy implements SerializableModel {
-  const DwOrderBy._({
-    required this.fieldName,
-    required this.orderDescending,
-  });
+  const DwOrderBy._({required this.fieldName, required this.orderDescending});
 
   final String? fieldName;
   final bool orderDescending;
 
-  DwOrderBy({
-    required this.fieldName,
-    required this.orderDescending,
-  });
+  DwOrderBy({required this.fieldName, required this.orderDescending});
 
   factory DwOrderBy.fromJson(Map<String, dynamic> jsonSerialization) {
     return DwOrderBy._(
@@ -23,10 +17,7 @@ class DwOrderBy implements SerializableModel {
 
   @override
   toJson() {
-    return {
-      'fieldName': fieldName,
-      'orderDescending': orderDescending,
-    };
+    return {'fieldName': fieldName, 'orderDescending': orderDescending};
   }
 
   @override
@@ -41,9 +32,5 @@ class DwOrderBy implements SerializableModel {
   }
 
   @override
-  int get hashCode => Object.hash(
-        runtimeType,
-        fieldName,
-        orderDescending,
-      );
+  int get hashCode => Object.hash(runtimeType, fieldName, orderDescending);
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/auth/auth_request/dw_auth_request.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/auth/auth_request/dw_auth_request.dart
@@ -238,15 +238,7 @@ class _DwAuthRequestImpl extends DwAuthRequest {
           : this.failReason,
       extraData: extraData is Map<String, String>?
           ? extraData
-          : this.extraData?.map(
-              (
-                key0,
-                value0,
-              ) => MapEntry(
-                key0,
-                value0,
-              ),
-            ),
+          : this.extraData?.map((key0, value0) => MapEntry(key0, value0)),
     );
   }
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/auth/dw_auth_key.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/auth/dw_auth_key.dart
@@ -14,12 +14,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 /// Provides a method of access for a user to authenticate with the server.
 abstract class DwAuthKey implements _i1.SerializableModel {
-  DwAuthKey._({
-    this.id,
-    required this.userId,
-    required this.hash,
-    this.key,
-  });
+  DwAuthKey._({this.id, required this.userId, required this.hash, this.key});
 
   factory DwAuthKey({
     int? id,
@@ -54,12 +49,7 @@ abstract class DwAuthKey implements _i1.SerializableModel {
   /// Returns a shallow copy of this [DwAuthKey]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  DwAuthKey copyWith({
-    int? id,
-    int? userId,
-    String? hash,
-    String? key,
-  });
+  DwAuthKey copyWith({int? id, int? userId, String? hash, String? key});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -85,12 +75,7 @@ class _DwAuthKeyImpl extends DwAuthKey {
     required int userId,
     required String hash,
     String? key,
-  }) : super._(
-         id: id,
-         userId: userId,
-         hash: hash,
-         key: key,
-       );
+  }) : super._(id: id, userId: userId, hash: hash, key: key);
 
   /// Returns a shallow copy of this [DwAuthKey]
   /// with some or all fields replaced by the given arguments.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/client.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/client.dart
@@ -36,12 +36,9 @@ class EndpointDwCrud extends _i1.EndpointRef {
       caller.callStreamingServerEndpoint<
         _i2.Stream<_i1.SerializableModel>,
         _i1.SerializableModel
-      >(
-        'dartway_serverpod_core.dwCrud',
-        'subscribeOnUpdates',
-        {'channel': channel},
-        {},
-      );
+      >('dartway_serverpod_core.dwCrud', 'subscribeOnUpdates', {
+        'channel': channel,
+      }, {});
 
   _i2.Future<_i3.DwApiResponse<_i4.DwModelWrapper>> getOne({
     required String className,
@@ -50,11 +47,7 @@ class EndpointDwCrud extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<_i3.DwApiResponse<_i4.DwModelWrapper>>(
     'dartway_serverpod_core.dwCrud',
     'getOne',
-    {
-      'className': className,
-      'filter': filter,
-      'apiGroup': apiGroup,
-    },
+    {'className': className, 'filter': filter, 'apiGroup': apiGroup},
   );
 
   _i2.Future<_i3.DwApiResponse<int>> getCount({
@@ -64,11 +57,7 @@ class EndpointDwCrud extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<_i3.DwApiResponse<int>>(
     'dartway_serverpod_core.dwCrud',
     'getCount',
-    {
-      'className': className,
-      'filter': filter,
-      'apiGroup': apiGroup,
-    },
+    {'className': className, 'filter': filter, 'apiGroup': apiGroup},
   );
 
   _i2.Future<_i3.DwApiResponse<List<_i4.DwModelWrapper>>> getAll({
@@ -97,10 +86,7 @@ class EndpointDwCrud extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<_i3.DwApiResponse<_i4.DwModelWrapper>>(
     'dartway_serverpod_core.dwCrud',
     'saveModel',
-    {
-      'wrappedModel': wrappedModel,
-      'apiGroup': apiGroup,
-    },
+    {'wrappedModel': wrappedModel, 'apiGroup': apiGroup},
   );
 
   _i2.Future<_i3.DwApiResponse<bool>> delete({
@@ -110,11 +96,7 @@ class EndpointDwCrud extends _i1.EndpointRef {
   }) => caller.callServerEndpoint<_i3.DwApiResponse<bool>>(
     'dartway_serverpod_core.dwCrud',
     'delete',
-    {
-      'className': className,
-      'modelId': modelId,
-      'apiGroup': apiGroup,
-    },
+    {'className': className, 'modelId': modelId, 'apiGroup': apiGroup},
   );
 }
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/dw_channel_closed.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/dw_channel_closed.dart
@@ -18,10 +18,7 @@ import 'dw_channel_closed_reason.dart' as _i2;
 /// the other must.
 abstract class DwChannelClosed
     implements _i1.SerializableException, _i1.SerializableModel {
-  DwChannelClosed._({
-    required this.channel,
-    required this.reason,
-  });
+  DwChannelClosed._({required this.channel, required this.reason});
 
   factory DwChannelClosed({
     required String channel,
@@ -67,10 +64,7 @@ class _DwChannelClosedImpl extends DwChannelClosed {
   _DwChannelClosedImpl({
     required String channel,
     required _i2.DwChannelClosedReason reason,
-  }) : super._(
-         channel: channel,
-         reason: reason,
-       );
+  }) : super._(channel: channel, reason: reason);
 
   /// Returns a shallow copy of this [DwChannelClosed]
   /// with some or all fields replaced by the given arguments.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/protocol.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/protocol.dart
@@ -70,15 +70,13 @@ class Protocol extends _i1.SerializationManager {
   }
 
   @override
-  T deserialize<T>(
-    dynamic data, [
-    Type? t,
-  ]) {
+  T deserialize<T>(dynamic data, [Type? t]) {
     t ??= T;
 
     if (data is Map<String, dynamic>) {
-      final manualDeserialization =
-          _i21.DwApiResponse.manualDeserialization<T>(data);
+      final manualDeserialization = _i21.DwApiResponse.manualDeserialization<T>(
+        data,
+      );
       if (manualDeserialization != null) {
         return manualDeserialization;
       }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/app/session/service/dw_authentification_key_manager.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/app/session/service/dw_authentification_key_manager.dart
@@ -92,9 +92,9 @@ class DwAuthenticationKeyManager implements ClientAuthKeyProvider {
         DwCoreServerpodClient.protocol.deserialize<UserProfileClass>(json),
       );
     } catch (e) {
-      final jsonString = await _storage.getString(
-        '${_userProfilePrefsKey}_$runMode',
-      ).catchError((_) => null);
+      final jsonString = await _storage
+          .getString('${_userProfilePrefsKey}_$runMode')
+          .catchError((_) => null);
       final userId = _tryExtractUserIdFromJson(jsonString);
       return (userId, null);
     }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_backend_filters_mixin.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_backend_filters_mixin.dart
@@ -14,43 +14,43 @@ mixin DwBackendFiltersMixin<T> on Enum {
 
   DwBackendFilter<T> greaterThan(T value, {bool negate = false}) =>
       (T != int && T != double && T != DateTime)
-          ? throw UnsupportedError(comparisonFiltersTypeErrorText)
-          : DwBackendFilter<T>.value(
-            type: DwBackendFilterType.greaterThan,
-            fieldName: name,
-            fieldValue: value,
-            negate: negate,
-          );
+      ? throw UnsupportedError(comparisonFiltersTypeErrorText)
+      : DwBackendFilter<T>.value(
+          type: DwBackendFilterType.greaterThan,
+          fieldName: name,
+          fieldValue: value,
+          negate: negate,
+        );
 
   DwBackendFilter<T> greaterThanOrEquals(T value, {bool negate = false}) =>
       (T != int && T != double && T != DateTime)
-          ? throw UnsupportedError(comparisonFiltersTypeErrorText)
-          : DwBackendFilter<T>.value(
-            type: DwBackendFilterType.greaterThanOrEquals,
-            fieldName: name,
-            fieldValue: value,
-            negate: negate,
-          );
+      ? throw UnsupportedError(comparisonFiltersTypeErrorText)
+      : DwBackendFilter<T>.value(
+          type: DwBackendFilterType.greaterThanOrEquals,
+          fieldName: name,
+          fieldValue: value,
+          negate: negate,
+        );
 
   DwBackendFilter<T> lessThan(T value, {bool negate = false}) =>
       (T != int && T != double && T != DateTime)
-          ? throw UnsupportedError(comparisonFiltersTypeErrorText)
-          : DwBackendFilter<T>.value(
-            type: DwBackendFilterType.lessThan,
-            fieldName: name,
-            fieldValue: value,
-            negate: negate,
-          );
+      ? throw UnsupportedError(comparisonFiltersTypeErrorText)
+      : DwBackendFilter<T>.value(
+          type: DwBackendFilterType.lessThan,
+          fieldName: name,
+          fieldValue: value,
+          negate: negate,
+        );
 
   DwBackendFilter<T> lessThanOrEquals(T value, {bool negate = false}) =>
       (T != int && T != double && T != DateTime)
-          ? throw UnsupportedError(comparisonFiltersTypeErrorText)
-          : DwBackendFilter<T>.value(
-            type: DwBackendFilterType.lessThanOrEquals,
-            fieldName: name,
-            fieldValue: value,
-            negate: negate,
-          );
+      ? throw UnsupportedError(comparisonFiltersTypeErrorText)
+      : DwBackendFilter<T>.value(
+          type: DwBackendFilterType.lessThanOrEquals,
+          fieldName: name,
+          fieldValue: value,
+          negate: negate,
+        );
 
   DwBackendFilter<String> like(String value, {bool negate = false}) =>
       DwBackendFilter.value(

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_cursor_pagination.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_cursor_pagination.dart
@@ -12,10 +12,7 @@ class DwCursorPagination implements DwPaginationStrategy {
 
   @override
   DwPaginationParams buildParams() {
-    return DwPaginationParams(
-      beforeId: _oldestId,
-      limit: limit,
-    );
+    return DwPaginationParams(beforeId: _oldestId, limit: limit);
   }
 
   @override

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_offset_pagination.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_offset_pagination.dart
@@ -12,10 +12,7 @@ class DwOffsetPagination implements DwPaginationStrategy {
 
   @override
   DwPaginationParams buildParams() {
-    return DwPaginationParams(
-      offset: _nextPage * pageSize,
-      limit: pageSize,
-    );
+    return DwPaginationParams(offset: _nextPage * pageSize, limit: pageSize);
   }
 
   @override

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repo.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repo.dart
@@ -137,7 +137,8 @@ class DwRepo {
   Future<int> count<T extends SerializableModel>({
     DwBackendFilter? filter,
     String? apiGroupOverride,
-  }) => DwRepository.count<T>(filter: filter, apiGroupOverride: apiGroupOverride);
+  }) =>
+      DwRepository.count<T>(filter: filter, apiGroupOverride: apiGroupOverride);
 
   /// Applies a **custom** (non-CRUD) endpoint's [DwApiResponse] to the repo:
   /// returns its value (throwing on error) and, unless [updateListeners] is

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/connection_error_handling.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/connection_error_handling.dart
@@ -12,7 +12,8 @@ import '../private/dw_singleton.dart';
 /// Builds a `Client.onFailedCall` handler: connection-level failures go to
 /// [onConnectionError] (default: silently ignored — no alert), everything else
 /// to [onUnexpectedError] (the app's alert/report sink).
-void Function(MethodCallContext, Object, StackTrace) dwConnectionAwareOnFailedCall({
+void Function(MethodCallContext, Object, StackTrace)
+dwConnectionAwareOnFailedCall({
   void Function(MethodCallContext ctx, Object error)? onConnectionError,
   required void Function(MethodCallContext ctx, Object error, StackTrace st)
   onUnexpectedError,
@@ -33,16 +34,15 @@ void Function(MethodCallContext, Object, StackTrace) dwConnectionAwareOnFailedCa
 /// Pass it when constructing the Client (`onFailedCall` is final there).
 void Function(MethodCallContext, Object, StackTrace) dwReportingOnFailedCall({
   void Function(MethodCallContext ctx, Object error)? onConnectionError,
-}) =>
-    dwConnectionAwareOnFailedCall(
-      onConnectionError: onConnectionError,
-      onUnexpectedError: (ctx, error, stackTrace) => dw.handleError(
-        error,
-        stackTrace,
-        source: DwErrorSource.failedCall,
-        failedCall: '${ctx.endpointName}.${ctx.methodName}',
-      ),
-    );
+}) => dwConnectionAwareOnFailedCall(
+  onConnectionError: onConnectionError,
+  onUnexpectedError: (ctx, error, stackTrace) => dw.handleError(
+    error,
+    stackTrace,
+    source: DwErrorSource.failedCall,
+    failedCall: '${ctx.endpointName}.${ctx.methodName}',
+  ),
+);
 
 /// Builds a zone-level error handler with the same routing, but without a
 /// [MethodCallContext]: connection-level → [onConnectionError]

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_error_report_alert_mapping.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_error_report_alert_mapping.dart
@@ -5,13 +5,13 @@ import 'package:dartway_serverpod_core_shared/dartway_serverpod_core_shared.dart
 /// app-state snapshot becomes the context block of the Telegram alert.
 extension DwErrorReportAlertMapping on DwErrorReport {
   DwAlertContext toAlertContext({String? userLabel}) => DwAlertContext(
-        platform: context.platform,
-        appVersion: context.appVersion,
-        userLabel: userLabel,
-        route: context.route,
-        features: context.featureIds,
-        actionLabel: actionLabel,
-        failedCall: failedCall,
-        extra: context.entries,
-      );
+    platform: context.platform,
+    appVersion: context.appVersion,
+    userLabel: userLabel,
+    route: context.route,
+    features: context.featureIds,
+    actionLabel: actionLabel,
+    failedCall: failedCall,
+    extra: context.entries,
+  );
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_file_upload_handler.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_file_upload_handler.dart
@@ -13,13 +13,13 @@ import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 class DwFileUploadHandler {
-  static String Function(XFile file) defaultUploadNameTemplate =
-      (XFile file) => DateFormat('yyyy-MM-dd hh:mm:ss').format(DateTime.now());
+  static String Function(XFile file) defaultUploadNameTemplate = (XFile file) =>
+      DateFormat('yyyy-MM-dd hh:mm:ss').format(DateTime.now());
 
   // The PlatformFile counterpart: it carries an extension but no usable name
-  static String Function(PlatformFile file) defaultPlatformUploadNameTemplate =
-      (PlatformFile file) =>
-          '${DateFormat('yyyy-MM-dd hh:mm:ss').format(DateTime.now())}${file.extension != null ? '.${file.extension!.toLowerCase()}' : ''}';
+  static String Function(PlatformFile file)
+  defaultPlatformUploadNameTemplate = (PlatformFile file) =>
+      '${DateFormat('yyyy-MM-dd hh:mm:ss').format(DateTime.now())}${file.extension != null ? '.${file.extension!.toLowerCase()}' : ''}';
 
   // -----------------------------
   //  EXISTING IMAGE UPLOAD LOGIC
@@ -64,10 +64,9 @@ class DwFileUploadHandler {
 
     final bytesToUpload = jpegBytes ?? originalBytes;
 
-    final uploadPath =
-        path == null
-            ? defaultUploadNameTemplate(xFile)
-            : '$path/${defaultUploadNameTemplate(xFile)}';
+    final uploadPath = path == null
+        ? defaultUploadNameTemplate(xFile)
+        : '$path/${defaultUploadNameTemplate(xFile)}';
 
     return uploadBytesToServer(bytes: bytesToUpload, path: uploadPath);
   }
@@ -104,10 +103,9 @@ class DwFileUploadHandler {
 
     final bytesToUpload = bytes;
 
-    final uploadPath =
-        path == null
-            ? defaultPlatformUploadNameTemplate(platformFile)
-            : '$path/${defaultPlatformUploadNameTemplate(platformFile)}';
+    final uploadPath = path == null
+        ? defaultPlatformUploadNameTemplate(platformFile)
+        : '$path/${defaultPlatformUploadNameTemplate(platformFile)}';
 
     return uploadBytesToServer(bytes: bytesToUpload, path: uploadPath);
   }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/widgets/infinite_list_view.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/widgets/infinite_list_view.dart
@@ -52,10 +52,9 @@ class _State<Entity> extends ConsumerState<InfiniteListView<Entity>> {
           isFirstLoadTriggered = true;
         }
 
-        final displayItems =
-            widget.groupBy != null
-                ? widget.groupBy!(ref, items) // grouped
-                : items; // flat
+        final displayItems = widget.groupBy != null
+            ? widget.groupBy!(ref, items) // grouped
+            : items; // flat
 
         Widget itemBuilder(BuildContext context, int index) {
           final item = displayItems[index];
@@ -103,19 +102,18 @@ class _State<Entity> extends ConsumerState<InfiniteListView<Entity>> {
             }
             return false;
           },
-          child:
-              displayItems.isEmpty
-                  ? widget.emptyListPlaceHolder
-                  : widget.separatorBuilder != null
-                  ? ListView.separated(
-                    itemCount: displayItems.length,
-                    itemBuilder: itemBuilder,
-                    separatorBuilder: widget.separatorBuilder!,
-                  )
-                  : ListView.builder(
-                    itemCount: displayItems.length,
-                    itemBuilder: itemBuilder,
-                  ),
+          child: displayItems.isEmpty
+              ? widget.emptyListPlaceHolder
+              : widget.separatorBuilder != null
+              ? ListView.separated(
+                  itemCount: displayItems.length,
+                  itemBuilder: itemBuilder,
+                  separatorBuilder: widget.separatorBuilder!,
+                )
+              : ListView.builder(
+                  itemCount: displayItems.length,
+                  itemBuilder: itemBuilder,
+                ),
         );
       },
     );

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/connection_error_handling_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/connection_error_handling_test.dart
@@ -37,17 +37,20 @@ void main() {
       expect(connection, isNull);
     });
 
-    test('connection error with no onConnectionError is silently swallowed', () {
-      var unexpectedCalled = false;
+    test(
+      'connection error with no onConnectionError is silently swallowed',
+      () {
+        var unexpectedCalled = false;
 
-      final handler = dwConnectionAwareErrorHandler(
-        onUnexpectedError: (_, _) => unexpectedCalled = true,
-      );
+        final handler = dwConnectionAwareErrorHandler(
+          onUnexpectedError: (_, _) => unexpectedCalled = true,
+        );
 
-      // Must not throw and must not reach onUnexpectedError.
-      handler(Exception('Failed to fetch'), StackTrace.empty);
+        // Must not throw and must not reach onUnexpectedError.
+        handler(Exception('Failed to fetch'), StackTrace.empty);
 
-      expect(unexpectedCalled, isFalse);
-    });
+        expect(unexpectedCalled, isFalse);
+      },
+    );
   });
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_channel_subscriptions_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_channel_subscriptions_test.dart
@@ -223,10 +223,7 @@ void main() {
         'dwPublicUpdates',
         'chat:12',
       ]);
-      expect(channelSubscriptions.liveChannels, [
-        'dwPublicUpdates',
-        'chat:12',
-      ]);
+      expect(channelSubscriptions.liveChannels, ['dwPublicUpdates', 'chat:12']);
     });
 
     test('closes the streams it replaces', () async {

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_session_service_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_session_service_test.dart
@@ -77,22 +77,25 @@ void main() {
     expect(keyManager.removeCalls, 1);
   });
 
-  test('keeps the cached profile when validation fails on connection', () async {
-    final cached = _FakeProfile(1);
-    final keyManager = _FakeKeyManager((1, cached));
-    final service = _buildService(
-      keyManager: keyManager,
-      fetchUserProfile: (_) async =>
-          throw TimeoutException('Future not completed'),
-    );
+  test(
+    'keeps the cached profile when validation fails on connection',
+    () async {
+      final cached = _FakeProfile(1);
+      final keyManager = _FakeKeyManager((1, cached));
+      final service = _buildService(
+        keyManager: keyManager,
+        fetchUserProfile: (_) async =>
+            throw TimeoutException('Future not completed'),
+      );
 
-    await service.initialize(); // must NOT throw
+      await service.initialize(); // must NOT throw
 
-    expect(service.currentUserProfile, same(cached));
-    expect(service.currentUserId, 1);
-    expect(keyManager.removeCalls, 0);
-    await service.initialize(); // already initialized → no-op
-  });
+      expect(service.currentUserProfile, same(cached));
+      expect(service.currentUserId, 1);
+      expect(keyManager.removeCalls, 0);
+      await service.initialize(); // already initialized → no-op
+    },
+  );
 
   test('rethrows when there is no cached profile', () async {
     final service = _buildService(
@@ -164,7 +167,8 @@ class _FakeKeyManager extends DwAuthenticationKeyManager {
   SerializableModel? storedProfile;
 
   @override
-  Future<(int?, T?)> loadLocalUserProfile<T extends SerializableModel>() async =>
+  Future<(int?, T?)>
+  loadLocalUserProfile<T extends SerializableModel>() async =>
       (_result.$1, _result.$2 as T?);
 
   @override

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_user_profile_providers_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_user_profile_providers_test.dart
@@ -87,7 +87,10 @@ void main() {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
-      expect(() => container.read(providers.requireUserProfile), throwsA(anything));
+      expect(
+        () => container.read(providers.requireUserProfile),
+        throwsA(anything),
+      );
 
       container.read(_session.notifier).signIn(_FakeProfile(7));
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
@@ -111,7 +111,8 @@ class DwAuthConfig<UserProfileClass extends TableRow> {
     Session session, {
     required DwAuthRequest authRequest,
     required UserProfileClass? userProfile,
-  })? preAuthValidation;
+  })?
+  preAuthValidation;
 
   /// Final application-owned authorization check immediately before an auth key
   /// is inserted.
@@ -126,7 +127,8 @@ class DwAuthConfig<UserProfileClass extends TableRow> {
     Session session, {
     required int userId,
     required Transaction transaction,
-  })? preAuthKeyIssuance;
+  })?
+  preAuthKeyIssuance;
 
   /// Validates an external auth provider's credential (e.g. an Apple identity
   /// token) carried on a non-email [DwAuthRequest]. Return `null` when the
@@ -138,27 +140,31 @@ class DwAuthConfig<UserProfileClass extends TableRow> {
   final Future<DwAuthFailReason?> Function(
     Session session, {
     required DwAuthRequest authRequest,
-  })? verifyExternalCredential;
+  })?
+  verifyExternalCredential;
 
   /// Callback for triggering actions when a user signs in.
   final Future<void> Function(
     Session session, {
     required int userId,
     required bool isFirstSignIn,
-  })? onSignInTrigger;
+  })?
+  onSignInTrigger;
 
   /// Callback for generating a verification code.
   final Future<String> Function(
     Session session, {
     required DwAuthRequest verificationRequest,
-  })? generateVerificationCodeMethod;
+  })?
+  generateVerificationCodeMethod;
 
   /// Callback for sending validation message.
   final Future<void> Function(
     Session session, {
     required DwAuthRequest verificationRequest,
     required String verificationCode,
-  })? sendVerificationCodeMethod;
+  })?
+  sendVerificationCodeMethod;
 
   // static DwAuthConfig _config = DwAuthConfig(
   //   secretHashKey: 'DwHashSecret',

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/cloud_storage/policy.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/cloud_storage/policy.dart
@@ -21,9 +21,16 @@ class Policy {
   int maxFileSize;
   bool public;
 
-  Policy(this.key, this.bucket, this.datetime, this.expiration, this.credential,
-      this.maxFileSize,
-      {this.region = 'us-east-1', this.public = true});
+  Policy(
+    this.key,
+    this.bucket,
+    this.datetime,
+    this.expiration,
+    this.credential,
+    this.maxFileSize, {
+    this.region = 'us-east-1',
+    this.public = true,
+  });
 
   factory Policy.fromS3PresignedPost(
     String key,
@@ -44,8 +51,16 @@ class Policy {
     final cred =
         '$accessKeyId/${SigV4.buildCredentialScope(datetime, region, 's3')}';
 
-    return Policy(key, bucket, datetime, expiration, cred, maxFileSize,
-        region: region, public: public);
+    return Policy(
+      key,
+      bucket,
+      datetime,
+      expiration,
+      cred,
+      maxFileSize,
+      region: region,
+      public: public,
+    );
   }
 
   String encode() {

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
@@ -159,9 +159,7 @@ class DwCore<UserProfileClass extends TableRow> {
       // The two the framework names itself. `userUpdates$id` was the sharpest
       // edge of all: the name is a number away from every other user's, so it
       // was readable by anyone signed in, not just by its owner.
-      const DwChannelConfig.owner(
-        prefix: DwCoreConst.userUpdatesChannelPrefix,
-      ),
+      const DwChannelConfig.owner(prefix: DwCoreConst.userUpdatesChannelPrefix),
       const DwChannelConfig.public(prefix: DwCoreConst.publicUpdatesChannel),
       ...channelConfigurations,
     ]);

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_api_response.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_api_response.dart
@@ -25,33 +25,31 @@ class DwApiResponse<T> implements SerializableModel, ProtocolSerialization {
     this.updatedModels,
   });
 
-  const DwApiResponse.notConfigured({
-    required String? source,
-  })  : isOk = false,
-        value = null,
-        error =
-            'Action not configured on server ${source != null ? ' ($source)' : ''}',
-        warning = null,
-        updatedModels = null;
+  const DwApiResponse.notConfigured({required String? source})
+    : isOk = false,
+      value = null,
+      error =
+          'Action not configured on server ${source != null ? ' ($source)' : ''}',
+      warning = null,
+      updatedModels = null;
 
   const DwApiResponse.forbidden()
-      : isOk = false,
-        value = null,
-        error = 'Not enough permissions',
-        warning = null,
-        updatedModels = null;
+    : isOk = false,
+      value = null,
+      error = 'Not enough permissions',
+      warning = null,
+      updatedModels = null;
 
   /// The caller is not signed in and the config did not opt into anonymous
   /// access. Distinct from [DwApiResponse.forbidden]: there the caller is
   /// known and lacks permission, here there is no caller at all — the client
   /// can act on that by sending the user to the login screen.
   const DwApiResponse.notAuthenticated({String? source})
-      : isOk = false,
-        value = null,
-        error =
-            'Authentication required${source != null ? ' ($source)' : ''}',
-        warning = null,
-        updatedModels = null;
+    : isOk = false,
+      value = null,
+      error = 'Authentication required${source != null ? ' ($source)' : ''}',
+      warning = null,
+      updatedModels = null;
 
   final bool isOk;
   final T? value;
@@ -59,9 +57,7 @@ class DwApiResponse<T> implements SerializableModel, ProtocolSerialization {
   final String? error;
   final List<DwModelWrapper>? updatedModels;
 
-  factory DwApiResponse.fromJson(
-    Map<String, dynamic> jsonSerialization,
-  ) {
+  factory DwApiResponse.fromJson(Map<String, dynamic> jsonSerialization) {
     return DwApiResponse(
       isOk: jsonSerialization['isOk'] as bool,
       value: _protocol.deserialize<T>(jsonSerialization['value']),
@@ -70,8 +66,8 @@ class DwApiResponse<T> implements SerializableModel, ProtocolSerialization {
       updatedModels: jsonSerialization['updatedModels'] == null
           ? null
           : (jsonSerialization['updatedModels'] as List)
-              .map((e) => _protocol.deserialize<DwModelWrapper>(e))
-              .toList(),
+                .map((e) => _protocol.deserialize<DwModelWrapper>(e))
+                .toList(),
     );
   }
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_auth_data.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_auth_data.dart
@@ -19,9 +19,7 @@ class DwAuthData implements SerializableModel, ProtocolSerialization {
 
   String get dwMappingClassname => className.split('.').last;
 
-  factory DwAuthData.fromJson(
-    Map<String, dynamic> jsonSerialization,
-  ) {
+  factory DwAuthData.fromJson(Map<String, dynamic> jsonSerialization) {
     return DwAuthData(
       key: jsonSerialization['key'],
       keyId: jsonSerialization['keyId'],
@@ -51,11 +49,7 @@ class DwAuthData implements SerializableModel, ProtocolSerialization {
     };
   }
 
-  DwAuthData copyWith({
-    TableRow? userProfile,
-    String? key,
-    int? keyId,
-  }) {
+  DwAuthData copyWith({TableRow? userProfile, String? key, int? keyId}) {
     return DwAuthData(
       key: key ?? this.key,
       keyId: keyId ?? this.keyId,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_backend_filter.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_backend_filter.dart
@@ -23,28 +23,28 @@ class DwBackendFilter implements SerializableModel {
   final bool negate;
 
   DwBackendFilter.andPrototype({required this.children, this.negate = false})
-      : type = DwBackendFilterType.and,
-        fieldName = null,
-        valueClassName = 'List',
-        fieldValue = null;
+    : type = DwBackendFilterType.and,
+      fieldName = null,
+      valueClassName = 'List',
+      fieldValue = null;
 
   DwBackendFilter.orPrototype({required this.children, this.negate = false})
-      : type = DwBackendFilterType.or,
-        fieldName = null,
-        valueClassName = 'List',
-        fieldValue = null;
+    : type = DwBackendFilterType.or,
+      fieldName = null,
+      valueClassName = 'List',
+      fieldValue = null;
 
   DwBackendFilter.equalsPrototype({
     required this.fieldName,
     this.negate = false,
-  })  : type = DwBackendFilterType.equals,
-        valueClassName =
-            Serverpod.instance.serializationManager.getClassNameForObject(
-                  null,
-                ) ??
-                'unknown',
-        fieldValue = null,
-        children = null;
+  }) : type = DwBackendFilterType.equals,
+       valueClassName =
+           Serverpod.instance.serializationManager.getClassNameForObject(
+             null,
+           ) ??
+           'unknown',
+       fieldValue = null,
+       children = null;
 
   factory DwBackendFilter.fromJson(Map<String, dynamic> jsonSerialization) {
     return DwBackendFilter._(
@@ -60,8 +60,8 @@ class DwBackendFilter implements SerializableModel {
       children: jsonSerialization['children'] == null
           ? null
           : (jsonSerialization['children'] as List)
-              .map((e) => DwBackendFilter.fromJson(e as Map<String, dynamic>))
-              .toList(),
+                .map((e) => DwBackendFilter.fromJson(e as Map<String, dynamic>))
+                .toList(),
       negate: jsonSerialization['negate'] as bool,
     );
   }
@@ -97,23 +97,23 @@ class DwBackendFilter implements SerializableModel {
 
   @override
   int get hashCode => Object.hash(
-        runtimeType,
-        type,
-        valueClassName,
-        fieldName,
-        fieldValue,
-        _listEquality.hash(children),
-        negate,
-      );
+    runtimeType,
+    type,
+    valueClassName,
+    fieldName,
+    fieldValue,
+    _listEquality.hash(children),
+    negate,
+  );
 
   Map<String, dynamic> get attributeMap => {
-        '${negate ? 'not ' : ''}${type.name}': switch (type) {
-          DwBackendFilterType.and || DwBackendFilterType.or => [
-              if (children != null) ...children!.map((e) => e.attributeMap),
-            ],
-          _ => fieldName,
-        },
-      };
+    '${negate ? 'not ' : ''}${type.name}': switch (type) {
+      DwBackendFilterType.and || DwBackendFilterType.or => [
+        if (children != null) ...children!.map((e) => e.attributeMap),
+      ],
+      _ => fieldName,
+    },
+  };
 
   Expression prepareWhere(Table table, {bool outerNegate = false}) {
     bool shouldNegate = negate != outerNegate;
@@ -293,8 +293,7 @@ class DwBackendFilter implements SerializableModel {
       return switch (type) {
         DwBackendFilterType.equals => negate ? column.notEquals : column.equals,
         _ => throw Exception('Unsupported filter type'),
-      }
-          .call(fieldValue);
+      }.call(fieldValue);
     }
     throw Exception('Unsupported filter type');
   }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_model_wrapper.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_model_wrapper.dart
@@ -15,17 +15,15 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
           .map((object) => DwModelWrapper(object: object!))
           .toList();
 
-  DwModelWrapper({
-    required this.object,
-  })  : className = _protocol.getClassNameForObject(object) ?? 'unknown',
-        modelId = object is TableRow ? object.id : null,
-        isDeleted = false;
+  DwModelWrapper({required this.object})
+    : className = _protocol.getClassNameForObject(object) ?? 'unknown',
+      modelId = object is TableRow ? object.id : null,
+      isDeleted = false;
 
-  DwModelWrapper.deleted({
-    required this.object,
-  })  : className = _protocol.getClassNameForObject(object) ?? 'unknown',
-        modelId = object is TableRow ? object.id : null,
-        isDeleted = true;
+  DwModelWrapper.deleted({required this.object})
+    : className = _protocol.getClassNameForObject(object) ?? 'unknown',
+      modelId = object is TableRow ? object.id : null,
+      isDeleted = true;
 
   final String className;
   final int? modelId;
@@ -35,9 +33,7 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
 
   String get dwMappingClassname => className.split('.').last;
 
-  factory DwModelWrapper.fromJson(
-    Map<String, dynamic> jsonSerialization,
-  ) {
+  factory DwModelWrapper.fromJson(Map<String, dynamic> jsonSerialization) {
     final object = _protocol.deserializeByClassName(jsonSerialization);
     final deleted = jsonSerialization['isDeleted'] as bool? ?? false;
     if (deleted) {
@@ -74,10 +70,7 @@ class DwModelWrapper implements SerializableModel, ProtocolSerialization {
     required this.isDeleted,
   });
 
-  DwModelWrapper copyWith({
-    SerializableModel? object,
-    bool? isDeleted,
-  }) {
+  DwModelWrapper copyWith({SerializableModel? object, bool? isDeleted}) {
     final newObject = object ?? this.object;
     return DwModelWrapper._internal(
       object: newObject,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_order_by.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_order_by.dart
@@ -1,10 +1,7 @@
 import 'package:serverpod/serverpod.dart';
 
 class DwOrderBy implements SerializableModel {
-  const DwOrderBy._({
-    required this.fieldName,
-    required this.orderDescending,
-  });
+  const DwOrderBy._({required this.fieldName, required this.orderDescending});
 
   final String? fieldName;
   final bool orderDescending;
@@ -18,10 +15,7 @@ class DwOrderBy implements SerializableModel {
 
   @override
   toJson() {
-    return {
-      'fieldName': fieldName,
-      'orderDescending': orderDescending,
-    };
+    return {'fieldName': fieldName, 'orderDescending': orderDescending};
   }
 
   @override
@@ -36,20 +30,13 @@ class DwOrderBy implements SerializableModel {
   }
 
   @override
-  int get hashCode => Object.hash(
-        runtimeType,
-        fieldName,
-        orderDescending,
-      );
+  int get hashCode => Object.hash(runtimeType, fieldName, orderDescending);
 
   Order prepareOrderBy(Table table) {
     final column = table.columns.firstWhere(
       (col) => col.columnName == fieldName,
     );
 
-    return Order(
-      column: column,
-      orderDescending: orderDescending,
-    );
+    return Order(column: column, orderDescending: orderDescending);
   }
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_protocol_json.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_protocol_json.dart
@@ -22,7 +22,7 @@ import 'package:serverpod/serverpod.dart';
 ///
 /// No fallback to `toJson` once [ProtocolSerialization] is on the model: a
 /// fallback is how the leak comes back.
-dynamic dwJsonForProtocol(SerializableModel model) => model
-        is ProtocolSerialization
+dynamic dwJsonForProtocol(SerializableModel model) =>
+    model is ProtocolSerialization
     ? (model as ProtocolSerialization).toJsonForProtocol()
     : model.toJson();

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/domain/dw_get_interface.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/domain/dw_get_interface.dart
@@ -1,9 +1,7 @@
 import 'package:serverpod/serverpod.dart';
 
 abstract class DwGetConfigInterface<T extends TableRow> {
-  final Future<Expression?> Function(
-    Session session,
-  )? accessFilter;
+  final Future<Expression?> Function(Session session)? accessFilter;
   final Include? include;
   final List<Order>? defaultOrderByList;
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
@@ -13,7 +13,6 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
     this.afterSaveSideEffects,
   });
 
-
   /// Whether a caller who is not signed in may reach this operation.
   ///
   /// Defaults to `false`: a CRUD endpoint is reachable without a session, so

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_get_list_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_get_list_config.dart
@@ -20,7 +20,6 @@ class DwDtoGetListConfig<DTO extends SerializableModel, Model extends TableRow>
     required this.transformModelFunction,
   });
 
-
   /// Whether a caller who is not signed in may reach this operation.
   ///
   /// Defaults to `false`: a CRUD endpoint is reachable without a session, so
@@ -52,10 +51,7 @@ class DwDtoGetListConfig<DTO extends SerializableModel, Model extends TableRow>
     int? offset,
   }) async {
     final resultItems = await session.db.find<Model>(
-      where: await getWhereExpression(
-        session,
-        whereClause: whereClause,
-      ),
+      where: await getWhereExpression(session, whereClause: whereClause),
       include: include,
       orderByList: orderByList ?? defaultOrderByList,
       limit: limit,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_delete_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_delete_config.dart
@@ -5,8 +5,11 @@ import 'package:serverpod/serverpod.dart';
 
 class DwDeleteConfig<T extends TableRow> {
   const DwDeleteConfig({
-    this.allowAnonymous = false,this.allowDelete, this.afterDelete, this.broadcastTo});
-
+    this.allowAnonymous = false,
+    this.allowDelete,
+    this.afterDelete,
+    this.broadcastTo,
+  });
 
   /// Whether a caller who is not signed in may reach this operation.
   ///

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_get_model_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_get_model_config.dart
@@ -19,7 +19,7 @@ class DwGetModelConfig<T extends TableRow> extends DwGetConfigInterface<T> {
   final DwBackendFilter filterPrototype;
 
   final Future<T?> Function(Session session, DwBackendFilter filter)?
-      createIfMissing;
+  createIfMissing;
 
   Future<T?> _getObject(
     Session session,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_get_model_list_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_get_model_list_config.dart
@@ -7,7 +7,8 @@ import '../domain/dw_get_interface.dart';
 import '../domain/dw_get_list_interface.dart';
 
 class DwGetModelListConfig<Model extends TableRow>
-    extends DwGetConfigInterface<Model> implements DwGetListInterface<Model> {
+    extends DwGetConfigInterface<Model>
+    implements DwGetListInterface<Model> {
   const DwGetModelListConfig({
     required super.accessFilter,
     super.allowAnonymous,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
@@ -282,13 +282,12 @@ class DwSaveConfig<T extends TableRow> {
           return;
         }
 
-        final context =
-            DwSaveContext<T>(
-              currentUserId: session.signedInUserProfileId,
-              isInsert: false,
-              initialModel: initialModel,
-              currentModel: model,
-            )..transaction = transaction;
+        final context = DwSaveContext<T>(
+          currentUserId: session.signedInUserProfileId,
+          isInsert: false,
+          initialModel: initialModel,
+          currentModel: model,
+        )..transaction = transaction;
         saveContext = context;
 
         // --- allowSave (under the lock) ---

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/endpoints/dw_crud_endpoint.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/endpoints/dw_crud_endpoint.dart
@@ -188,9 +188,7 @@ class DwCrudEndpoint extends Endpoint {
           return DwApiResponse.notConfigured(source: 'saveModel $className');
         }
         if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
-          return DwApiResponse.notAuthenticated(
-            source: 'saveModel $className',
-          );
+          return DwApiResponse.notAuthenticated(source: 'saveModel $className');
         }
         return await caller.save(session, model);
       } else {
@@ -200,9 +198,7 @@ class DwCrudEndpoint extends Endpoint {
           return DwApiResponse.notConfigured(source: 'saveModel $className');
         }
         if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
-          return DwApiResponse.notAuthenticated(
-            source: 'saveModel $className',
-          );
+          return DwApiResponse.notAuthenticated(source: 'saveModel $className');
         }
         return await caller.save(session, model);
       }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/endpoints/dw_upload_endpoint.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/endpoints/dw_upload_endpoint.dart
@@ -32,9 +32,7 @@ class DwUploadEndpoint extends Endpoint {
     Session session, {
     required String path,
   }) async {
-    final t = await _storage.createMultipartUploadDescription(
-      objectPath: path,
-    );
+    final t = await _storage.createMultipartUploadDescription(objectPath: path);
 
     // final t11 = jsonDecode(t);
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/auth_request/dw_auth_request.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/auth_request/dw_auth_request.dart
@@ -302,15 +302,7 @@ class _DwAuthRequestImpl extends DwAuthRequest {
           : this.failReason,
       extraData: extraData is Map<String, String>?
           ? extraData
-          : this.extraData?.map(
-              (
-                key0,
-                value0,
-              ) => MapEntry(
-                key0,
-                value0,
-              ),
-            ),
+          : this.extraData?.map((key0, value0) => MapEntry(key0, value0)),
     );
   }
 }
@@ -319,92 +311,54 @@ class DwAuthRequestUpdateTable extends _i1.UpdateTable<DwAuthRequestTable> {
   DwAuthRequestUpdateTable(super.table);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 
   _i1.ColumnValue<_i3.DwAuthRequestType, _i3.DwAuthRequestType> requestType(
     _i3.DwAuthRequestType value,
-  ) => _i1.ColumnValue(
-    table.requestType,
-    value,
-  );
+  ) => _i1.ColumnValue(table.requestType, value);
 
   _i1.ColumnValue<String, String> userIdentifier(String value) =>
-      _i1.ColumnValue(
-        table.userIdentifier,
-        value,
-      );
+      _i1.ColumnValue(table.userIdentifier, value);
 
-  _i1.ColumnValue<int, int> userId(int? value) => _i1.ColumnValue(
-    table.userId,
-    value,
-  );
+  _i1.ColumnValue<int, int> userId(int? value) =>
+      _i1.ColumnValue(table.userId, value);
 
   _i1.ColumnValue<_i4.DwAuthProvider, _i4.DwAuthProvider> authProvider(
     _i4.DwAuthProvider value,
-  ) => _i1.ColumnValue(
-    table.authProvider,
-    value,
-  );
+  ) => _i1.ColumnValue(table.authProvider, value);
 
   _i1.ColumnValue<_i5.DwAuthVerificationType, _i5.DwAuthVerificationType>
-  verificationType(_i5.DwAuthVerificationType? value) => _i1.ColumnValue(
-    table.verificationType,
-    value,
-  );
+  verificationType(_i5.DwAuthVerificationType? value) =>
+      _i1.ColumnValue(table.verificationType, value);
 
   _i1.ColumnValue<String, String> verificationHash(String? value) =>
-      _i1.ColumnValue(
-        table.verificationHash,
-        value,
-      );
+      _i1.ColumnValue(table.verificationHash, value);
 
   _i1.ColumnValue<_i2.DwAuthRequestStatus, _i2.DwAuthRequestStatus> status(
     _i2.DwAuthRequestStatus value,
-  ) => _i1.ColumnValue(
-    table.status,
-    value,
-  );
+  ) => _i1.ColumnValue(table.status, value);
 
   _i1.ColumnValue<_i6.DwAuthFailReason, _i6.DwAuthFailReason> failReason(
     _i6.DwAuthFailReason? value,
-  ) => _i1.ColumnValue(
-    table.failReason,
-    value,
-  );
+  ) => _i1.ColumnValue(table.failReason, value);
 
   _i1.ColumnValue<Map<String, String>, Map<String, String>> extraData(
     Map<String, String>? value,
-  ) => _i1.ColumnValue(
-    table.extraData,
-    value,
-  );
+  ) => _i1.ColumnValue(table.extraData, value);
 }
 
 class DwAuthRequestTable extends _i1.Table<int?> {
   DwAuthRequestTable({super.tableRelation})
     : super(tableName: 'dw_auth_request') {
     updateTable = DwAuthRequestUpdateTable(this);
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-      hasDefault: true,
-    );
+    createdAt = _i1.ColumnDateTime('createdAt', this, hasDefault: true);
     requestType = _i1.ColumnEnum(
       'requestType',
       this,
       _i1.EnumSerialization.byName,
     );
-    userIdentifier = _i1.ColumnString(
-      'userIdentifier',
-      this,
-    );
-    userId = _i1.ColumnInt(
-      'userId',
-      this,
-    );
+    userIdentifier = _i1.ColumnString('userIdentifier', this);
+    userId = _i1.ColumnInt('userId', this);
     authProvider = _i1.ColumnEnum(
       'authProvider',
       this,
@@ -415,10 +369,7 @@ class DwAuthRequestTable extends _i1.Table<int?> {
       this,
       _i1.EnumSerialization.byIndex,
     );
-    verificationHash = _i1.ColumnString(
-      'verificationHash',
-      this,
-    );
+    verificationHash = _i1.ColumnString('verificationHash', this);
     status = _i1.ColumnEnum(
       'status',
       this,
@@ -430,10 +381,7 @@ class DwAuthRequestTable extends _i1.Table<int?> {
       this,
       _i1.EnumSerialization.byName,
     );
-    extraData = _i1.ColumnSerializable<Map<String, String>>(
-      'extraData',
-      this,
-    );
+    extraData = _i1.ColumnSerializable<Map<String, String>>('extraData', this);
   }
 
   late final DwAuthRequestUpdateTable updateTable;
@@ -641,10 +589,7 @@ class DwAuthRequestRepository {
     DwAuthRequest row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<DwAuthRequest>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<DwAuthRequest>(row, transaction: transaction);
   }
 
   /// Updates all [DwAuthRequest]s in the list and returns the updated rows. If
@@ -729,10 +674,7 @@ class DwAuthRequestRepository {
     List<DwAuthRequest> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<DwAuthRequest>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<DwAuthRequest>(rows, transaction: transaction);
   }
 
   /// Deletes a single [DwAuthRequest].
@@ -741,10 +683,7 @@ class DwAuthRequestRepository {
     DwAuthRequest row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<DwAuthRequest>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<DwAuthRequest>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/auth_verification/dw_auth_verification.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/auth_verification/dw_auth_verification.dart
@@ -212,52 +212,32 @@ class DwAuthVerificationUpdateTable
     extends _i1.UpdateTable<DwAuthVerificationTable> {
   DwAuthVerificationUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> dwAuthRequestId(int value) => _i1.ColumnValue(
-    table.dwAuthRequestId,
-    value,
-  );
+  _i1.ColumnValue<int, int> dwAuthRequestId(int value) =>
+      _i1.ColumnValue(table.dwAuthRequestId, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 
   _i1.ColumnValue<_i3.DwAuthFailReason, _i3.DwAuthFailReason> failReason(
     _i3.DwAuthFailReason? value,
-  ) => _i1.ColumnValue(
-    table.failReason,
-    value,
-  );
+  ) => _i1.ColumnValue(table.failReason, value);
 
-  _i1.ColumnValue<String, String> accessToken(String? value) => _i1.ColumnValue(
-    table.accessToken,
-    value,
-  );
+  _i1.ColumnValue<String, String> accessToken(String? value) =>
+      _i1.ColumnValue(table.accessToken, value);
 }
 
 class DwAuthVerificationTable extends _i1.Table<int?> {
   DwAuthVerificationTable({super.tableRelation})
     : super(tableName: 'dw_auth_verification') {
     updateTable = DwAuthVerificationUpdateTable(this);
-    dwAuthRequestId = _i1.ColumnInt(
-      'dwAuthRequestId',
-      this,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-      hasDefault: true,
-    );
+    dwAuthRequestId = _i1.ColumnInt('dwAuthRequestId', this);
+    createdAt = _i1.ColumnDateTime('createdAt', this, hasDefault: true);
     failReason = _i1.ColumnEnum(
       'failReason',
       this,
       _i1.EnumSerialization.byName,
     );
-    accessToken = _i1.ColumnString(
-      'accessToken',
-      this,
-    );
+    accessToken = _i1.ColumnString('accessToken', this);
   }
 
   late final DwAuthVerificationUpdateTable updateTable;

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/dw_auth_key.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/dw_auth_key.dart
@@ -15,12 +15,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Provides a method of access for a user to authenticate with the server.
 abstract class DwAuthKey
     implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
-  DwAuthKey._({
-    this.id,
-    required this.userId,
-    required this.hash,
-    this.key,
-  });
+  DwAuthKey._({this.id, required this.userId, required this.hash, this.key});
 
   factory DwAuthKey({
     int? id,
@@ -60,12 +55,7 @@ abstract class DwAuthKey
   /// Returns a shallow copy of this [DwAuthKey]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  DwAuthKey copyWith({
-    int? id,
-    int? userId,
-    String? hash,
-    String? key,
-  });
+  DwAuthKey copyWith({int? id, int? userId, String? hash, String? key});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -126,12 +116,7 @@ class _DwAuthKeyImpl extends DwAuthKey {
     required int userId,
     required String hash,
     String? key,
-  }) : super._(
-         id: id,
-         userId: userId,
-         hash: hash,
-         key: key,
-       );
+  }) : super._(id: id, userId: userId, hash: hash, key: key);
 
   /// Returns a shallow copy of this [DwAuthKey]
   /// with some or all fields replaced by the given arguments.
@@ -155,28 +140,18 @@ class _DwAuthKeyImpl extends DwAuthKey {
 class DwAuthKeyUpdateTable extends _i1.UpdateTable<DwAuthKeyTable> {
   DwAuthKeyUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> userId(int value) => _i1.ColumnValue(
-    table.userId,
-    value,
-  );
+  _i1.ColumnValue<int, int> userId(int value) =>
+      _i1.ColumnValue(table.userId, value);
 
-  _i1.ColumnValue<String, String> hash(String value) => _i1.ColumnValue(
-    table.hash,
-    value,
-  );
+  _i1.ColumnValue<String, String> hash(String value) =>
+      _i1.ColumnValue(table.hash, value);
 }
 
 class DwAuthKeyTable extends _i1.Table<int?> {
   DwAuthKeyTable({super.tableRelation}) : super(tableName: 'dw_auth_key') {
     updateTable = DwAuthKeyUpdateTable(this);
-    userId = _i1.ColumnInt(
-      'userId',
-      this,
-    );
-    hash = _i1.ColumnString(
-      'hash',
-      this,
-    );
+    userId = _i1.ColumnInt('userId', this);
+    hash = _i1.ColumnString('hash', this);
   }
 
   late final DwAuthKeyUpdateTable updateTable;
@@ -188,11 +163,7 @@ class DwAuthKeyTable extends _i1.Table<int?> {
   late final _i1.ColumnString hash;
 
   @override
-  List<_i1.Column> get columns => [
-    id,
-    userId,
-    hash,
-  ];
+  List<_i1.Column> get columns => [id, userId, hash];
 }
 
 class DwAuthKeyInclude extends _i1.IncludeObject {
@@ -362,10 +333,7 @@ class DwAuthKeyRepository {
     DwAuthKey row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<DwAuthKey>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<DwAuthKey>(row, transaction: transaction);
   }
 
   /// Updates all [DwAuthKey]s in the list and returns the updated rows. If
@@ -450,10 +418,7 @@ class DwAuthKeyRepository {
     List<DwAuthKey> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<DwAuthKey>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<DwAuthKey>(rows, transaction: transaction);
   }
 
   /// Deletes a single [DwAuthKey].
@@ -462,10 +427,7 @@ class DwAuthKeyRepository {
     DwAuthKey row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<DwAuthKey>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<DwAuthKey>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/dw_user_password.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/auth/dw_user_password.dart
@@ -167,49 +167,27 @@ class _DwUserPasswordImpl extends DwUserPassword {
 class DwUserPasswordUpdateTable extends _i1.UpdateTable<DwUserPasswordTable> {
   DwUserPasswordUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> userId(int value) => _i1.ColumnValue(
-    table.userId,
-    value,
-  );
+  _i1.ColumnValue<int, int> userId(int value) =>
+      _i1.ColumnValue(table.userId, value);
 
-  _i1.ColumnValue<String, String> passwordHash(String value) => _i1.ColumnValue(
-    table.passwordHash,
-    value,
-  );
+  _i1.ColumnValue<String, String> passwordHash(String value) =>
+      _i1.ColumnValue(table.passwordHash, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 
   _i1.ColumnValue<DateTime, DateTime> updatedAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.updatedAt,
-        value,
-      );
+      _i1.ColumnValue(table.updatedAt, value);
 }
 
 class DwUserPasswordTable extends _i1.Table<int?> {
   DwUserPasswordTable({super.tableRelation})
     : super(tableName: 'dw_user_password') {
     updateTable = DwUserPasswordUpdateTable(this);
-    userId = _i1.ColumnInt(
-      'userId',
-      this,
-    );
-    passwordHash = _i1.ColumnString(
-      'passwordHash',
-      this,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
-    updatedAt = _i1.ColumnDateTime(
-      'updatedAt',
-      this,
-    );
+    userId = _i1.ColumnInt('userId', this);
+    passwordHash = _i1.ColumnString('passwordHash', this);
+    createdAt = _i1.ColumnDateTime('createdAt', this);
+    updatedAt = _i1.ColumnDateTime('updatedAt', this);
   }
 
   late final DwUserPasswordUpdateTable updateTable;
@@ -399,10 +377,7 @@ class DwUserPasswordRepository {
     DwUserPassword row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<DwUserPassword>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<DwUserPassword>(row, transaction: transaction);
   }
 
   /// Updates all [DwUserPassword]s in the list and returns the updated rows. If
@@ -487,10 +462,7 @@ class DwUserPasswordRepository {
     List<DwUserPassword> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<DwUserPassword>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<DwUserPassword>(rows, transaction: transaction);
   }
 
   /// Deletes a single [DwUserPassword].
@@ -499,10 +471,7 @@ class DwUserPasswordRepository {
     DwUserPassword row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<DwUserPassword>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<DwUserPassword>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/cloud_files/dw_cloud_file.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/cloud_files/dw_cloud_file.dart
@@ -215,84 +215,42 @@ class _DwCloudFileImpl extends DwCloudFile {
 class DwCloudFileUpdateTable extends _i1.UpdateTable<DwCloudFileTable> {
   DwCloudFileUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> createdBy(int? value) => _i1.ColumnValue(
-    table.createdBy,
-    value,
-  );
+  _i1.ColumnValue<int, int> createdBy(int? value) =>
+      _i1.ColumnValue(table.createdBy, value);
 
-  _i1.ColumnValue<String, String> bucket(String value) => _i1.ColumnValue(
-    table.bucket,
-    value,
-  );
+  _i1.ColumnValue<String, String> bucket(String value) =>
+      _i1.ColumnValue(table.bucket, value);
 
-  _i1.ColumnValue<String, String> path(String value) => _i1.ColumnValue(
-    table.path,
-    value,
-  );
+  _i1.ColumnValue<String, String> path(String value) =>
+      _i1.ColumnValue(table.path, value);
 
-  _i1.ColumnValue<String, String> publicUrl(String value) => _i1.ColumnValue(
-    table.publicUrl,
-    value,
-  );
+  _i1.ColumnValue<String, String> publicUrl(String value) =>
+      _i1.ColumnValue(table.publicUrl, value);
 
-  _i1.ColumnValue<int, int> size(int? value) => _i1.ColumnValue(
-    table.size,
-    value,
-  );
+  _i1.ColumnValue<int, int> size(int? value) =>
+      _i1.ColumnValue(table.size, value);
 
-  _i1.ColumnValue<String, String> mimeType(String? value) => _i1.ColumnValue(
-    table.mimeType,
-    value,
-  );
+  _i1.ColumnValue<String, String> mimeType(String? value) =>
+      _i1.ColumnValue(table.mimeType, value);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 
   _i1.ColumnValue<DateTime, DateTime> verifiedAt(DateTime? value) =>
-      _i1.ColumnValue(
-        table.verifiedAt,
-        value,
-      );
+      _i1.ColumnValue(table.verifiedAt, value);
 }
 
 class DwCloudFileTable extends _i1.Table<int?> {
   DwCloudFileTable({super.tableRelation}) : super(tableName: 'dw_cloud_file') {
     updateTable = DwCloudFileUpdateTable(this);
-    createdBy = _i1.ColumnInt(
-      'createdBy',
-      this,
-    );
-    bucket = _i1.ColumnString(
-      'bucket',
-      this,
-    );
-    path = _i1.ColumnString(
-      'path',
-      this,
-    );
-    publicUrl = _i1.ColumnString(
-      'publicUrl',
-      this,
-    );
-    size = _i1.ColumnInt(
-      'size',
-      this,
-    );
-    mimeType = _i1.ColumnString(
-      'mimeType',
-      this,
-    );
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
-    verifiedAt = _i1.ColumnDateTime(
-      'verifiedAt',
-      this,
-    );
+    createdBy = _i1.ColumnInt('createdBy', this);
+    bucket = _i1.ColumnString('bucket', this);
+    path = _i1.ColumnString('path', this);
+    publicUrl = _i1.ColumnString('publicUrl', this);
+    size = _i1.ColumnInt('size', this);
+    mimeType = _i1.ColumnString('mimeType', this);
+    createdAt = _i1.ColumnDateTime('createdAt', this);
+    verifiedAt = _i1.ColumnDateTime('verifiedAt', this);
   }
 
   late final DwCloudFileUpdateTable updateTable;
@@ -494,10 +452,7 @@ class DwCloudFileRepository {
     DwCloudFile row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<DwCloudFile>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<DwCloudFile>(row, transaction: transaction);
   }
 
   /// Updates all [DwCloudFile]s in the list and returns the updated rows. If
@@ -582,10 +537,7 @@ class DwCloudFileRepository {
     List<DwCloudFile> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<DwCloudFile>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<DwCloudFile>(rows, transaction: transaction);
   }
 
   /// Deletes a single [DwCloudFile].
@@ -594,10 +546,7 @@ class DwCloudFileRepository {
     DwCloudFile row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<DwCloudFile>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<DwCloudFile>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/dw_app_notification.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/dw_app_notification.dart
@@ -205,77 +205,39 @@ class DwAppNotificationUpdateTable
     extends _i1.UpdateTable<DwAppNotificationTable> {
   DwAppNotificationUpdateTable(super.table);
 
-  _i1.ColumnValue<int, int> toUserId(int value) => _i1.ColumnValue(
-    table.toUserId,
-    value,
-  );
+  _i1.ColumnValue<int, int> toUserId(int value) =>
+      _i1.ColumnValue(table.toUserId, value);
 
-  _i1.ColumnValue<String, String> identifier(String? value) => _i1.ColumnValue(
-    table.identifier,
-    value,
-  );
+  _i1.ColumnValue<String, String> identifier(String? value) =>
+      _i1.ColumnValue(table.identifier, value);
 
   _i1.ColumnValue<DateTime, DateTime> timestamp(DateTime value) =>
-      _i1.ColumnValue(
-        table.timestamp,
-        value,
-      );
+      _i1.ColumnValue(table.timestamp, value);
 
-  _i1.ColumnValue<String, String> title(String value) => _i1.ColumnValue(
-    table.title,
-    value,
-  );
+  _i1.ColumnValue<String, String> title(String value) =>
+      _i1.ColumnValue(table.title, value);
 
-  _i1.ColumnValue<String, String> body(String? value) => _i1.ColumnValue(
-    table.body,
-    value,
-  );
+  _i1.ColumnValue<String, String> body(String? value) =>
+      _i1.ColumnValue(table.body, value);
 
-  _i1.ColumnValue<String, String> goToPath(String? value) => _i1.ColumnValue(
-    table.goToPath,
-    value,
-  );
+  _i1.ColumnValue<String, String> goToPath(String? value) =>
+      _i1.ColumnValue(table.goToPath, value);
 
-  _i1.ColumnValue<bool, bool> isRead(bool value) => _i1.ColumnValue(
-    table.isRead,
-    value,
-  );
+  _i1.ColumnValue<bool, bool> isRead(bool value) =>
+      _i1.ColumnValue(table.isRead, value);
 }
 
 class DwAppNotificationTable extends _i1.Table<int?> {
   DwAppNotificationTable({super.tableRelation})
     : super(tableName: 'dw_app_notification') {
     updateTable = DwAppNotificationUpdateTable(this);
-    toUserId = _i1.ColumnInt(
-      'toUserId',
-      this,
-    );
-    identifier = _i1.ColumnString(
-      'identifier',
-      this,
-    );
-    timestamp = _i1.ColumnDateTime(
-      'timestamp',
-      this,
-      hasDefault: true,
-    );
-    title = _i1.ColumnString(
-      'title',
-      this,
-    );
-    body = _i1.ColumnString(
-      'body',
-      this,
-    );
-    goToPath = _i1.ColumnString(
-      'goToPath',
-      this,
-    );
-    isRead = _i1.ColumnBool(
-      'isRead',
-      this,
-      hasDefault: true,
-    );
+    toUserId = _i1.ColumnInt('toUserId', this);
+    identifier = _i1.ColumnString('identifier', this);
+    timestamp = _i1.ColumnDateTime('timestamp', this, hasDefault: true);
+    title = _i1.ColumnString('title', this);
+    body = _i1.ColumnString('body', this);
+    goToPath = _i1.ColumnString('goToPath', this);
+    isRead = _i1.ColumnBool('isRead', this, hasDefault: true);
   }
 
   late final DwAppNotificationUpdateTable updateTable;
@@ -564,10 +526,7 @@ class DwAppNotificationRepository {
     List<DwAppNotification> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<DwAppNotification>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<DwAppNotification>(rows, transaction: transaction);
   }
 
   /// Deletes a single [DwAppNotification].

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/dw_channel_closed.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/dw_channel_closed.dart
@@ -21,10 +21,7 @@ abstract class DwChannelClosed
         _i1.SerializableException,
         _i1.SerializableModel,
         _i1.ProtocolSerialization {
-  DwChannelClosed._({
-    required this.channel,
-    required this.reason,
-  });
+  DwChannelClosed._({required this.channel, required this.reason});
 
   factory DwChannelClosed({
     required String channel,
@@ -79,10 +76,7 @@ class _DwChannelClosedImpl extends DwChannelClosed {
   _DwChannelClosedImpl({
     required String channel,
     required _i2.DwChannelClosedReason reason,
-  }) : super._(
-         channel: channel,
-         reason: reason,
-       );
+  }) : super._(channel: channel, reason: reason);
 
   /// Returns a shallow copy of this [DwChannelClosed]
   /// with some or all fields replaced by the given arguments.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/dw_webhook_log.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/dw_webhook_log.dart
@@ -250,110 +250,54 @@ class DwWebServerLogUpdateTable extends _i1.UpdateTable<DwWebServerLogTable> {
   DwWebServerLogUpdateTable(super.table);
 
   _i1.ColumnValue<DateTime, DateTime> createdAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.createdAt,
-        value,
-      );
+      _i1.ColumnValue(table.createdAt, value);
 
-  _i1.ColumnValue<String, String> method(String value) => _i1.ColumnValue(
-    table.method,
-    value,
-  );
+  _i1.ColumnValue<String, String> method(String value) =>
+      _i1.ColumnValue(table.method, value);
 
-  _i1.ColumnValue<String, String> url(String value) => _i1.ColumnValue(
-    table.url,
-    value,
-  );
+  _i1.ColumnValue<String, String> url(String value) =>
+      _i1.ColumnValue(table.url, value);
 
-  _i1.ColumnValue<String, String> headers(String? value) => _i1.ColumnValue(
-    table.headers,
-    value,
-  );
+  _i1.ColumnValue<String, String> headers(String? value) =>
+      _i1.ColumnValue(table.headers, value);
 
-  _i1.ColumnValue<String, String> body(String? value) => _i1.ColumnValue(
-    table.body,
-    value,
-  );
+  _i1.ColumnValue<String, String> body(String? value) =>
+      _i1.ColumnValue(table.body, value);
 
-  _i1.ColumnValue<int, int> statusCode(int? value) => _i1.ColumnValue(
-    table.statusCode,
-    value,
-  );
+  _i1.ColumnValue<int, int> statusCode(int? value) =>
+      _i1.ColumnValue(table.statusCode, value);
 
-  _i1.ColumnValue<String, String> status(String? value) => _i1.ColumnValue(
-    table.status,
-    value,
-  );
+  _i1.ColumnValue<String, String> status(String? value) =>
+      _i1.ColumnValue(table.status, value);
 
-  _i1.ColumnValue<String, String> error(String? value) => _i1.ColumnValue(
-    table.error,
-    value,
-  );
+  _i1.ColumnValue<String, String> error(String? value) =>
+      _i1.ColumnValue(table.error, value);
 
-  _i1.ColumnValue<int, int> durationMs(int? value) => _i1.ColumnValue(
-    table.durationMs,
-    value,
-  );
+  _i1.ColumnValue<int, int> durationMs(int? value) =>
+      _i1.ColumnValue(table.durationMs, value);
 
-  _i1.ColumnValue<String, String> handler(String? value) => _i1.ColumnValue(
-    table.handler,
-    value,
-  );
+  _i1.ColumnValue<String, String> handler(String? value) =>
+      _i1.ColumnValue(table.handler, value);
 
-  _i1.ColumnValue<String, String> ip(String? value) => _i1.ColumnValue(
-    table.ip,
-    value,
-  );
+  _i1.ColumnValue<String, String> ip(String? value) =>
+      _i1.ColumnValue(table.ip, value);
 }
 
 class DwWebServerLogTable extends _i1.Table<int?> {
   DwWebServerLogTable({super.tableRelation})
     : super(tableName: 'dw_web_server_log') {
     updateTable = DwWebServerLogUpdateTable(this);
-    createdAt = _i1.ColumnDateTime(
-      'createdAt',
-      this,
-    );
-    method = _i1.ColumnString(
-      'method',
-      this,
-    );
-    url = _i1.ColumnString(
-      'url',
-      this,
-    );
-    headers = _i1.ColumnString(
-      'headers',
-      this,
-    );
-    body = _i1.ColumnString(
-      'body',
-      this,
-    );
-    statusCode = _i1.ColumnInt(
-      'statusCode',
-      this,
-    );
-    status = _i1.ColumnString(
-      'status',
-      this,
-    );
-    error = _i1.ColumnString(
-      'error',
-      this,
-    );
-    durationMs = _i1.ColumnInt(
-      'durationMs',
-      this,
-    );
-    handler = _i1.ColumnString(
-      'handler',
-      this,
-    );
-    ip = _i1.ColumnString(
-      'ip',
-      this,
-    );
+    createdAt = _i1.ColumnDateTime('createdAt', this);
+    method = _i1.ColumnString('method', this);
+    url = _i1.ColumnString('url', this);
+    headers = _i1.ColumnString('headers', this);
+    body = _i1.ColumnString('body', this);
+    statusCode = _i1.ColumnInt('statusCode', this);
+    status = _i1.ColumnString('status', this);
+    error = _i1.ColumnString('error', this);
+    durationMs = _i1.ColumnInt('durationMs', this);
+    handler = _i1.ColumnString('handler', this);
+    ip = _i1.ColumnString('ip', this);
   }
 
   late final DwWebServerLogUpdateTable updateTable;
@@ -564,10 +508,7 @@ class DwWebServerLogRepository {
     DwWebServerLog row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<DwWebServerLog>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<DwWebServerLog>(row, transaction: transaction);
   }
 
   /// Updates all [DwWebServerLog]s in the list and returns the updated rows. If
@@ -652,10 +593,7 @@ class DwWebServerLogRepository {
     List<DwWebServerLog> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<DwWebServerLog>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<DwWebServerLog>(rows, transaction: transaction);
   }
 
   /// Deletes a single [DwWebServerLog].
@@ -664,10 +602,7 @@ class DwWebServerLogRepository {
     DwWebServerLog row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<DwWebServerLog>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<DwWebServerLog>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/endpoints.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/endpoints.dart
@@ -28,17 +28,9 @@ class Endpoints extends _i1.EndpointDispatch {
   void initializeEndpoints(_i1.Server server) {
     var endpoints = <String, _i1.Endpoint>{
       'dwCrud': _i2.DwCrudEndpoint()
-        ..initialize(
-          server,
-          'dwCrud',
-          'dartway_serverpod_core',
-        ),
+        ..initialize(server, 'dwCrud', 'dartway_serverpod_core'),
       'dwUpload': _i3.DwUploadEndpoint()
-        ..initialize(
-          server,
-          'dwUpload',
-          'dartway_serverpod_core',
-        ),
+        ..initialize(server, 'dwUpload', 'dartway_serverpod_core'),
     };
     connectors['dwCrud'] = _i1.EndpointConnector(
       name: 'dwCrud',
@@ -63,11 +55,8 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
-          call:
-              (
-                _i1.Session session,
-                Map<String, dynamic> params,
-              ) async => (endpoints['dwCrud'] as _i2.DwCrudEndpoint).getOne(
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['dwCrud'] as _i2.DwCrudEndpoint).getOne(
                 session,
                 className: params['className'],
                 filter: params['filter'],
@@ -93,11 +82,8 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
-          call:
-              (
-                _i1.Session session,
-                Map<String, dynamic> params,
-              ) async => (endpoints['dwCrud'] as _i2.DwCrudEndpoint).getCount(
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['dwCrud'] as _i2.DwCrudEndpoint).getCount(
                 session,
                 className: params['className'],
                 filter: params['filter'],
@@ -138,11 +124,8 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
-          call:
-              (
-                _i1.Session session,
-                Map<String, dynamic> params,
-              ) async => (endpoints['dwCrud'] as _i2.DwCrudEndpoint).getAll(
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['dwCrud'] as _i2.DwCrudEndpoint).getAll(
                 session,
                 className: params['className'],
                 filter: params['filter'],
@@ -166,11 +149,8 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
-          call:
-              (
-                _i1.Session session,
-                Map<String, dynamic> params,
-              ) async => (endpoints['dwCrud'] as _i2.DwCrudEndpoint).saveModel(
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['dwCrud'] as _i2.DwCrudEndpoint).saveModel(
                 session,
                 wrappedModel: params['wrappedModel'],
                 apiGroup: params['apiGroup'],
@@ -195,11 +175,8 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
-          call:
-              (
-                _i1.Session session,
-                Map<String, dynamic> params,
-              ) async => (endpoints['dwCrud'] as _i2.DwCrudEndpoint).delete(
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['dwCrud'] as _i2.DwCrudEndpoint).delete(
                 session,
                 className: params['className'],
                 modelId: params['modelId'],
@@ -223,10 +200,7 @@ class Endpoints extends _i1.EndpointDispatch {
                 Map<String, dynamic> params,
                 Map<String, Stream> streamParams,
               ) => (endpoints['dwCrud'] as _i2.DwCrudEndpoint)
-                  .subscribeOnUpdates(
-                    session,
-                    channel: params['channel'],
-                  ),
+                  .subscribeOnUpdates(session, channel: params['channel']),
         ),
       },
     );
@@ -243,15 +217,9 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
-          call:
-              (
-                _i1.Session session,
-                Map<String, dynamic> params,
-              ) async => (endpoints['dwUpload'] as _i3.DwUploadEndpoint)
-                  .getUploadDescription(
-                    session,
-                    path: params['path'],
-                  ),
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['dwUpload'] as _i3.DwUploadEndpoint)
+                  .getUploadDescription(session, path: params['path']),
         ),
         'verifyUpload': _i1.MethodConnector(
           name: 'verifyUpload',
@@ -262,15 +230,11 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
-          call:
-              (
-                _i1.Session session,
-                Map<String, dynamic> params,
-              ) async =>
-                  (endpoints['dwUpload'] as _i3.DwUploadEndpoint).verifyUpload(
-                    session,
-                    path: params['path'],
-                  ),
+          call: (_i1.Session session, Map<String, dynamic> params) async =>
+              (endpoints['dwUpload'] as _i3.DwUploadEndpoint).verifyUpload(
+                session,
+                path: params['path'],
+              ),
         ),
       },
     );

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/future_calls.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/future_calls.dart
@@ -51,10 +51,7 @@ class FutureCalls extends _i1.FutureCallDispatch<_FutureCallRef> {
   }
 
   @override
-  void initialize(
-    _i1.FutureCallManager futureCallManager,
-    String serverId,
-  ) {
+  void initialize(_i1.FutureCallManager futureCallManager, String serverId) {
     var registeredFutureCalls = <String, _i1.FutureCall>{
       'DwOrphanedAuthKeyCleanupRunFutureCall':
           DwOrphanedAuthKeyCleanupRunFutureCall(),
@@ -69,39 +66,29 @@ class FutureCalls extends _i1.FutureCallDispatch<_FutureCallRef> {
   }
 
   @override
-  _FutureCallRef callAtTime(
-    DateTime time, {
-    String? identifier,
-  }) {
-    return _FutureCallRef(
-      (name, object) {
-        return _effectiveFutureCallManager.scheduleFutureCall(
-          name,
-          object,
-          time,
-          _effectiveServerId,
-          identifier,
-        );
-      },
-    );
+  _FutureCallRef callAtTime(DateTime time, {String? identifier}) {
+    return _FutureCallRef((name, object) {
+      return _effectiveFutureCallManager.scheduleFutureCall(
+        name,
+        object,
+        time,
+        _effectiveServerId,
+        identifier,
+      );
+    });
   }
 
   @override
-  _FutureCallRef callWithDelay(
-    Duration delay, {
-    String? identifier,
-  }) {
-    return _FutureCallRef(
-      (name, object) {
-        return _effectiveFutureCallManager.scheduleFutureCall(
-          name,
-          object,
-          DateTime.now().toUtc().add(delay),
-          _effectiveServerId,
-          identifier,
-        );
-      },
-    );
+  _FutureCallRef callWithDelay(Duration delay, {String? identifier}) {
+    return _FutureCallRef((name, object) {
+      return _effectiveFutureCallManager.scheduleFutureCall(
+        name,
+        object,
+        DateTime.now().toUtc().add(delay),
+        _effectiveServerId,
+        identifier,
+      );
+    });
   }
 
   @override
@@ -125,10 +112,7 @@ class _DwOrphanedAuthKeyCleanupFutureCallDispatcher {
   final _InvokeFutureCall _invokeFutureCall;
 
   Future<void> run() {
-    return _invokeFutureCall(
-      'DwOrphanedAuthKeyCleanupRunFutureCall',
-      null,
-    );
+    return _invokeFutureCall('DwOrphanedAuthKeyCleanupRunFutureCall', null);
   }
 
   Future<void> invoke(_i1.SerializableModel? object) {
@@ -156,9 +140,6 @@ class DwOrphanedAuthKeyCleanupInvokeFutureCall
     _i1.Session session,
     _i1.SerializableModel? object,
   ) async {
-    await _i3.DwOrphanedAuthKeyCleanup().invoke(
-      session,
-      object,
-    );
+    await _i3.DwOrphanedAuthKeyCleanup().invoke(session, object);
   }
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/protocol.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/generated/protocol.dart
@@ -615,10 +615,7 @@ class Protocol extends _i1.SerializationManagerServer {
   }
 
   @override
-  T deserialize<T>(
-    dynamic data, [
-    Type? t,
-  ]) {
+  T deserialize<T>(dynamic data, [Type? t]) {
     t ??= T;
 
     final dataClassName = getClassNameFromObjectJson(data);

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/channels/dw_channel_config_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/channels/dw_channel_config_test.dart
@@ -118,7 +118,8 @@ void main() {
       expect(
         predicateRan,
         isFalse,
-        reason: 'allowAnonymous is false, so the predicate never has to '
+        reason:
+            'allowAnonymous is false, so the predicate never has to '
             'remember it might be called without a user',
       );
     });

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/streaming/channel_revocation_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/streaming/channel_revocation_test.dart
@@ -141,9 +141,8 @@ void main() {
       for (final channel in [channelName, 'orders42', 'dwPublicUpdates'])
         openChannelStream<SerializableModel>(session, channel).listen(
           (_) {},
-          onError: (error) => endedChannels.add(
-            (error as DwChannelClosed).channel,
-          ),
+          onError: (error) =>
+              endedChannels.add((error as DwChannelClosed).channel),
         ),
     ];
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/dartway_serverpod_core_shared.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/dartway_serverpod_core_shared.dart
@@ -12,4 +12,3 @@ export 'src/alerts/configs/dw_telegram_alerts_keys.dart';
 export 'src/alerts/dw_alert_context.dart';
 export 'src/alerts/dw_alerts.dart';
 export 'src/static/dw_core_const.dart';
-

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/alerts/dw_alert_formatter.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/alerts/dw_alert_formatter.dart
@@ -14,9 +14,9 @@ abstract final class DwAlertFormatter {
 
   /// Escapes MarkdownV2 reserved characters in a VALUE (not in the template).
   static String escapeMarkdownV2(String value) => value.replaceAllMapped(
-        RegExp(r'([_*\[\]()~`>#+\-=|{}.!\\])'),
-        (m) => '\\${m.group(1)}',
-      );
+    RegExp(r'([_*\[\]()~`>#+\-=|{}.!\\])'),
+    (m) => '\\${m.group(1)}',
+  );
 
   /// Inside a MarkdownV2 code block only backticks and backslashes need care.
   static String _escapeCodeBlock(String value) =>
@@ -67,8 +67,11 @@ abstract final class DwAlertFormatter {
 
     // The stack gets whatever budget the fixed sections left over.
     final stackBudget = telegramMessageLimit - fixed.length - 2;
-    final stackBlock =
-        _formatStack(stack, maxLines: stackTraceMaxLines, budget: stackBudget);
+    final stackBlock = _formatStack(
+      stack,
+      maxLines: stackTraceMaxLines,
+      budget: stackBudget,
+    );
     return stackBlock == null ? fixed : '$fixed\n\n$stackBlock';
   }
 
@@ -105,8 +108,9 @@ abstract final class DwAlertFormatter {
     required int budget,
   }) {
     final allLines = stack.split('\n');
-    final shownCount =
-        maxLines == null ? allLines.length : maxLines.clamp(0, allLines.length);
+    final shownCount = maxLines == null
+        ? allLines.length
+        : maxLines.clamp(0, allLines.length);
     if (shownCount == 0 || budget < 60) return null;
 
     final headerSuffix = maxLines != null && allLines.length > maxLines

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/services/dw_telegram_service.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/services/dw_telegram_service.dart
@@ -21,8 +21,9 @@ class DwTelegramService {
     Function(String message)? reportErrorFunction,
   }) async {
     try {
-      final safeMessage =
-          escapeMessage ? _prepareMessage(message) : _truncate(message);
+      final safeMessage = escapeMessage
+          ? _prepareMessage(message)
+          : _truncate(message);
 
       final url = Uri.parse("https://api.telegram.org/bot$token/sendMessage");
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/test/dw_alert_formatter_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/test/dw_alert_formatter_test.dart
@@ -8,14 +8,18 @@ void main() {
   group('escapeMarkdownV2', () {
     test('escapes every reserved character and backslash', () {
       expect(
-        DwAlertFormatter.escapeMarkdownV2(r'a_b*c[d](e)~f`g>h#i+j-k=l|m{n}o.p!\'),
+        DwAlertFormatter.escapeMarkdownV2(
+          r'a_b*c[d](e)~f`g>h#i+j-k=l|m{n}o.p!\',
+        ),
         r'a\_b\*c\[d\]\(e\)\~f\`g\>h\#i\+j\-k\=l\|m\{n\}o\.p\!\\',
       );
     });
 
     test('leaves plain text untouched', () {
-      expect(DwAlertFormatter.escapeMarkdownV2('plain text 123'),
-          'plain text 123');
+      expect(
+        DwAlertFormatter.escapeMarkdownV2('plain text 123'),
+        'plain text 123',
+      );
     });
   });
 
@@ -108,8 +112,10 @@ void main() {
         stackTraceMaxLines: null,
       );
 
-      expect(message.length,
-          lessThanOrEqualTo(DwAlertFormatter.telegramMessageLimit));
+      expect(
+        message.length,
+        lessThanOrEqualTo(DwAlertFormatter.telegramMessageLimit),
+      );
       // if a code block opened, it must be closed
       expect('```'.allMatches(message).length, anyOf(0, 2));
     });

--- a/packages/dartway_shared_preferences/lib/src/dw_shared_preferences.dart
+++ b/packages/dartway_shared_preferences/lib/src/dw_shared_preferences.dart
@@ -26,8 +26,7 @@ extension DwPrefsAccess on DwPlugins {
 typedef DwPrefProvider<T> = NotifierProvider<PrefNotifier<T>, T>;
 
 /// What [DwSharedPreferences.mappedProvider] returns — see [DwPrefProvider].
-typedef DwMappedPrefProvider<T> =
-    NotifierProvider<MappedPrefNotifier<T>, T>;
+typedef DwMappedPrefProvider<T> = NotifierProvider<MappedPrefNotifier<T>, T>;
 
 /// What [DwSharedPreferences.providerFamily] returns — see [DwPrefProvider] for
 /// why the plugin names its own return types. Call it with an [Arg] to get a

--- a/packages/dartway_shared_preferences/test/consumer_needs_only_this_package_test.dart
+++ b/packages/dartway_shared_preferences/test/consumer_needs_only_this_package_test.dart
@@ -31,7 +31,8 @@ late final DwPrefProvider<bool> darkModeProvider = _prefs.provider<bool>(
 late final DwMappedPrefProvider<_Theme> themeProvider = _prefs
     .mappedProvider<_Theme>(
       key: 'theme',
-      mapFrom: (stored) => _Theme.values.asNameMap()[stored ?? ''] ?? _Theme.system,
+      mapFrom: (stored) =>
+          _Theme.values.asNameMap()[stored ?? ''] ?? _Theme.system,
       mapTo: (theme) => theme.name,
     );
 
@@ -49,7 +50,8 @@ late final DwPrefProviderFamily<String, int> projectSortProvider = _prefs
 late final DwMappedPrefProviderFamily<_Theme, String> sectionThemeProvider =
     _prefs.mappedProviderFamily<_Theme, String>(
       keyFor: (section) => 'section.$section.theme',
-      mapFrom: (stored) => _Theme.values.asNameMap()[stored ?? ''] ?? _Theme.system,
+      mapFrom: (stored) =>
+          _Theme.values.asNameMap()[stored ?? ''] ?? _Theme.system,
       mapTo: (theme) => theme.name,
     );
 

--- a/packages/dartway_shared_preferences/test/dw_shared_preferences_test.dart
+++ b/packages/dartway_shared_preferences/test/dw_shared_preferences_test.dart
@@ -25,31 +25,40 @@ void main() {
     addTearDown(container.dispose);
   });
 
-  test('provider returns the default, then reflects and persists an update',
-      () async {
-    final darkMode = prefs.provider<bool>(key: 'darkMode', defaultValue: false);
+  test(
+    'provider returns the default, then reflects and persists an update',
+    () async {
+      final darkMode = prefs.provider<bool>(
+        key: 'darkMode',
+        defaultValue: false,
+      );
 
-    expect(container.read(darkMode), isFalse);
+      expect(container.read(darkMode), isFalse);
 
-    await container.read(darkMode.notifier).update(true);
+      await container.read(darkMode.notifier).update(true);
 
-    expect(container.read(darkMode), isTrue);
-    expect(prefs.raw.getBool('darkMode'), isTrue);
-  });
+      expect(container.read(darkMode), isTrue);
+      expect(prefs.raw.getBool('darkMode'), isTrue);
+    },
+  );
 
-  test('provider throws UnsupportedError for a type SharedPreferences cannot store',
-      () async {
-    final when =
-        prefs.provider<DateTime>(key: 'when', defaultValue: DateTime(2020));
+  test(
+    'provider throws UnsupportedError for a type SharedPreferences cannot store',
+    () async {
+      final when = prefs.provider<DateTime>(
+        key: 'when',
+        defaultValue: DateTime(2020),
+      );
 
-    // Reading the default is fine; only the write hits the type dispatch.
-    expect(container.read(when), DateTime(2020));
+      // Reading the default is fine; only the write hits the type dispatch.
+      expect(container.read(when), DateTime(2020));
 
-    await expectLater(
-      container.read(when.notifier).update(DateTime(2021)),
-      throwsA(isA<UnsupportedError>()),
-    );
-  });
+      await expectLater(
+        container.read(when.notifier).update(DateTime(2021)),
+        throwsA(isA<UnsupportedError>()),
+      );
+    },
+  );
 
   test('mappedProvider round-trips a custom type through a String', () async {
     final theme = prefs.mappedProvider<_Theme>(
@@ -83,24 +92,29 @@ void main() {
       expect(prefs.raw.getString('project.2.sort'), isNull);
     });
 
-    test('the same argument resolves to one provider, shared by every reader',
-        () async {
-      final sort = prefs.providerFamily<String, int>(
-        keyFor: (projectId) => 'project.$projectId.sort',
-        defaultValue: 'name',
-      );
+    test(
+      'the same argument resolves to one provider, shared by every reader',
+      () async {
+        final sort = prefs.providerFamily<String, int>(
+          keyFor: (projectId) => 'project.$projectId.sort',
+          defaultValue: 'name',
+        );
 
-      // Two separate calls with the same argument. Riverpod compares family
-      // providers by (family, argument), so the container holds one state
-      // behind both — the guarantee a loop over `provider` cannot give.
-      expect(sort(7), sort(7));
-      expect(container.read(sort(7).notifier), same(container.read(sort(7).notifier)));
+        // Two separate calls with the same argument. Riverpod compares family
+        // providers by (family, argument), so the container holds one state
+        // behind both — the guarantee a loop over `provider` cannot give.
+        expect(sort(7), sort(7));
+        expect(
+          container.read(sort(7).notifier),
+          same(container.read(sort(7).notifier)),
+        );
 
-      await container.read(sort(7).notifier).update('createdAt');
+        await container.read(sort(7).notifier).update('createdAt');
 
-      // A second reader that resolved the family independently sees the write.
-      expect(container.read(sort(7)), 'createdAt');
-    });
+        // A second reader that resolved the family independently sees the write.
+        expect(container.read(sort(7)), 'createdAt');
+      },
+    );
 
     test('reads a value already in storage instead of the default', () async {
       SharedPreferences.setMockInitialValues({'project.3.sort': 'createdAt'});
@@ -134,23 +148,25 @@ void main() {
       expect(prefs.raw.getString('section.reports.theme'), isNull);
     });
 
-    test('the same argument resolves to one provider, shared by every reader',
-        () async {
-      final theme = prefs.mappedProviderFamily<_Theme, String>(
-        keyFor: (section) => 'section.$section.theme',
-        mapFrom: (raw) => _Theme.values.byName(raw ?? 'system'),
-        mapTo: (mode) => mode.name,
-      );
+    test(
+      'the same argument resolves to one provider, shared by every reader',
+      () async {
+        final theme = prefs.mappedProviderFamily<_Theme, String>(
+          keyFor: (section) => 'section.$section.theme',
+          mapFrom: (raw) => _Theme.values.byName(raw ?? 'system'),
+          mapTo: (mode) => mode.name,
+        );
 
-      expect(theme('billing'), theme('billing'));
-      expect(
-        container.read(theme('billing').notifier),
-        same(container.read(theme('billing').notifier)),
-      );
+        expect(theme('billing'), theme('billing'));
+        expect(
+          container.read(theme('billing').notifier),
+          same(container.read(theme('billing').notifier)),
+        );
 
-      await container.read(theme('billing').notifier).update(_Theme.dark);
+        await container.read(theme('billing').notifier).update(_Theme.dark);
 
-      expect(container.read(theme('billing')), _Theme.dark);
-    });
+        expect(container.read(theme('billing')), _Theme.dark);
+      },
+    );
   });
 }

--- a/packages/dartway_studio_bridge/lib/src/access/studio_bridge_token.dart
+++ b/packages/dartway_studio_bridge/lib/src/access/studio_bridge_token.dart
@@ -88,10 +88,7 @@ Future<bool> verifyStudioBridgeToken(
     ascii.encode(payloadSegment),
     signature: Signature(
       signature,
-      publicKey: SimplePublicKey(
-        publicKeyBytes,
-        type: KeyPairType.ed25519,
-      ),
+      publicKey: SimplePublicKey(publicKeyBytes, type: KeyPairType.ed25519),
     ),
   );
 }

--- a/packages/dartway_studio_bridge/lib/src/client/studio_bridge_client.dart
+++ b/packages/dartway_studio_bridge/lib/src/client/studio_bridge_client.dart
@@ -21,8 +21,8 @@ class StudioBridgeClient {
     required StudioMessageChannel channel,
     StudioAccessTokenSupplier? accessToken,
     this.connectRetryInterval = const Duration(seconds: 2),
-  })  : _channel = channel,
-        _accessToken = accessToken ?? _noAccessToken;
+  }) : _channel = channel,
+       _accessToken = accessToken ?? _noAccessToken;
 
   static String _noAccessToken() => '';
 
@@ -88,20 +88,22 @@ class StudioBridgeClient {
         _connected = false;
         unawaited(_sendConnect());
       case ManifestMessage(
-          :final manifest,
-          :final currentPath,
-          :final session,
-          :final features,
-          :final currentLocale,
-        ):
+        :final manifest,
+        :final currentPath,
+        :final session,
+        :final features,
+        :final currentLocale,
+      ):
         _connected = true;
-        _events.add(StudioProjectConnected(
-          manifest: manifest,
-          currentPath: currentPath,
-          session: session,
-          features: features,
-          currentLocale: currentLocale,
-        ));
+        _events.add(
+          StudioProjectConnected(
+            manifest: manifest,
+            currentPath: currentPath,
+            session: session,
+            features: features,
+            currentLocale: currentLocale,
+          ),
+        );
       case RouteChangedMessage(:final path, :final routeName):
         _events.add(StudioProjectRouteChanged(path, routeName: routeName));
       case SessionChangedMessage(:final session):
@@ -127,14 +129,10 @@ class StudioBridgeClient {
   /// Ask the app to sign in with the given test credentials (from Studio's
   /// project config) through its regular auth flow. [secret] is whatever the
   /// app's auth expects: a test verification code, or a password.
-  void requestSignIn({
-    required String identifier,
-    required String secret,
-  }) =>
-      _channel.send(SignInRequestMessage(
-        identifier: identifier,
-        secret: secret,
-      ));
+  void requestSignIn({required String identifier, required String secret}) =>
+      _channel.send(
+        SignInRequestMessage(identifier: identifier, secret: secret),
+      );
 
   void requestSignOut() => _channel.send(const SignOutRequestMessage());
 
@@ -166,10 +164,13 @@ class StudioBridgeClient {
         verticalFraction: verticalFraction,
       ),
     );
-    return pending.future.timeout(timeout, onTimeout: () {
-      _pendingInspects.remove(requestId);
-      return null;
-    });
+    return pending.future.timeout(
+      timeout,
+      onTimeout: () {
+        _pendingInspects.remove(requestId);
+        return null;
+      },
+    );
   }
 
   void dispose() {

--- a/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
+++ b/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
@@ -33,10 +33,11 @@ abstract interface class StudioBridgeHostDelegate {
 /// The point arrives as fractions of the app's own viewport (see
 /// [InspectPointRequestMessage]) — convert with the app's own logical
 /// viewport size, not any size Studio thinks the frame is.
-typedef StudioInspectPoint = FutureOr<StudioFeatureInfo?> Function(
-  double horizontalFraction,
-  double verticalFraction,
-);
+typedef StudioInspectPoint =
+    FutureOr<StudioFeatureInfo?> Function(
+      double horizontalFraction,
+      double verticalFraction,
+    );
 
 /// The app-side end of the Studio bridge: announces the app, answers the
 /// handshake with the manifest, reports route/session changes and dispatches
@@ -157,16 +158,12 @@ class StudioBridgeHost {
       case LocaleRequestMessage(:final locale):
         _delegate.onLocaleRequest(locale);
       case InspectPointRequestMessage(
-          :final requestId,
-          :final horizontalFraction,
-          :final verticalFraction,
-        ):
+        :final requestId,
+        :final horizontalFraction,
+        :final verticalFraction,
+      ):
         unawaited(
-          _answerInspectPoint(
-            requestId,
-            horizontalFraction,
-            verticalFraction,
-          ),
+          _answerInspectPoint(requestId, horizontalFraction, verticalFraction),
         );
       default:
         break; // App → Studio messages echoed back are ignored.
@@ -188,25 +185,29 @@ class StudioBridgeHost {
     try {
       feature = await _inspectPoint(horizontalFraction, verticalFraction);
     } catch (error, stackTrace) {
-      FlutterError.reportError(FlutterErrorDetails(
-        exception: error,
-        stack: stackTrace,
-        library: 'dartway_studio_bridge',
-        context: ErrorDescription('answering a Studio inspect-point request'),
-      ));
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'dartway_studio_bridge',
+          context: ErrorDescription('answering a Studio inspect-point request'),
+        ),
+      );
     }
     _channel.send(
       InspectPointResultMessage(requestId: requestId, feature: feature),
     );
   }
 
-  void _sendManifest() => _channel.send(ManifestMessage(
-        manifest: _manifest,
-        currentPath: _currentPath(),
-        session: _currentSession(),
-        features: _currentFeatures(),
-        currentLocale: _currentLocale(),
-      ));
+  void _sendManifest() => _channel.send(
+    ManifestMessage(
+      manifest: _manifest,
+      currentPath: _currentPath(),
+      session: _currentSession(),
+      features: _currentFeatures(),
+      currentLocale: _currentLocale(),
+    ),
+  );
 
   /// The reports below are dropped until a Studio has been let in. Nothing is
   /// lost by that: whoever connects is handed the whole state in the handshake

--- a/packages/dartway_studio_bridge/lib/src/models/studio_feature_info.dart
+++ b/packages/dartway_studio_bridge/lib/src/models/studio_feature_info.dart
@@ -52,15 +52,15 @@ class StudioFeatureInfo {
   bool get hasKnownIssues => knownIssues.isNotEmpty;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'title': title,
-        if (purpose != null) 'purpose': purpose,
-        if (behaviors.isNotEmpty) 'behaviors': behaviors,
-        if (requirements.isNotEmpty) 'requirements': requirements,
-        if (implementationNotes.isNotEmpty)
-          'implementationNotes': implementationNotes,
-        if (knownIssues.isNotEmpty) 'knownIssues': knownIssues,
-      };
+    'id': id,
+    'title': title,
+    if (purpose != null) 'purpose': purpose,
+    if (behaviors.isNotEmpty) 'behaviors': behaviors,
+    if (requirements.isNotEmpty) 'requirements': requirements,
+    if (implementationNotes.isNotEmpty)
+      'implementationNotes': implementationNotes,
+    if (knownIssues.isNotEmpty) 'knownIssues': knownIssues,
+  };
 
   /// Parsing stays lenient: an app built against an older bridge sends neither
   /// the new lists nor `purpose`, and an app built against a newer one may send
@@ -77,15 +77,15 @@ class StudioFeatureInfo {
       );
 
   static List<StudioFeatureInfo> listFromJson(Object? json) => [
-        if (json is List)
-          for (final item in json)
-            if (item is Map<String, dynamic>) StudioFeatureInfo.fromJson(item),
-      ];
+    if (json is List)
+      for (final item in json)
+        if (item is Map<String, dynamic>) StudioFeatureInfo.fromJson(item),
+  ];
 
   /// Lenient string-list parsing, shared with the other spec models.
   static List<String> stringListFromJson(Object? json) => [
-        if (json is List)
-          for (final item in json)
-            if (item is String) item,
-      ];
+    if (json is List)
+      for (final item in json)
+        if (item is String) item,
+  ];
 }

--- a/packages/dartway_studio_bridge/lib/src/models/studio_manifest_index.dart
+++ b/packages/dartway_studio_bridge/lib/src/models/studio_manifest_index.dart
@@ -6,10 +6,10 @@ import 'studio_zone_spec.dart';
 /// route path and build breadcrumb labels from the parent chain.
 class StudioManifestIndex {
   StudioManifestIndex(this.manifest)
-      : _byPath = {
-          for (final zone in manifest.zones)
-            for (final screen in zone.screens) screen.path: screen,
-        };
+    : _byPath = {
+        for (final zone in manifest.zones)
+          for (final screen in zone.screens) screen.path: screen,
+      };
 
   final StudioProjectManifest manifest;
   final Map<String, StudioScreenSpec> _byPath;
@@ -92,9 +92,9 @@ class StudioManifestIndex {
       path.split('/').where((segment) => segment.isNotEmpty).toList();
 
   StudioZoneSpec zoneOf(StudioScreenSpec spec) => manifest.zones.firstWhere(
-        (zone) => zone.screens.contains(spec),
-        orElse: () => manifest.zones.first,
-      );
+    (zone) => zone.screens.contains(spec),
+    orElse: () => manifest.zones.first,
+  );
 
   /// Breadcrumb-style label built from the parent chain, e.g.
   /// `Profile › Services`. Zone roots keep their own title.

--- a/packages/dartway_studio_bridge/lib/src/models/studio_project_manifest.dart
+++ b/packages/dartway_studio_bridge/lib/src/models/studio_project_manifest.dart
@@ -37,11 +37,11 @@ class StudioProjectManifest {
   final List<String> supportedLocales;
 
   Map<String, dynamic> toJson() => {
-        'projectName': projectName,
-        'zones': [for (final zone in zones) zone.toJson()],
-        'features': [for (final feature in features) feature.toJson()],
-        'supportedLocales': supportedLocales,
-      };
+    'projectName': projectName,
+    'zones': [for (final zone in zones) zone.toJson()],
+    'features': [for (final feature in features) feature.toJson()],
+    'supportedLocales': supportedLocales,
+  };
 
   factory StudioProjectManifest.fromJson(Map<String, dynamic> json) =>
       StudioProjectManifest(
@@ -52,7 +52,8 @@ class StudioProjectManifest {
               if (item is Map<String, dynamic>) StudioZoneSpec.fromJson(item),
         ],
         features: StudioFeatureInfo.listFromJson(json['features']),
-        supportedLocales:
-            StudioScreenSpec.stringListFromJson(json['supportedLocales']),
+        supportedLocales: StudioScreenSpec.stringListFromJson(
+          json['supportedLocales'],
+        ),
       );
 }

--- a/packages/dartway_studio_bridge/lib/src/models/studio_screen_spec.dart
+++ b/packages/dartway_studio_bridge/lib/src/models/studio_screen_spec.dart
@@ -30,12 +30,12 @@ class StudioScreenSpec {
   final List<String> discussionQuestions;
 
   Map<String, dynamic> toJson() => {
-        'path': path,
-        if (parentPath != null) 'parentPath': parentPath,
-        'title': title,
-        'purpose': purpose,
-        'discussionQuestions': discussionQuestions,
-      };
+    'path': path,
+    if (parentPath != null) 'parentPath': parentPath,
+    'title': title,
+    'purpose': purpose,
+    'discussionQuestions': discussionQuestions,
+  };
 
   factory StudioScreenSpec.fromJson(Map<String, dynamic> json) =>
       StudioScreenSpec(
@@ -48,8 +48,8 @@ class StudioScreenSpec {
 
   /// Lenient string-list parsing shared by the spec models.
   static List<String> stringListFromJson(Object? json) => [
-        if (json is List)
-          for (final item in json)
-            if (item is String) item,
-      ];
+    if (json is List)
+      for (final item in json)
+        if (item is String) item,
+  ];
 }

--- a/packages/dartway_studio_bridge/lib/src/models/studio_session_state.dart
+++ b/packages/dartway_studio_bridge/lib/src/models/studio_session_state.dart
@@ -25,11 +25,11 @@ class StudioSessionState {
   final bool isBusy;
 
   Map<String, dynamic> toJson() => {
-        'isSignedIn': isSignedIn,
-        if (userIdentifier != null) 'userIdentifier': userIdentifier,
-        if (displayLabel != null) 'displayLabel': displayLabel,
-        'isBusy': isBusy,
-      };
+    'isSignedIn': isSignedIn,
+    if (userIdentifier != null) 'userIdentifier': userIdentifier,
+    if (displayLabel != null) 'displayLabel': displayLabel,
+    'isBusy': isBusy,
+  };
 
   factory StudioSessionState.fromJson(Map<String, dynamic> json) =>
       StudioSessionState(

--- a/packages/dartway_studio_bridge/lib/src/models/studio_zone_spec.dart
+++ b/packages/dartway_studio_bridge/lib/src/models/studio_zone_spec.dart
@@ -34,21 +34,22 @@ class StudioZoneSpec {
   final List<StudioScreenSpec> screens;
 
   Map<String, dynamic> toJson() => {
-        'label': label,
-        'rootPath': rootPath,
-        'access': access.name,
-        'screens': [for (final screen in screens) screen.toJson()],
-      };
+    'label': label,
+    'rootPath': rootPath,
+    'access': access.name,
+    'screens': [for (final screen in screens) screen.toJson()],
+  };
 
   factory StudioZoneSpec.fromJson(Map<String, dynamic> json) => StudioZoneSpec(
-        label: json['label'] as String? ?? '',
-        rootPath: json['rootPath'] as String? ?? '/',
-        access: StudioZoneAccess.values.asNameMap()[json['access']] ??
-            StudioZoneAccess.any,
-        screens: [
-          if (json['screens'] is List)
-            for (final item in json['screens'] as List)
-              if (item is Map<String, dynamic>) StudioScreenSpec.fromJson(item),
-        ],
-      );
+    label: json['label'] as String? ?? '',
+    rootPath: json['rootPath'] as String? ?? '/',
+    access:
+        StudioZoneAccess.values.asNameMap()[json['access']] ??
+        StudioZoneAccess.any,
+    screens: [
+      if (json['screens'] is List)
+        for (final item in json['screens'] as List)
+          if (item is Map<String, dynamic>) StudioScreenSpec.fromJson(item),
+    ],
+  );
 }

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_app_messages.dart
@@ -59,12 +59,12 @@ class ManifestMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
-        'manifest': manifest.toJson(),
-        'currentPath': currentPath,
-        'session': session.toJson(),
-        'features': [for (final f in features) f.toJson()],
-        'currentLocale': currentLocale,
-      };
+    'manifest': manifest.toJson(),
+    'currentPath': currentPath,
+    'session': session.toJson(),
+    'features': [for (final f in features) f.toJson()],
+    'currentLocale': currentLocale,
+  };
 
   factory ManifestMessage.fromPayload(Map<String, dynamic> payload) =>
       ManifestMessage(
@@ -96,9 +96,9 @@ class RouteChangedMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
-        'path': path,
-        if (routeName != null) 'routeName': routeName,
-      };
+    'path': path,
+    if (routeName != null) 'routeName': routeName,
+  };
 
   factory RouteChangedMessage.fromPayload(Map<String, dynamic> payload) =>
       RouteChangedMessage(
@@ -120,9 +120,9 @@ class FeaturesChangedMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
-        'path': path,
-        'features': [for (final f in features) f.toJson()],
-      };
+    'path': path,
+    'features': [for (final f in features) f.toJson()],
+  };
 
   factory FeaturesChangedMessage.fromPayload(Map<String, dynamic> payload) =>
       FeaturesChangedMessage(
@@ -187,13 +187,11 @@ class InspectPointResultMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
-        'requestId': requestId,
-        if (feature != null) 'feature': feature!.toJson(),
-      };
+    'requestId': requestId,
+    if (feature != null) 'feature': feature!.toJson(),
+  };
 
-  factory InspectPointResultMessage.fromPayload(
-    Map<String, dynamic> payload,
-  ) =>
+  factory InspectPointResultMessage.fromPayload(Map<String, dynamic> payload) =>
       InspectPointResultMessage(
         requestId: payload['requestId'] as String? ?? '',
         feature: switch (payload['feature']) {

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
@@ -17,10 +17,10 @@ sealed class StudioBridgeMessage {
   Map<String, dynamic> payloadToJson() => const {};
 
   String encode() => jsonEncode({
-        StudioBridgeProtocol.envelopeKey: StudioBridgeProtocol.version,
-        StudioBridgeProtocol.typeKey: type,
-        StudioBridgeProtocol.payloadKey: payloadToJson(),
-      });
+    StudioBridgeProtocol.envelopeKey: StudioBridgeProtocol.version,
+    StudioBridgeProtocol.typeKey: type,
+    StudioBridgeProtocol.payloadKey: payloadToJson(),
+  });
 
   /// Parses raw postMessage data; null for anything that is not a valid
   /// message of the supported protocol version (foreign messages are common
@@ -40,30 +40,36 @@ sealed class StudioBridgeMessage {
     }
     final payload =
         decoded[StudioBridgeProtocol.payloadKey] as Map<String, dynamic>? ??
-            const {};
+        const {};
     return switch (decoded[StudioBridgeProtocol.typeKey]) {
       StudioBridgeProtocol.appReady => const AppReadyMessage(),
       StudioBridgeProtocol.connectRefused => const ConnectRefusedMessage(),
       StudioBridgeProtocol.manifest => ManifestMessage.fromPayload(payload),
-      StudioBridgeProtocol.routeChanged =>
-        RouteChangedMessage.fromPayload(payload),
-      StudioBridgeProtocol.sessionChanged =>
-        SessionChangedMessage.fromPayload(payload),
+      StudioBridgeProtocol.routeChanged => RouteChangedMessage.fromPayload(
+        payload,
+      ),
+      StudioBridgeProtocol.sessionChanged => SessionChangedMessage.fromPayload(
+        payload,
+      ),
       StudioBridgeProtocol.featuresChanged =>
         FeaturesChangedMessage.fromPayload(payload),
-      StudioBridgeProtocol.localeChanged =>
-        LocaleChangedMessage.fromPayload(payload),
+      StudioBridgeProtocol.localeChanged => LocaleChangedMessage.fromPayload(
+        payload,
+      ),
       StudioBridgeProtocol.inspectPointResult =>
         InspectPointResultMessage.fromPayload(payload),
-      StudioBridgeProtocol.studioConnect =>
-        StudioConnectMessage.fromPayload(payload),
+      StudioBridgeProtocol.studioConnect => StudioConnectMessage.fromPayload(
+        payload,
+      ),
       StudioBridgeProtocol.navigateRequest =>
         NavigateRequestMessage.fromPayload(payload),
-      StudioBridgeProtocol.signInRequest =>
-        SignInRequestMessage.fromPayload(payload),
+      StudioBridgeProtocol.signInRequest => SignInRequestMessage.fromPayload(
+        payload,
+      ),
       StudioBridgeProtocol.signOutRequest => const SignOutRequestMessage(),
-      StudioBridgeProtocol.localeRequest =>
-        LocaleRequestMessage.fromPayload(payload),
+      StudioBridgeProtocol.localeRequest => LocaleRequestMessage.fromPayload(
+        payload,
+      ),
       StudioBridgeProtocol.inspectPointRequest =>
         InspectPointRequestMessage.fromPayload(payload),
       _ => null,

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_request_messages.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_request_messages.dart
@@ -48,10 +48,7 @@ class NavigateRequestMessage extends StudioBridgeMessage {
 /// personas are a platform concern) — the app itself ships no test users and
 /// no special sign-in path; it uses them exactly like user-typed ones.
 class SignInRequestMessage extends StudioBridgeMessage {
-  const SignInRequestMessage({
-    required this.identifier,
-    required this.secret,
-  });
+  const SignInRequestMessage({required this.identifier, required this.secret});
 
   /// The user identifier in the form the app's auth expects (phone, email).
   final String identifier;
@@ -65,9 +62,9 @@ class SignInRequestMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
-        'identifier': identifier,
-        'secret': secret,
-      };
+    'identifier': identifier,
+    'secret': secret,
+  };
 
   factory SignInRequestMessage.fromPayload(Map<String, dynamic> payload) =>
       SignInRequestMessage(
@@ -132,19 +129,17 @@ class InspectPointRequestMessage extends StudioBridgeMessage {
 
   @override
   Map<String, dynamic> payloadToJson() => {
-        'requestId': requestId,
-        'horizontalFraction': horizontalFraction,
-        'verticalFraction': verticalFraction,
-      };
+    'requestId': requestId,
+    'horizontalFraction': horizontalFraction,
+    'verticalFraction': verticalFraction,
+  };
 
   factory InspectPointRequestMessage.fromPayload(
     Map<String, dynamic> payload,
-  ) =>
-      InspectPointRequestMessage(
-        requestId: payload['requestId'] as String? ?? '',
-        horizontalFraction:
-            (payload['horizontalFraction'] as num?)?.toDouble() ?? 0,
-        verticalFraction:
-            (payload['verticalFraction'] as num?)?.toDouble() ?? 0,
-      );
+  ) => InspectPointRequestMessage(
+    requestId: payload['requestId'] as String? ?? '',
+    horizontalFraction:
+        (payload['horizontalFraction'] as num?)?.toDouble() ?? 0,
+    verticalFraction: (payload['verticalFraction'] as num?)?.toDouble() ?? 0,
+  );
 }

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_web.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_web.dart
@@ -13,7 +13,7 @@ StudioFrameController createStudioFrameController({required String appUrl}) =>
 
 class _StudioFrameControllerWeb implements StudioFrameController {
   _StudioFrameControllerWeb(String appUrl)
-      : viewType = 'dartway-studio-frame-${_instanceCounter++}' {
+    : viewType = 'dartway-studio-frame-${_instanceCounter++}' {
     _frame = web.document.createElement('iframe') as web.HTMLIFrameElement
       ..src = appUrl;
     _frame.style

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_stub.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_stub.dart
@@ -2,6 +2,4 @@ import 'studio_probe_frame.dart';
 
 /// The Studio client loads an app in an iframe — web only.
 StudioProbeFrame openStudioProbeFrame({required String appUrl}) =>
-    throw UnsupportedError(
-      'StudioProbeFrame is only available in web builds',
-    );
+    throw UnsupportedError('StudioProbeFrame is only available in web builds');

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_web.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_web.dart
@@ -38,8 +38,9 @@ class _StudioProbeFrameWeb implements StudioProbeFrame {
       ..pointerEvents = 'none'
       ..zIndex = '-1';
     _container.appendChild(_frame);
-    (web.document.body ?? web.document.documentElement!)
-        .appendChild(_container);
+    (web.document.body ?? web.document.documentElement!).appendChild(
+      _container,
+    );
 
     _channel = StudioClientWebChannel(_frame, Uri.parse(appUrl).origin);
   }

--- a/packages/dartway_studio_bridge/test/studio_bridge_client_inspect_point_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_client_inspect_point_test.dart
@@ -30,39 +30,41 @@ extension on _FakeChannel {
 
 void main() {
   group('StudioBridgeClient.inspectPoint', () {
-    test('sends the fractional point and resolves with the app\'s answer',
-        () async {
-      final channel = _FakeChannel();
-      final client = StudioBridgeClient(channel: channel)..start();
+    test(
+      'sends the fractional point and resolves with the app\'s answer',
+      () async {
+        final channel = _FakeChannel();
+        final client = StudioBridgeClient(channel: channel)..start();
 
-      final result = client.inspectPoint(0.25, 0.5);
-      expect(
-        channel.sent,
-        contains(
-          isA<InspectPointRequestMessage>()
-              .having(
-                (message) => message.horizontalFraction,
-                'horizontalFraction',
-                0.25,
-              )
-              .having(
-                (message) => message.verticalFraction,
-                'verticalFraction',
-                0.5,
-              ),
-        ),
-      );
+        final result = client.inspectPoint(0.25, 0.5);
+        expect(
+          channel.sent,
+          contains(
+            isA<InspectPointRequestMessage>()
+                .having(
+                  (message) => message.horizontalFraction,
+                  'horizontalFraction',
+                  0.25,
+                )
+                .having(
+                  (message) => message.verticalFraction,
+                  'verticalFraction',
+                  0.5,
+                ),
+          ),
+        );
 
-      channel.emit(
-        InspectPointResultMessage(
-          requestId: channel.inspectRequests.single.requestId,
-          feature: const StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
-        ),
-      );
+        channel.emit(
+          InspectPointResultMessage(
+            requestId: channel.inspectRequests.single.requestId,
+            feature: const StudioFeatureInfo(id: 'ad/card', title: 'Ad card'),
+          ),
+        );
 
-      expect((await result)?.id, 'ad/card');
-      client.dispose();
-    });
+        expect((await result)?.id, 'ad/card');
+        client.dispose();
+      },
+    );
 
     test('resolves with null when the app never answers', () async {
       final channel = _FakeChannel();

--- a/packages/dartway_studio_bridge/test/studio_bridge_host_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_host_test.dart
@@ -77,10 +77,11 @@ Future<bool> _acceptsOnly(String accessToken) async => accessToken == 'good';
 /// what a stale or foreign signature looks like from the host's side.
 String _wellFormedToken() {
   final payload = base64Url
-      .encode(utf8.encode(jsonEncode({
-        'origin': 'https://app.example.com',
-        'exp': 1765540000,
-      })))
+      .encode(
+        utf8.encode(
+          jsonEncode({'origin': 'https://app.example.com', 'exp': 1765540000}),
+        ),
+      )
       .replaceAll('=', '');
   return '$payload.${base64Url.encode(List.filled(64, 7)).replaceAll('=', '')}';
 }
@@ -189,22 +190,26 @@ void main() {
   });
 
   group('the gate covers every command, not just the manifest', () {
-    test('an embedding page that presented nothing cannot drive the app',
-        () async {
-      final host = attach();
+    test(
+      'an embedding page that presented nothing cannot drive the app',
+      () async {
+        final host = attach();
 
-      studio.say(const NavigateRequestMessage('/admin'));
-      studio.say(const SignInRequestMessage(
-        identifier: '79990000002',
-        secret: '123456',
-      ));
-      studio.say(const SignOutRequestMessage());
-      studio.say(const LocaleRequestMessage('en'));
-      await pumpEventQueue();
+        studio.say(const NavigateRequestMessage('/admin'));
+        studio.say(
+          const SignInRequestMessage(
+            identifier: '79990000002',
+            secret: '123456',
+          ),
+        );
+        studio.say(const SignOutRequestMessage());
+        studio.say(const LocaleRequestMessage('en'));
+        await pumpEventQueue();
 
-      expect(delegate.done, isEmpty);
-      expect(host.isConnected, isFalse);
-    });
+        expect(delegate.done, isEmpty);
+        expect(host.isConnected, isFalse);
+      },
+    );
 
     test('nor read what is declared on the screen', () async {
       attach(
@@ -212,27 +217,31 @@ void main() {
             const StudioFeatureInfo(id: 'schedule/list', title: 'List'),
       );
 
-      studio.say(const InspectPointRequestMessage(
-        requestId: 'inspect-1',
-        horizontalFraction: 0.5,
-        verticalFraction: 0.5,
-      ));
+      studio.say(
+        const InspectPointRequestMessage(
+          requestId: 'inspect-1',
+          horizontalFraction: 0.5,
+          verticalFraction: 0.5,
+        ),
+      );
       await pumpEventQueue();
 
       expect(studio.of<InspectPointResultMessage>(), isEmpty);
     });
 
-    test('a refused Studio stays refused for the commands that follow',
-        () async {
-      attach();
-      studio.say(const StudioConnectMessage(accessToken: 'forged'));
-      await pumpEventQueue();
+    test(
+      'a refused Studio stays refused for the commands that follow',
+      () async {
+        attach();
+        studio.say(const StudioConnectMessage(accessToken: 'forged'));
+        await pumpEventQueue();
 
-      studio.say(const NavigateRequestMessage('/admin'));
-      await pumpEventQueue();
+        studio.say(const NavigateRequestMessage('/admin'));
+        await pumpEventQueue();
 
-      expect(delegate.done, isEmpty);
-    });
+        expect(delegate.done, isEmpty);
+      },
+    );
 
     test('and every command lands once it has been let in', () async {
       attach(
@@ -242,17 +251,18 @@ void main() {
       await connect();
 
       studio.say(const NavigateRequestMessage('/admin'));
-      studio.say(const SignInRequestMessage(
-        identifier: '79990000002',
-        secret: '123456',
-      ));
+      studio.say(
+        const SignInRequestMessage(identifier: '79990000002', secret: '123456'),
+      );
       studio.say(const SignOutRequestMessage());
       studio.say(const LocaleRequestMessage('en'));
-      studio.say(const InspectPointRequestMessage(
-        requestId: 'inspect-1',
-        horizontalFraction: 0.5,
-        verticalFraction: 0.5,
-      ));
+      studio.say(
+        const InspectPointRequestMessage(
+          requestId: 'inspect-1',
+          horizontalFraction: 0.5,
+          verticalFraction: 0.5,
+        ),
+      );
       await pumpEventQueue();
 
       expect(delegate.done, [
@@ -298,11 +308,15 @@ void main() {
       ]);
 
       expect(studio.of<RouteChangedMessage>().single.routeName, 'adDetail');
-      expect(studio.of<SessionChangedMessage>().single.session.isSignedIn,
-          isFalse);
+      expect(
+        studio.of<SessionChangedMessage>().single.session.isSignedIn,
+        isFalse,
+      );
       expect(studio.of<LocaleChangedMessage>().single.locale, 'en');
-      expect(studio.of<FeaturesChangedMessage>().single.features.single.id,
-          'schedule/list');
+      expect(
+        studio.of<FeaturesChangedMessage>().single.features.single.id,
+        'schedule/list',
+      );
     });
   });
 

--- a/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_message_test.dart
@@ -6,10 +6,7 @@ StudioBridgeMessage? _roundTrip(StudioBridgeMessage message) =>
     StudioBridgeMessage.tryDecode(message.encode());
 
 void main() {
-  const manifest = StudioProjectManifest(
-    projectName: 'Demo',
-    zones: [],
-  );
+  const manifest = StudioProjectManifest(projectName: 'Demo', zones: []);
 
   group('round-trip every message type', () {
     test('appReady', () {
@@ -24,23 +21,27 @@ void main() {
     });
 
     test('studioConnect carries the access token', () {
-      final decoded =
-          _roundTrip(const StudioConnectMessage(accessToken: 'abc'));
+      final decoded = _roundTrip(
+        const StudioConnectMessage(accessToken: 'abc'),
+      );
       expect((decoded as StudioConnectMessage).accessToken, 'abc');
       // A connect with no token at all decodes to an empty one — which only a
       // build in its zero-config local-dev mode accepts.
       expect(
         (StudioBridgeMessage.tryDecode(
-          '{"dartwayStudioBridge":4,"type":"studioConnect","payload":{}}',
-        ) as StudioConnectMessage)
+                  '{"dartwayStudioBridge":4,"type":"studioConnect","payload":{}}',
+                )
+                as StudioConnectMessage)
             .accessToken,
         '',
       );
     });
 
     test('signOutRequest', () {
-      expect(_roundTrip(const SignOutRequestMessage()),
-          isA<SignOutRequestMessage>());
+      expect(
+        _roundTrip(const SignOutRequestMessage()),
+        isA<SignOutRequestMessage>(),
+      );
     });
 
     test('navigateRequest carries the path', () {
@@ -49,10 +50,9 @@ void main() {
     });
 
     test('signInRequest carries the credentials', () {
-      final decoded = _roundTrip(const SignInRequestMessage(
-        identifier: '79990000002',
-        secret: '123456',
-      ));
+      final decoded = _roundTrip(
+        const SignInRequestMessage(identifier: '79990000002', secret: '123456'),
+      );
       final msg = decoded as SignInRequestMessage;
       expect(msg.identifier, '79990000002');
       expect(msg.secret, '123456');
@@ -126,8 +126,9 @@ void main() {
     });
 
     test('inspectPointResult carries null when nothing was found there', () {
-      final decoded =
-          _roundTrip(const InspectPointResultMessage(requestId: 'inspect-7'));
+      final decoded = _roundTrip(
+        const InspectPointResultMessage(requestId: 'inspect-7'),
+      );
       final result = decoded as InspectPointResultMessage;
       expect(result.requestId, 'inspect-7');
       expect(result.feature, isNull);
@@ -180,13 +181,15 @@ void main() {
       expect(StudioBridgeMessage.tryDecode('{"type":"appReady"}'), isNull);
       expect(
         StudioBridgeMessage.tryDecode(
-            '{"dartwayStudioBridge":999,"type":"appReady"}'),
+          '{"dartwayStudioBridge":999,"type":"appReady"}',
+        ),
         isNull,
       );
       // v1 (bilingual passports) is a different schema — must be ignored.
       expect(
         StudioBridgeMessage.tryDecode(
-            '{"dartwayStudioBridge":1,"type":"appReady"}'),
+          '{"dartwayStudioBridge":1,"type":"appReady"}',
+        ),
         isNull,
       );
     });
@@ -194,8 +197,9 @@ void main() {
     test('unknown message type', () {
       expect(
         StudioBridgeMessage.tryDecode(
-            '{"dartwayStudioBridge":${StudioBridgeProtocol.version},'
-            '"type":"bogus","payload":{}}'),
+          '{"dartwayStudioBridge":${StudioBridgeProtocol.version},'
+          '"type":"bogus","payload":{}}',
+        ),
         isNull,
       );
     });
@@ -212,22 +216,26 @@ void main() {
   test('encoded envelope carries the protocol version', () {
     expect(
       const AppReadyMessage().encode(),
-      contains('"${StudioBridgeProtocol.envelopeKey}":'
-          '${StudioBridgeProtocol.version}'),
+      contains(
+        '"${StudioBridgeProtocol.envelopeKey}":'
+        '${StudioBridgeProtocol.version}',
+      ),
     );
   });
 
-  test('connectRefused goes on the wire exactly as the JS package writes it',
-      () {
-    // The literal below is the same string, character for character, as the
-    // golden in `js/studio-bridge/test/protocol.test.ts`. The two
-    // implementations share no schema — only this — and an app on either of
-    // them talks to a Studio that was never told which it is.
-    expect(
-      const ConnectRefusedMessage().encode(),
-      '{"dartwayStudioBridge":4,"type":"connectRefused","payload":{}}',
-    );
-  });
+  test(
+    'connectRefused goes on the wire exactly as the JS package writes it',
+    () {
+      // The literal below is the same string, character for character, as the
+      // golden in `js/studio-bridge/test/protocol.test.ts`. The two
+      // implementations share no schema — only this — and an app on either of
+      // them talks to a Studio that was never told which it is.
+      expect(
+        const ConnectRefusedMessage().encode(),
+        '{"dartwayStudioBridge":4,"type":"connectRefused","payload":{}}',
+      );
+    },
+  );
 
   test('an old build that never heard of connectRefused just drops it', () {
     // The reason the protocol version stayed at 4: an unknown *type* falls

--- a/packages/dartway_studio_bridge/test/studio_bridge_token_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_bridge_token_test.dart
@@ -242,11 +242,13 @@ void main() {
       expect(await validator(validToken), isFalse);
     });
 
-    test('a build with no origin named accepts any connection (local dev)',
-        () async {
-      final validator = studioSignedAccessValidator('');
-      expect(await validator(''), isTrue);
-      expect(await validator('anything at all'), isTrue);
-    });
+    test(
+      'a build with no origin named accepts any connection (local dev)',
+      () async {
+        final validator = studioSignedAccessValidator('');
+        expect(await validator(''), isTrue);
+        expect(await validator('anything at all'), isTrue);
+      },
+    );
   });
 }

--- a/packages/dartway_studio_bridge/test/studio_handshake_probe_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_handshake_probe_test.dart
@@ -90,8 +90,10 @@ void main() {
       final silentApp = _FakeApp();
       StudioHandshakeResult? result;
       unawaited(
-        runStudioHandshake(silentApp, timeout: const Duration(seconds: 10))
-            .then((value) => result = value),
+        runStudioHandshake(
+          silentApp,
+          timeout: const Duration(seconds: 10),
+        ).then((value) => result = value),
       );
 
       async.elapse(const Duration(seconds: 9));

--- a/packages/dartway_studio_bridge/test/studio_manifest_index_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_manifest_index_test.dart
@@ -2,12 +2,7 @@ import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 StudioScreenSpec _screen(String path, String? parent, String title) =>
-    StudioScreenSpec(
-      path: path,
-      parentPath: parent,
-      title: title,
-      purpose: '',
-    );
+    StudioScreenSpec(path: path, parentPath: parent, title: title, purpose: '');
 
 void main() {
   final manifest = StudioProjectManifest(
@@ -20,7 +15,11 @@ void main() {
         screens: [
           _screen('/schedule', null, 'Schedule'),
           _screen('/schedule/profile', '/schedule', 'Profile'),
-          _screen('/schedule/profile/services', '/schedule/profile', 'Services'),
+          _screen(
+            '/schedule/profile/services',
+            '/schedule/profile',
+            'Services',
+          ),
           _screen('/member/:memberId', '/schedule', 'Member'),
           _screen('/schedule/day/:date', '/schedule', 'Day'),
           _screen('/schedule/day/today', '/schedule', 'Today'),
@@ -43,8 +42,10 @@ void main() {
 
     test('deepest non-root prefix for nested location', () {
       // No exact spec for the edit sub-route → deepest declared prefix wins.
-      expect(index.specForPath('/schedule/profile/edit')!.path,
-          '/schedule/profile');
+      expect(
+        index.specForPath('/schedule/profile/edit')!.path,
+        '/schedule/profile',
+      );
     });
 
     test('unknown path with no root spec returns null', () {

--- a/packages/dartway_studio_bridge/test/studio_models_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_models_test.dart
@@ -47,14 +47,15 @@ void main() {
         access: StudioZoneAccess.signedOut,
         screens: [],
       );
-      expect(StudioZoneSpec.fromJson(zone.toJson()).access,
-          StudioZoneAccess.signedOut);
+      expect(
+        StudioZoneSpec.fromJson(zone.toJson()).access,
+        StudioZoneAccess.signedOut,
+      );
       expect(
         StudioZoneSpec.fromJson(const {'rootPath': '/x'}).access,
         StudioZoneAccess.any,
       );
     });
-
   });
 
   group('StudioSessionState', () {
@@ -114,7 +115,9 @@ void main() {
     });
 
     test('features and supportedLocales default to empty', () {
-      final decoded = StudioProjectManifest.fromJson(const {'projectName': 'x'});
+      final decoded = StudioProjectManifest.fromJson(const {
+        'projectName': 'x',
+      });
       expect(decoded.features, isEmpty);
       expect(decoded.supportedLocales, isEmpty);
     });

--- a/packages/dartway_telegram/test/dw_telegram_test.dart
+++ b/packages/dartway_telegram/test/dw_telegram_test.dart
@@ -10,17 +10,17 @@ void main() {
   final pluggedIn = DwTelegramWebApp.create(
     config: const DwTelegramWebAppConfig(requestFullScreen: true),
   );
-  final dwInstance = DwFlutter(
-    config: const DwConfig(),
-    plugins: [pluggedIn],
-  );
+  final dwInstance = DwFlutter(config: const DwConfig(), plugins: [pluggedIn]);
 
   group('DwTelegramPlatform.fromRaw', () {
     test('maps the clients Telegram reports today', () {
       expect(DwTelegramPlatform.fromRaw('ios'), DwTelegramPlatform.ios);
       expect(DwTelegramPlatform.fromRaw('android'), DwTelegramPlatform.android);
       expect(DwTelegramPlatform.fromRaw('macos'), DwTelegramPlatform.macos);
-      expect(DwTelegramPlatform.fromRaw('tdesktop'), DwTelegramPlatform.desktop);
+      expect(
+        DwTelegramPlatform.fromRaw('tdesktop'),
+        DwTelegramPlatform.desktop,
+      );
       expect(DwTelegramPlatform.fromRaw('weba'), DwTelegramPlatform.web);
     });
 

--- a/template/dartway_starter_client/lib/src/protocol/client.dart
+++ b/template/dartway_starter_client/lib/src/protocol/client.dart
@@ -33,12 +33,7 @@ class Client extends _i2.ServerpodClientShared {
     super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
-    Function(
-      _i2.MethodCallContext,
-      Object,
-      StackTrace,
-    )?
-    onFailedCall,
+    Function(_i2.MethodCallContext, Object, StackTrace)? onFailedCall,
     Function(_i2.MethodCallContext)? onSucceededCall,
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(

--- a/template/dartway_starter_client/lib/src/protocol/protocol.dart
+++ b/template/dartway_starter_client/lib/src/protocol/protocol.dart
@@ -37,10 +37,7 @@ class Protocol extends _i1.SerializationManager {
   }
 
   @override
-  T deserialize<T>(
-    dynamic data, [
-    Type? t,
-  ]) {
+  T deserialize<T>(dynamic data, [Type? t]) {
     t ??= T;
 
     final dataClassName = getClassNameFromObjectJson(data);

--- a/template/dartway_starter_client/lib/src/protocol/settings/app_setting.dart
+++ b/template/dartway_starter_client/lib/src/protocol/settings/app_setting.dart
@@ -13,11 +13,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 abstract class AppSetting implements _i1.SerializableModel {
-  AppSetting._({
-    this.id,
-    required this.settingKey,
-    required this.settingValue,
-  });
+  AppSetting._({this.id, required this.settingKey, required this.settingValue});
 
   factory AppSetting({
     int? id,
@@ -45,11 +41,7 @@ abstract class AppSetting implements _i1.SerializableModel {
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  AppSetting copyWith({
-    int? id,
-    String? settingKey,
-    String? settingValue,
-  });
+  AppSetting copyWith({int? id, String? settingKey, String? settingValue});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -73,11 +65,7 @@ class _AppSettingImpl extends AppSetting {
     int? id,
     required String settingKey,
     required String settingValue,
-  }) : super._(
-         id: id,
-         settingKey: settingKey,
-         settingValue: settingValue,
-       );
+  }) : super._(id: id, settingKey: settingKey, settingValue: settingValue);
 
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.

--- a/template/dartway_starter_flutter/lib/core/studio/studio_bridge_binding.dart
+++ b/template/dartway_starter_flutter/lib/core/studio/studio_bridge_binding.dart
@@ -13,17 +13,18 @@ import 'logic/studio_session_state_provider.dart';
 /// features are discovered from mounted [DwFeature] widgets and mapped onto
 /// the bridge wire model.
 StudioFeatureInfo _toWireModel(DwFeatureSpec feature) => StudioFeatureInfo(
-      id: feature.id,
-      title: feature.title,
-      purpose: feature.purpose,
-      behaviors: feature.behaviors,
-      requirements: feature.requirements,
-      implementationNotes: feature.implementationNotes,
-      knownIssues: feature.knownIssues,
-    );
+  id: feature.id,
+  title: feature.title,
+  purpose: feature.purpose,
+  behaviors: feature.behaviors,
+  requirements: feature.requirements,
+  implementationNotes: feature.implementationNotes,
+  knownIssues: feature.knownIssues,
+);
 
-List<StudioFeatureInfo> _mountedFeatureInfos() =>
-    [for (final feature in DwFeature.scanMounted()) _toWireModel(feature)];
+List<StudioFeatureInfo> _mountedFeatureInfos() => [
+  for (final feature in DwFeature.scanMounted()) _toWireModel(feature),
+];
 
 /// Answers Studio's "pencil" tap-to-inspect flow: the point arrives as
 /// fractions of this app's own logical viewport, converted here (not by

--- a/template/dartway_starter_server/lib/server.dart
+++ b/template/dartway_starter_server/lib/server.dart
@@ -1,10 +1,7 @@
 import 'dart:io';
 
 import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart'
-    show
-        DwOrphanedAuthKeyCleanup,
-        DwRecurringJobs,
-        dwAuthenticationHandler;
+    show DwOrphanedAuthKeyCleanup, DwRecurringJobs, dwAuthenticationHandler;
 import 'package:dartway_starter_server/src/web/routes/root.dart';
 import 'package:serverpod/serverpod.dart';
 

--- a/template/dartway_starter_server/lib/src/crud/app_setting_crud_config.dart
+++ b/template/dartway_starter_server/lib/src/crud/app_setting_crud_config.dart
@@ -6,15 +6,13 @@ import 'package:dartway_starter_server/src/generated/protocol.dart';
 /// Everyone reads settings; only the admin writes, nobody deletes.
 final appSettingCrudConfig = DwCrudConfig<AppSetting>(
   table: AppSetting.t,
-  getListConfig: DwGetModelListConfig(
-    accessFilter: (session) async => null,
-  ),
+  getListConfig: DwGetModelListConfig(accessFilter: (session) async => null),
   saveConfig: DwSaveConfig<AppSetting>(
     allowSave: (session, saveContext) async => session.isAdmin,
     validateSave: (session, saveContext) async =>
         saveContext.currentModel.settingKey.trim().isEmpty
-            ? 'Setting key is required'
-            : null,
+        ? 'Setting key is required'
+        : null,
     // Settings are the same for everyone, so a change belongs on every screen at
     // once: the admin renames the app and the home screen updates for every
     // signed-in user, with no refresh and no listener written anywhere. The app

--- a/template/dartway_starter_server/lib/src/crud/user_profile_crud_config.dart
+++ b/template/dartway_starter_server/lib/src/crud/user_profile_crud_config.dart
@@ -7,9 +7,7 @@ final userProfileCrudConfig = DwCrudConfig<UserProfile>(
   table: UserProfile.t,
   // Only the admin lists all profiles (the admin users table). Everyone else
   // sees nothing here — secure-by-default via adminOnlyAccessFilter.
-  getListConfig: DwGetModelListConfig(
-    accessFilter: adminOnlyAccessFilter,
-  ),
+  getListConfig: DwGetModelListConfig(accessFilter: adminOnlyAccessFilter),
   saveConfig: DwSaveConfig<UserProfile>(
     // A signed-in user saves only their own profile; the admin saves anyone's.
     allowSave: (session, saveContext) async =>

--- a/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
+++ b/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
@@ -36,10 +36,7 @@ void initDartwayCore({
     // reachable at all — access is granted, never forgotten away.
     // Your domain models go below; see `example/` in the DartWay monorepo for a
     // full application built this way.
-    crudConfigurations: [
-      userProfileCrudConfig,
-      appSettingCrudConfig,
-    ],
+    crudConfigurations: [userProfileCrudConfig, appSettingCrudConfig],
     dtoConfigurations: [],
     // One entry per realtime channel the app names itself. A channel that is
     // not declared here cannot be subscribed to — a channel name arrives from
@@ -72,29 +69,28 @@ void initDartwayCore({
       // (UserProfile.testVerificationCode, serverOnly — never sent to clients);
       // everyone else gets a fresh random code. Works in any run mode, so store
       // reviewers can sign in, while real users are never handed a fixed code.
-      generateVerificationCodeMethod: (
-        session, {
-        required DwAuthRequest verificationRequest,
-      }) async {
-        final profile = await UserProfile.db.findFirstRow(
-          session,
-          where: (t) =>
-              t.userIdentifier.equals(verificationRequest.userIdentifier),
-        );
-        return profile?.testVerificationCode ?? _randomVerificationCode();
-      },
+      generateVerificationCodeMethod:
+          (session, {required DwAuthRequest verificationRequest}) async {
+            final profile = await UserProfile.db.findFirstRow(
+              session,
+              where: (t) =>
+                  t.userIdentifier.equals(verificationRequest.userIdentifier),
+            );
+            return profile?.testVerificationCode ?? _randomVerificationCode();
+          },
       // Dev: log the code to the server console instead of sending an SMS.
       // Wire a real SMS/email sender here for production.
-      sendVerificationCodeMethod: (
-        session, {
-        required DwAuthRequest verificationRequest,
-        required String verificationCode,
-      }) async {
-        session.log(
-          'Verification code for ${verificationRequest.userIdentifier}: '
-          '$verificationCode',
-        );
-      },
+      sendVerificationCodeMethod:
+          (
+            session, {
+            required DwAuthRequest verificationRequest,
+            required String verificationCode,
+          }) async {
+            session.log(
+              'Verification code for ${verificationRequest.userIdentifier}: '
+              '$verificationCode',
+            );
+          },
     ),
   );
 }

--- a/template/dartway_starter_server/lib/src/generated/protocol.dart
+++ b/template/dartway_starter_server/lib/src/generated/protocol.dart
@@ -192,10 +192,7 @@ class Protocol extends _i1.SerializationManagerServer {
   }
 
   @override
-  T deserialize<T>(
-    dynamic data, [
-    Type? t,
-  ]) {
+  T deserialize<T>(dynamic data, [Type? t]) {
     t ??= T;
 
     final dataClassName = getClassNameFromObjectJson(data);

--- a/template/dartway_starter_server/lib/src/generated/settings/app_setting.dart
+++ b/template/dartway_starter_server/lib/src/generated/settings/app_setting.dart
@@ -14,11 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class AppSetting
     implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
-  AppSetting._({
-    this.id,
-    required this.settingKey,
-    required this.settingValue,
-  });
+  AppSetting._({this.id, required this.settingKey, required this.settingValue});
 
   factory AppSetting({
     int? id,
@@ -51,11 +47,7 @@ abstract class AppSetting
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.
   @_i1.useResult
-  AppSetting copyWith({
-    int? id,
-    String? settingKey,
-    String? settingValue,
-  });
+  AppSetting copyWith({int? id, String? settingKey, String? settingValue});
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -113,11 +105,7 @@ class _AppSettingImpl extends AppSetting {
     int? id,
     required String settingKey,
     required String settingValue,
-  }) : super._(
-         id: id,
-         settingKey: settingKey,
-         settingValue: settingValue,
-       );
+  }) : super._(id: id, settingKey: settingKey, settingValue: settingValue);
 
   /// Returns a shallow copy of this [AppSetting]
   /// with some or all fields replaced by the given arguments.
@@ -139,28 +127,18 @@ class _AppSettingImpl extends AppSetting {
 class AppSettingUpdateTable extends _i1.UpdateTable<AppSettingTable> {
   AppSettingUpdateTable(super.table);
 
-  _i1.ColumnValue<String, String> settingKey(String value) => _i1.ColumnValue(
-    table.settingKey,
-    value,
-  );
+  _i1.ColumnValue<String, String> settingKey(String value) =>
+      _i1.ColumnValue(table.settingKey, value);
 
-  _i1.ColumnValue<String, String> settingValue(String value) => _i1.ColumnValue(
-    table.settingValue,
-    value,
-  );
+  _i1.ColumnValue<String, String> settingValue(String value) =>
+      _i1.ColumnValue(table.settingValue, value);
 }
 
 class AppSettingTable extends _i1.Table<int?> {
   AppSettingTable({super.tableRelation}) : super(tableName: 'app_setting') {
     updateTable = AppSettingUpdateTable(this);
-    settingKey = _i1.ColumnString(
-      'settingKey',
-      this,
-    );
-    settingValue = _i1.ColumnString(
-      'settingValue',
-      this,
-    );
+    settingKey = _i1.ColumnString('settingKey', this);
+    settingValue = _i1.ColumnString('settingValue', this);
   }
 
   late final AppSettingUpdateTable updateTable;
@@ -170,11 +148,7 @@ class AppSettingTable extends _i1.Table<int?> {
   late final _i1.ColumnString settingValue;
 
   @override
-  List<_i1.Column> get columns => [
-    id,
-    settingKey,
-    settingValue,
-  ];
+  List<_i1.Column> get columns => [id, settingKey, settingValue];
 }
 
 class AppSettingInclude extends _i1.IncludeObject {
@@ -344,10 +318,7 @@ class AppSettingRepository {
     AppSetting row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<AppSetting>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<AppSetting>(row, transaction: transaction);
   }
 
   /// Updates all [AppSetting]s in the list and returns the updated rows. If
@@ -432,10 +403,7 @@ class AppSettingRepository {
     List<AppSetting> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<AppSetting>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<AppSetting>(rows, transaction: transaction);
   }
 
   /// Deletes a single [AppSetting].
@@ -444,10 +412,7 @@ class AppSettingRepository {
     AppSetting row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<AppSetting>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<AppSetting>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/template/dartway_starter_server/lib/src/generated/user_profile/user_profile.dart
+++ b/template/dartway_starter_server/lib/src/generated/user_profile/user_profile.dart
@@ -251,109 +251,58 @@ class UserProfileUpdateTable extends _i1.UpdateTable<UserProfileTable> {
   UserProfileUpdateTable(super.table);
 
   _i1.ColumnValue<String, String> userIdentifier(String value) =>
-      _i1.ColumnValue(
-        table.userIdentifier,
-        value,
-      );
+      _i1.ColumnValue(table.userIdentifier, value);
 
-  _i1.ColumnValue<String, String> phone(String value) => _i1.ColumnValue(
-    table.phone,
-    value,
-  );
+  _i1.ColumnValue<String, String> phone(String value) =>
+      _i1.ColumnValue(table.phone, value);
 
   _i1.ColumnValue<bool, bool> agreedForMarketingCommunications(bool value) =>
-      _i1.ColumnValue(
-        table.agreedForMarketingCommunications,
-        value,
-      );
+      _i1.ColumnValue(table.agreedForMarketingCommunications, value);
 
   _i1.ColumnValue<DateTime, DateTime> conditionsAcceptedAt(DateTime value) =>
-      _i1.ColumnValue(
-        table.conditionsAcceptedAt,
-        value,
-      );
+      _i1.ColumnValue(table.conditionsAcceptedAt, value);
 
-  _i1.ColumnValue<String, String> firstName(String value) => _i1.ColumnValue(
-    table.firstName,
-    value,
-  );
+  _i1.ColumnValue<String, String> firstName(String value) =>
+      _i1.ColumnValue(table.firstName, value);
 
-  _i1.ColumnValue<String, String> lastName(String? value) => _i1.ColumnValue(
-    table.lastName,
-    value,
-  );
+  _i1.ColumnValue<String, String> lastName(String? value) =>
+      _i1.ColumnValue(table.lastName, value);
 
-  _i1.ColumnValue<String, String> imageUrl(String? value) => _i1.ColumnValue(
-    table.imageUrl,
-    value,
-  );
+  _i1.ColumnValue<String, String> imageUrl(String? value) =>
+      _i1.ColumnValue(table.imageUrl, value);
 
   _i1.ColumnValue<_i3.UserGender, _i3.UserGender> gender(
     _i3.UserGender? value,
-  ) => _i1.ColumnValue(
-    table.gender,
-    value,
-  );
+  ) => _i1.ColumnValue(table.gender, value);
 
   _i1.ColumnValue<_i2.UserRole, _i2.UserRole> role(_i2.UserRole value) =>
-      _i1.ColumnValue(
-        table.role,
-        value,
-      );
+      _i1.ColumnValue(table.role, value);
 
   _i1.ColumnValue<String, String> testVerificationCode(String? value) =>
-      _i1.ColumnValue(
-        table.testVerificationCode,
-        value,
-      );
+      _i1.ColumnValue(table.testVerificationCode, value);
 }
 
 class UserProfileTable extends _i1.Table<int?> {
   UserProfileTable({super.tableRelation}) : super(tableName: 'user_profile') {
     updateTable = UserProfileUpdateTable(this);
-    userIdentifier = _i1.ColumnString(
-      'userIdentifier',
-      this,
-    );
-    phone = _i1.ColumnString(
-      'phone',
-      this,
-    );
+    userIdentifier = _i1.ColumnString('userIdentifier', this);
+    phone = _i1.ColumnString('phone', this);
     agreedForMarketingCommunications = _i1.ColumnBool(
       'agreedForMarketingCommunications',
       this,
     );
-    conditionsAcceptedAt = _i1.ColumnDateTime(
-      'conditionsAcceptedAt',
-      this,
-    );
-    firstName = _i1.ColumnString(
-      'firstName',
-      this,
-    );
-    lastName = _i1.ColumnString(
-      'lastName',
-      this,
-    );
-    imageUrl = _i1.ColumnString(
-      'imageUrl',
-      this,
-    );
-    gender = _i1.ColumnEnum(
-      'gender',
-      this,
-      _i1.EnumSerialization.byName,
-    );
+    conditionsAcceptedAt = _i1.ColumnDateTime('conditionsAcceptedAt', this);
+    firstName = _i1.ColumnString('firstName', this);
+    lastName = _i1.ColumnString('lastName', this);
+    imageUrl = _i1.ColumnString('imageUrl', this);
+    gender = _i1.ColumnEnum('gender', this, _i1.EnumSerialization.byName);
     role = _i1.ColumnEnum(
       'role',
       this,
       _i1.EnumSerialization.byName,
       hasDefault: true,
     );
-    testVerificationCode = _i1.ColumnString(
-      'testVerificationCode',
-      this,
-    );
+    testVerificationCode = _i1.ColumnString('testVerificationCode', this);
   }
 
   late final UserProfileUpdateTable updateTable;
@@ -561,10 +510,7 @@ class UserProfileRepository {
     UserProfile row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.insertRow<UserProfile>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.insertRow<UserProfile>(row, transaction: transaction);
   }
 
   /// Updates all [UserProfile]s in the list and returns the updated rows. If
@@ -649,10 +595,7 @@ class UserProfileRepository {
     List<UserProfile> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.delete<UserProfile>(
-      rows,
-      transaction: transaction,
-    );
+    return session.db.delete<UserProfile>(rows, transaction: transaction);
   }
 
   /// Deletes a single [UserProfile].
@@ -661,10 +604,7 @@ class UserProfileRepository {
     UserProfile row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.db.deleteRow<UserProfile>(
-      row,
-      transaction: transaction,
-    );
+    return session.db.deleteRow<UserProfile>(row, transaction: transaction);
   }
 
   /// Deletes all rows matching the [where] expression.

--- a/template/dartway_starter_server/test/integration/auth_limits_test.dart
+++ b/template/dartway_starter_server/test/integration/auth_limits_test.dart
@@ -72,9 +72,10 @@ void main() {
             verification.failReason,
             DwAuthFailReason.invalidVerificationCode,
           );
-          expect(await _statusOf(session, request), isNot(
-            DwAuthRequestStatus.failed,
-          ));
+          expect(
+            await _statusOf(session, request),
+            isNot(DwAuthRequestStatus.failed),
+          );
         });
 
         test(
@@ -87,7 +88,10 @@ void main() {
               await _verify(session, request, _wrongCode);
             }
 
-            expect(await _statusOf(session, request), DwAuthRequestStatus.failed);
+            expect(
+              await _statusOf(session, request),
+              DwAuthRequestStatus.failed,
+            );
 
             final afterBurn = await _verify(session, request, _knownCode);
             expect(afterBurn.failReason, DwAuthFailReason.tooManyAttempts);
@@ -95,40 +99,41 @@ void main() {
           },
         );
 
-        test(
-          'parallel guesses cannot outrun the attempt limit',
-          () async {
-            final request = await _openLoginRequest(session);
+        test('parallel guesses cannot outrun the attempt limit', () async {
+          final request = await _openLoginRequest(session);
 
-            // The regression this guards: the limit used to be a read-then-write
-            // decision (count previous attempts, compare, proceed). Fired in
-            // parallel under READ COMMITTED, every attempt read "0 previous" and
-            // every attempt got to guess — the brute-force protection came off
-            // with a bit of concurrency. Twenty guesses at once must still buy
-            // no more than the configured five.
-            //
-            // What matters is how many actually got to *check the code*: an
-            // attempt that could not take the lock is refused outright
-            // (rateLimited) and learns nothing.
-            final verifications = await Future.wait([
-              for (var i = 0; i < 20; i++) _verify(session, request, _wrongCode),
-            ]);
+          // The regression this guards: the limit used to be a read-then-write
+          // decision (count previous attempts, compare, proceed). Fired in
+          // parallel under READ COMMITTED, every attempt read "0 previous" and
+          // every attempt got to guess — the brute-force protection came off
+          // with a bit of concurrency. Twenty guesses at once must still buy
+          // no more than the configured five.
+          //
+          // What matters is how many actually got to *check the code*: an
+          // attempt that could not take the lock is refused outright
+          // (rateLimited) and learns nothing.
+          final verifications = await Future.wait([
+            for (var i = 0; i < 20; i++) _verify(session, request, _wrongCode),
+          ]);
 
-            final guessesEvaluated = verifications
-                .where(
-                  (v) => v.failReason == DwAuthFailReason.invalidVerificationCode,
-                )
-                .length;
+          final guessesEvaluated = verifications
+              .where(
+                (v) => v.failReason == DwAuthFailReason.invalidVerificationCode,
+              )
+              .length;
 
-            expect(guessesEvaluated, lessThanOrEqualTo(_maxVerificationAttempts));
-          },
-        );
+          expect(guessesEvaluated, lessThanOrEqualTo(_maxVerificationAttempts));
+        });
       });
 
       group('access token', () {
         test('is single use', () async {
           final request = await _openLoginRequest(session);
-          final token = (await _verify(session, request, _knownCode)).accessToken!;
+          final token = (await _verify(
+            session,
+            request,
+            _knownCode,
+          )).accessToken!;
 
           final first = await _redeem(session, token);
           expect(first.status, DwAuthRequestStatus.verified);
@@ -138,28 +143,28 @@ void main() {
           expect(second.failReason, DwAuthFailReason.invalidAccessToken);
         });
 
-        test(
-          'two parallel redemptions sign in exactly once',
-          () async {
-            final request = await _openLoginRequest(session);
-            final token =
-                (await _verify(session, request, _knownCode)).accessToken!;
+        test('two parallel redemptions sign in exactly once', () async {
+          final request = await _openLoginRequest(session);
+          final token = (await _verify(
+            session,
+            request,
+            _knownCode,
+          )).accessToken!;
 
-            // Same regression, sharper stakes: both redemptions used to read
-            // `verified` and both were signed in, so a "single-use" token handed
-            // out two sessions.
-            final results = await Future.wait([
-              _redeem(session, token),
-              _redeem(session, token),
-            ]);
+          // Same regression, sharper stakes: both redemptions used to read
+          // `verified` and both were signed in, so a "single-use" token handed
+          // out two sessions.
+          final results = await Future.wait([
+            _redeem(session, token),
+            _redeem(session, token),
+          ]);
 
-            final signedIn = results
-                .where((r) => r.status == DwAuthRequestStatus.verified)
-                .length;
+          final signedIn = results
+              .where((r) => r.status == DwAuthRequestStatus.verified)
+              .length;
 
-            expect(signedIn, 1);
-          },
-        );
+          expect(signedIn, 1);
+        });
       });
 
       group('request rate limit', () {
@@ -212,10 +217,7 @@ Future<T> _save<T extends TableRow>(Session session, T model) async {
   // default one — the same lookup the CRUD endpoint performs.
   final saveConfig =
       (dw.getCrudConfig(className) ??
-              dw.getCrudConfig(
-                className,
-                api: DwCoreConst.dartwayInternalApi,
-              ))
+              dw.getCrudConfig(className, api: DwCoreConst.dartwayInternalApi))
           ?.saveConfig;
 
   if (saveConfig == null) {
@@ -277,8 +279,14 @@ Future<DwAuthRequestStatus> _statusOf(
 }
 
 Future<void> _wipeAuthTables(Session session) async {
-  await DwAuthVerification.db.deleteWhere(session, where: (t) => Constant.bool(true));
-  await DwAuthRequest.db.deleteWhere(session, where: (t) => Constant.bool(true));
+  await DwAuthVerification.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
+  await DwAuthRequest.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
   await DwAuthKey.db.deleteWhere(session, where: (t) => Constant.bool(true));
   await UserProfile.db.deleteWhere(session, where: (t) => Constant.bool(true));
 }

--- a/template/dartway_starter_server/test/integration/password_hashing_test.dart
+++ b/template/dartway_starter_server/test/integration/password_hashing_test.dart
@@ -65,28 +65,43 @@ void main() {
       tearDown(() async => _wipeTables(session));
 
       test('the old password signs them in', () async {
-        await _seedHash(session, userId, _LegacySha256Verifier.hashOf(_password));
+        await _seedHash(
+          session,
+          userId,
+          _LegacySha256Verifier.hashOf(_password),
+        );
 
         final request = await _signIn(session, _password);
 
         expect(request.status, DwAuthRequestStatus.verified);
       });
 
-      test('signing in rewrites the hash in bcrypt — once, and for good', () async {
-        await _seedHash(session, userId, _LegacySha256Verifier.hashOf(_password));
+      test(
+        'signing in rewrites the hash in bcrypt — once, and for good',
+        () async {
+          await _seedHash(
+            session,
+            userId,
+            _LegacySha256Verifier.hashOf(_password),
+          );
 
-        await _signIn(session, _password);
+          await _signIn(session, _password);
 
-        // The plaintext exists only during a sign-in, so this is the only moment
-        // the hash could be migrated at all.
-        final stored = await _storedHash(session, userId);
-        expect(stored, startsWith(r'$2'), reason: 'the hash should now be bcrypt');
+          // The plaintext exists only during a sign-in, so this is the only moment
+          // the hash could be migrated at all.
+          final stored = await _storedHash(session, userId);
+          expect(
+            stored,
+            startsWith(r'$2'),
+            reason: 'the hash should now be bcrypt',
+          );
 
-        // And the upgraded row is readable by the active hasher: the second
-        // sign-in never touches the legacy path.
-        final again = await _signIn(session, _password);
-        expect(again.status, DwAuthRequestStatus.verified);
-      });
+          // And the upgraded row is readable by the active hasher: the second
+          // sign-in never touches the legacy path.
+          final again = await _signIn(session, _password);
+          expect(again.status, DwAuthRequestStatus.verified);
+        },
+      );
 
       test('a wrong password is rejected and the hash is left alone', () async {
         final legacyHash = _LegacySha256Verifier.hashOf(_password);
@@ -99,30 +114,40 @@ void main() {
         expect(await _storedHash(session, userId), legacyHash);
       });
 
-      test('a hash nobody can read fails the login instead of crashing it', () async {
-        // The format of some third system, never registered as a verifier. Before
-        // the strategies existed this reached BCrypt.checkpw and threw, turning a
-        // failed login into a 500.
-        await _seedHash(session, userId, 'argon2id\$v=19\$m=65536,t=3,p=4\$deadbeef');
+      test(
+        'a hash nobody can read fails the login instead of crashing it',
+        () async {
+          // The format of some third system, never registered as a verifier. Before
+          // the strategies existed this reached BCrypt.checkpw and threw, turning a
+          // failed login into a 500.
+          await _seedHash(
+            session,
+            userId,
+            'argon2id\$v=19\$m=65536,t=3,p=4\$deadbeef',
+          );
 
-        final request = await _signIn(session, _password);
+          final request = await _signIn(session, _password);
 
-        expect(request.status, DwAuthRequestStatus.failed);
-        expect(request.failReason, DwAuthFailReason.invalidPassword);
-      });
+          expect(request.status, DwAuthRequestStatus.failed);
+          expect(request.failReason, DwAuthFailReason.invalidPassword);
+        },
+      );
 
-      test('a bcrypt password still works — the default path is untouched', () async {
-        await dw.auth!.setUserPassword(
-          session,
-          userId: userId,
-          newPassword: _password,
-        );
+      test(
+        'a bcrypt password still works — the default path is untouched',
+        () async {
+          await dw.auth!.setUserPassword(
+            session,
+            userId: userId,
+            newPassword: _password,
+          );
 
-        final request = await _signIn(session, _password);
+          final request = await _signIn(session, _password);
 
-        expect(request.status, DwAuthRequestStatus.verified);
-        expect(await _storedHash(session, userId), startsWith(r'$2'));
-      });
+          expect(request.status, DwAuthRequestStatus.verified);
+          expect(await _storedHash(session, userId), startsWith(r'$2'));
+        },
+      );
     },
     runMode: 'test',
     applyMigrations: true,
@@ -138,11 +163,7 @@ void main() {
 
 /// Seeds a hash the way a migration does: import what you cannot reverse.
 Future<void> _seedHash(Session session, int userId, String hash) =>
-    dw.auth!.setUserPassword(
-      session,
-      userId: userId,
-      newPasswordHash: hash,
-    );
+    dw.auth!.setUserPassword(session, userId: userId, newPasswordHash: hash);
 
 Future<String> _storedHash(Session session, int userId) async {
   final row = await DwUserPassword.db.findFirstRow(
@@ -174,10 +195,7 @@ Future<T> _save<T extends TableRow>(Session session, T model) async {
 
   final saveConfig =
       (dw.getCrudConfig(className) ??
-              dw.getCrudConfig(
-                className,
-                api: DwCoreConst.dartwayInternalApi,
-              ))
+              dw.getCrudConfig(className, api: DwCoreConst.dartwayInternalApi))
           ?.saveConfig;
 
   if (saveConfig == null) {
@@ -194,7 +212,10 @@ Future<T> _save<T extends TableRow>(Session session, T model) async {
 }
 
 Future<void> _wipeTables(Session session) async {
-  await DwUserPassword.db.deleteWhere(session, where: (t) => Constant.bool(true));
+  await DwUserPassword.db.deleteWhere(
+    session,
+    where: (t) => Constant.bool(true),
+  );
   await DwAuthKey.db.deleteWhere(session, where: (t) => Constant.bool(true));
   await UserProfile.db.deleteWhere(session, where: (t) => Constant.bool(true));
 }


### PR DESCRIPTION
## What this is

`dart format` over `packages/`, `example/` and `template/`. **Formatting only** — no line moved for any other reason.

## Why it is 151 files

Dart 3.7 changed the default formatter to the tall style, and this repository was never carried across. It has been living in two styles since:

| | Files |
|---|---|
| Already tall style | 430 |
| Still the old short style | **151** |

The split follows nothing meaningful — just whether a given file happened to be touched by somebody running a recent SDK. A typical hunk:

```diff
   Map<String, dynamic> toJson() => {
-        'label': label,
-        'rootPath': rootPath,
-      };
+    'label': label,
+    'rootPath': rootPath,
+  };
```

## Why nothing caught it

`dart analyze` has no opinion on layout. The one format check that exists — `generatedCodeUnformatted` in `dartway check` — judges *generated* code inside an *application* project, not the framework's own packages. There is no CI step running `dart format` either.

So the state stayed invisible until somebody ran the formatter, at which point it surfaced as unrelated files in whatever pull request they were writing. That happened during #64: a change touching three files reformatted six more it had never opened, and they had to be reverted by hand to keep the diff readable. The next person would have paid the same tax.

## Verified rather than assumed

- **The `manualDeserialization` patch survives.** Formatting rewrote the core client's generated `protocol.dart`, which is where the repository's known mine lives, so this was checked first: the block is still inside `Protocol.deserialize`, alias `_i21` intact.
- **`dart analyze` across the workspace** reports the same three issues as before — one dead-code warning in generated transport code, two Serverpod deprecation notices. No errors, nothing new.
- **Tests:** `dartway_cli` 98 passing, `dartway_serverpod_core_shared` 9 passing.
- **Idempotent:** `dart format --output=none --set-exit-if-changed` over all three trees now exits clean.

## One thing this commit does not fix

`dartway_studio_bridge` and `dartway_telegram` **cannot run their tests on Dart 3.12** — the VM's FFI transformer crashes while compiling them (`type 'InvalidType' is not a subtype of type 'FunctionType'`). This is not caused here: confirmed identical on the parent commit with these changes stashed. Left alone deliberately, but worth its own look — a suite that cannot load is not guarding anything, and two of them failing silently is how a regression gets in.

## Timing

Only one unmerged branch is live in a worktree (`docs/toolkit-rules-from-issues-zone`), and it touches markdown in `toolkit/` exclusively — zero Dart files. So this conflicts with nothing in flight, but it is worth merging promptly rather than letting new Dart work pile up against it.

## What would stop it recurring

Nothing in this PR. A CI step running `dart format --output=none --set-exit-if-changed` against a **pinned** SDK would — the pin is what answers the objection recorded in `generatedCodeUnformatted`'s own documentation, that a red result can mean "your SDK is newer" rather than "you skipped a step". This repository has no CI running Dart at all today, so that is a separate decision rather than a line to slip in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)