### PR TITLE
docs(toolkit): a feature asks for its own data, and the graph arrives with the model

### DIFF
--- a/toolkit/skills/dartway-clean-code/SKILL.md
+++ b/toolkit/skills/dartway-clean-code/SKILL.md
@@ -7,7 +7,11 @@ description: >-
   responsibility, not by line count), never pass BuildContext or WidgetRef as params, no _buildXxx()
   widget-returning methods, no ref.invalidate, no GlobalKey tree lookups, no
   outer padding/margin inside a widget, no private widget classes in public
-  feature files, a Serverpod model rebuilt with copyWith and never by listing
+  feature files (and the one allowed kind has no State and no callbacks),
+  a feature's constructor is its address (a model or an id) and not data its parent
+  computed, the action written in the widget that owns the button and never handed
+  down as a callback (no screen-wide busy flag),
+  a Serverpod model rebuilt with copyWith and never by listing
   its fields, no default for a setting whose value belongs to the environment
   (sender address, provider key, admin identifier);
   plus SOLID, KISS, DRY, YAGNI, Law of Demeter, composition over
@@ -346,7 +350,25 @@ then the size is declared in the kit and visible from the constructor name, not 
 // ✅ message_bubble.dart -> class MessageBubble; date_separator.dart -> class DateSeparator
 ```
 
-**Exception — a trivial presentational helper used once in the very same file** (e.g. `_CounterTile` inside `admin_counters.dart`): it has no value for reuse or a separate test, moving it into a public file is pure noise. Such a private class is allowed. The criterion: a feature entity you'll want to reuse/test → a public file; a local layout detail of a single screen → may stay private next to it.
+**Exception — a slice of layout extracted so `build` stops growing**, used once in the very same
+file (e.g. `_CounterTile` inside `admin_counters.dart`). It has no value for reuse or a separate
+test, and moving it into a public file is pure noise.
+
+**The exception is bounded by two facts about the class, not by how trivial it looks.** "Trivial" is
+judged by whoever has just written the thing, and it stretches: a 95-line class with its own `State`,
+its own `TextEditingController` and its own rule about what may not be submitted has been let
+through under this exception in a live project. It was unreachable from a test and unreachable from
+the widget next door that needed the same behaviour. So:
+
+- **a private widget class has no `State`.** State is behaviour, behaviour gets tested, and what
+  gets tested has a name and a file. `_Foo extends StatefulWidget` inside a feature file is the rule
+  being broken, whatever its length;
+- **a private widget class takes no callbacks.** A callback parameter means something is being
+  threaded through it from the parent — so it is not a detail of this file's layout, it is a piece
+  of the feature that was left unnamed (see §1.9b: the widget that owns the button owns the action).
+
+What is left over is a `StatelessWidget` with no callbacks, which is honestly trivial and can be
+recognised as such without taste.
 
 ## 1.9 Don't create a pass-through widget: if it decides nothing, inline the kit widget
 
@@ -374,6 +396,96 @@ class CourseLockedStubCard extends StatelessWidget {
 The sign that gives a pass-through away at the door: its only import is `ui_kit.dart` — it knows nothing about the domain, so it has nothing to decide.
 
 **If such a widget really is needed by many** (the same wrapper in five places) — that is no reason to breed a pass-through in the feature, it is a reason to add a **constructor in the kit** (`ChatCardContainer.bottomSheetSurface`): the meaning moves to where the look lives.
+
+## 1.9a A feature's constructor is its address, not its data
+
+**Why:** nothing in this contract says what a widget may accept, and that gap is wide enough to
+drive a React app through it. A feature taking fifteen parameters — four ready-made lists, a couple
+of maps and six callbacks — passes naming, passes file length (the file was 182 lines), passes
+`_buildXxx`, passes every rule above. And it can only ever be placed inside the one parent that
+knows how to assemble its arguments.
+
+**A feature is handed what names its subject** — a model, or an identifier of one. Everything else
+it asks for itself: the same `dw.repo` provider its parent watched (§3 of `dartway-data-layer` —
+identical configs are one request, so asking again costs nothing), an extension on the model it was
+already given, its own local state.
+
+**The question is not "how many parameters" but "could this widget have got it itself?"**
+
+| In the signature | Could it? | Verdict |
+|---|---|---|
+| A list the parent computed off a model the child also receives | yes — an extension on that model | remove |
+| A `Map<int, List<Something>>` assembled at the top of the screen and passed down four levels | yes — each level asks for its own | remove |
+| A flag derived from a model already passed (`hasOpenWork`, `isEditable`) | yes — a getter on the model | remove |
+| The model itself, its parent, an id | no | keep |
+| One callback for a decision only the parent can make (§1.9b) | no | keep |
+
+**The count is a symptom, not the rule.** Three parameters of which two are derived from the first
+are worse than five independent ones — the two derived ones are a claim that the child cannot be
+trusted to read its own subject.
+
+```dart
+// ❌ fifteen parameters: four lists, a type, a project, a busy flag, seven callbacks —
+//    placeable nowhere except inside the parent that assembles them
+TicketWorkCard(
+  task: task, questions: questions, corrections: corrections,
+  ticketType: ticket.ticketType, project: project, taskRuns: runs,
+  actions: availableActions, working: busy,
+  onRun: ..., onAccept: ..., onRework: ..., onCancel: ...,
+  onAnswer: ..., onDismiss: ..., onRetry: ...,
+);
+
+// ✅ three: everything else follows from the ticket, which arrived as one graph
+TicketWorkCard(ticket: ticket, task: task, project: project);
+```
+
+## 1.9b The action lives where the button is
+
+**Why:** `dw.action` is described as the thing you write an action *with*, and nowhere as *where* it
+lives — so handing a callback downwards is nobody's violation. In a live feature the cancelling of
+one question travelled from the button to `dw.repo.saveModel` through **six** hand-offs, and every
+one of them was a parameter on a widget that otherwise had no reason to know about saving.
+
+**A widget with a button does the thing the button promises.** `dw.action` wraps the call right
+there, in the widget the user pressed:
+
+```dart
+// ❌ the button is here, the write is five levels up: every widget in between
+//    carries onSubmit/onDismiss it does nothing with
+class TicketAnswerField extends StatelessWidget {
+  const TicketAnswerField({
+    required this.question,
+    required this.onSubmit,
+    required this.onDismiss,
+    super.key,
+  });
+}
+
+// ✅ the widget saves what it collected — nobody above it has to know it exists
+class TicketAnswerField extends ConsumerWidget {
+  const TicketAnswerField({required this.question, super.key});
+  // in build: DwActionBuilder(
+  //   action: dw.action((_) => question.answerWith(controller.text)),
+  //   builder: (context, onPressed, busy) => ...,   // busy is this button's own
+  // )
+}
+```
+
+**A callback is legitimate when the parent decides something the child cannot know** — where to go
+after success, whether the dialog closes, which route to leave on. There is normally **one** such
+callback on a feature, not six:
+
+```dart
+/// The one callback that arrives from above, and it earns its place: moving the
+/// stage carries the ticket into another column, so the card has to close —
+/// and only the card knows it is a card.
+final VoidCallback onMoved;
+```
+
+**There is no screen-wide `busy` flag.** `DwActionBuilder` computes busy for each button separately,
+under that button. A flag held at the top does not merely duplicate it — it lies: in a live app,
+pressing "accept" on one row greyed out "run" on every other row on the screen. If you find yourself
+adding `working: busy` to a constructor, the action is in the wrong place.
 
 ## 1.10 A Serverpod model is rebuilt with `copyWith` only
 
@@ -719,6 +831,8 @@ class ItemsListPage extends ConsumerWidget {
 - [ ] **No functions outside classes** — factory/method/extension; the only exceptions are `@riverpod` entry points and `main()` (§1.3a).
 - [ ] **No widget in a variable used once** (§1.4a) and **no commented-out code** (§1.4b).
 - [ ] **No pass-through widgets** — a class that only forwards its own parameters into a kit widget and knows nothing about the domain (`ui_kit.dart` its only import) is not created: inline the kit widget, and turn a repeating wrapper into a kit constructor (§1.9).
+- [ ] **A feature's constructor is its address** — a model or an id, not lists/maps/flags its parent computed for it. For every parameter: could the widget have got this itself? (§1.9a).
+- [ ] **The action is written in the widget that owns the button** (`dw.action` right there), not handed down as a callback; a callback stays only for a decision the parent alone can make. **No screen-wide `busy`** — `DwActionBuilder` counts it per button (§1.9b).
 - [ ] **No** `BuildContext`/`WidgetRef` in the parameters of services and functions — and **no `extension on BuildContext` that opens the app's own screens**: showing a feature is a static method on that feature's widget (§1.3).
 - [ ] **No** `_buildXxx()` methods returning a widget — those are separate widget classes (§1.4).
 - [ ] **No** private widget methods that transform the domain — those are extensions in the feature's `logic/` (§1.3c).
@@ -726,7 +840,7 @@ class ItemsListPage extends ConsumerWidget {
 - [ ] **No** `GlobalKey` for looking widgets up in the tree.
 - [ ] **No** outer `padding`/`margin` inside a widget — the parent sets the padding (§1.7). When refactoring someone else's widget the outer padding moves to the caller instead of being "kept as it was".
 - [ ] **No** `Expanded`/`SizedBox(…: double.infinity)` at the root of `build` — the parent gives the widget its space (§1.7a).
-- [ ] **No** private widget classes (`_Foo`) in public feature files.
+- [ ] **No** private widget classes (`_Foo`) in public feature files. The one exception is a slice of layout — so **no `State` and no callbacks** on a private widget class (§1.8).
 - [ ] **A Serverpod model is rebuilt with `copyWith`**, never by listing its fields in the constructor — a field with `default=` or a nullable one is optional, so a forgotten one is a silent default, not an error. Clearing a nullable field is `copyWith(field: null)` (§1.10). An unavoidable enumeration is driven by `Enum.values` or an exhaustive `switch`, not written out by hand.
 - [ ] **A setting whose value belongs to the environment has no default** — sender address, provider key, webhook URL, admin identifier. An unfilled key must be an error, not quiet work with somebody else's credentials (§1.11).
 - [ ] **A building block** — a widget with no product behaviour to describe — lives in `lib/shared/` with a doc comment, not in a zone with an empty `DwFeatureSpec`.

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -107,6 +107,12 @@ final clubSessionListConfig = DwGetModelListConfig<ClubSession>(
 );
 ```
 
+**An `include` is not a property of one config — it is a property of the model.** Give it a name of
+its own (`final clubSessionInclude = …`) and hand that same value to every config returning the
+entity, and to every hand-written read of it. **The client replaces the model with whatever
+arrives**, so one exit that forgets the include blanks the nested lists on every device — with no
+error anywhere. The full rule, and the three exits it covers, are in `dartway-data-layer` §3a.
+
 ## DwSaveConfig — create + update (unified)
 
 **All hooks share one signature:** `(Session session, DwSaveContext<T> saveContext)`. No `(initial, updated)` — both of them live in the context.
@@ -127,6 +133,18 @@ Execution order and signatures:
 The question is who needs to know, not when the work happens. A push notification nobody misses if it is late → `afterSaveSideEffects`. A verification code, a payment handed to a provider, an invitation the whole feature is about → `afterSaveTransform`, and the caller waits for it.
 
 One consequence to write into the hook: `afterSaveTransform` runs **after** the commit, so rejecting there does not undo the write. The row stays saved and only the response says no. Write the hook so that a retry is harmless, and say in the error text that retrying is what to do.
+
+**Its other job: re-reading the saved model with its `include`.** `saveContext.currentModel` holds
+the flat row that was written — hand that back and every client replaces its copy with a parent that
+has no children. Running after the commit, the hook also sees what the hooks themselves created:
+
+```dart
+afterSaveTransform: (session, saveContext) async {
+  final reloaded = await loadTicketGraph(session, saveContext.currentModel.id!);
+  if (reloaded != null) saveContext.currentModel = reloaded;
+  return null;
+},
+```
 
 ```dart
 afterSaveTransform: (session, saveContext) async {
@@ -192,6 +210,13 @@ One residual behaviour worth knowing: the model is not re-read from the database
 broadcastTo: (session, ctx) => [DwCoreConst.publicUpdatesChannel],   // public model
 broadcastTo: (session, ctx) => ['chat:${ctx.currentModel.chatId}'],  // a narrower audience
 ```
+
+What flies out is `beforeUpdates` + `currentModel` + `afterUpdates` — the very same set the caller
+gets back. So a model with an `include` reaches the channel with its graph **only if
+`afterSaveTransform` re-read it**; otherwise the subscribers' copies lose their children while the
+saver's own screen looks fine (`dartway-data-layer` §3a). The same goes for an imperative
+`session.sendUpdates(...)` and for a worker's `sendUpdatesToUser(...)`: whatever model you hand
+them is what replaces the client's.
 
 **A channel your app names itself has to be declared**, or nobody can subscribe to it. Add it to `channelConfigurations` in `DwCore.init` next to the `broadcastTo` that invented it — a channel name arrives from the client as a bare string, and the declaration is how the server tells a real one from a guess:
 
@@ -260,6 +285,11 @@ final clubSessionSaveConfig = DwSaveConfig<ClubSession>(
 ```
 
 The model is edited through `saveContext.currentModel`; related updates for the client go into `saveContext.beforeUpdates` / `saveContext.afterUpdates`. Transactional hooks must end with `return null` when they do not reject — otherwise the analyzer will catch `body_might_complete_normally_nullable`.
+
+**What goes into those lists is subject to the same include rule.** A child is put in flat and the
+client folds it into its parent itself; a **parent** is re-read with its include first. A bare
+`DwModelWrapper(object: parentModel)` — including from a child's own config, which is where it
+usually appears — wipes the graph on every subscriber, silently (`dartway-data-layer` §3a).
 
 ## DwDeleteConfig — deletion
 

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -6,6 +6,9 @@ description: >-
   (dw.repo.model/maybeModel/modelList), writes are dw.repo.saveModel/deleteModel
   (no repositories, no manual syncing), lists via dwBuildListAsync(loadingItemsCount:),
   narrowing by query via backendFilter, local filtering you do yourself with .where in the widget,
+  an entity and everything hanging off it read in ONE request (include on the server, DwRelationUpdatesConfig
+  for live child updates — a parent that leaves the server without its include silently blanks the
+  nested lists on every client),
   actions from the UI via dw.action (unified error/loading handling), notifications via dw.notify.* (not SnackBar),
   the profile via ref.watchUserProfile/readUserProfile (getters, not CRUD), sign-out via
   sessionProvider.notifier.signOut(), local screen state that survives a restart via
@@ -73,11 +76,36 @@ The skeleton is drawn from your own widget built on that instance — that's why
 
 **The placeholder is built in the loading state only**, so a widget test of a list screen that hands the builder a ready `AsyncData` does not have to stand up the default models — if a test does need them, that test is really exercising the loading state.
 
-## 3. Filtering — `backendFilter` (server) + `.where` (client)
+## 3. Filtering — count the round trips, not the filters
 
-**Why:** to narrow a list with a query to the DB — through `backendFilter`. Local filtering of already loaded data the framework deliberately **does not provide**: it is a trivial `.where`, do it yourself in the widget, don't look for a "framework" way.
+**Why:** what costs something is **how many times a screen asks the backend**, and a `modelList`
+without a `backendFilter` is not a lapse. Reading a list broadly — whole, even — and picking out
+what you need locally is the **right** answer whenever it saves a request. Local filtering of
+already loaded data the framework deliberately **does not provide**: it is a trivial `.where`, do it
+yourself in the widget, don't look for a "framework" way.
 
-**Server-side filter — `backendFilter:`.** When a list must be narrowed by a query (your own records, the messages of one chat, upcoming sessions). Filters are an enum with `DwBackendFiltersMixin` and its `.equals()`/`.greaterThan()`:
+**Several `modelList` calls with the same config are one request.** `DwModelListStateConfig` is a
+family key with value equality — `backendFilter`, `paginationStrategy`, `apiGroupOverride`,
+`relationUpdatesConfigs`, the custom listener and the sorter all take part in `==`. So two features
+watching the same list are two readers of **one** provider, not two fetches: splitting a screen into
+small features costs nothing on the wire, and merging them "to save a request" saves none. The
+metric to watch is the number of *distinct* configs a zone builds, not the number of `modelList`
+calls in it.
+
+> The one field left out of that equality is `orderByList`. Two lists differing **only** in their
+> order share a provider, and whichever was built first decides the order for both. Order such a
+> list on the client instead.
+
+**`backendFilter` is for a selection that otherwise would not fit or would carry rows that are not
+this user's business** — one client's bookings, one chat's messages, one project's records. Not for
+carving a list you already hold into slices: that is `.where`.
+
+**The choice is one line in the feature's passport**, so the next reader does not re-open it. An
+`implementationNotes` entry of the shape *"Data — `modelList<CommunityEvent>()` with no
+`backendFilter`: the block takes the whole list and shows all of it"* settles the question for good;
+so does *"filtered on the backend — a member must not receive another member's rows at all"*.
+
+**Server-side filter — `backendFilter:`.** Filters are an enum with `DwBackendFiltersMixin` and its `.equals()`/`.greaterThan()`:
 
 ```dart
 enum AppBackendFilters<T> with DwBackendFiltersMixin<T> {
@@ -108,6 +136,158 @@ coursesAsync.dwBuildListAsync(
 );
 ```
 
+## 3a. Relations — the graph arrives with the model, it is not assembled on the client
+
+**Why:** an entity and everything hanging off it is **one** read. A screen that fetches the parents,
+then the comments, then the events, then the attachments, and stitches them together by foreign key
+in memory has re-implemented the join the database does for free — and it pays for it four times on
+the wire, in four separate provider lifecycles that can disagree with each other. A production
+screen once opened with **seven** flat `modelList` calls and a hand-written matcher on top of them;
+it now opens with one.
+
+**How the graph gets there — three declarations, none of them in the widget:**
+
+1. the relation is declared in the YAML, bidirectionally — the same `relation(name=…)` on both
+   sides (`dartway-models`). The relation field on the parent is always `?`: `null` there means
+   "not loaded", not "absent";
+2. the CRUD config raises it with `include` (`dartway-crud-config`) — on `DwGetModelListConfig`,
+   and on every `DwGetModelConfig` that returns the same entity;
+3. the children arrive as ordinary fields of the model. The screen reads `ticket.comments`, and
+   `dartway-clean-code` §1.3a decides where the reading-out lives: an extension on the model.
+
+```dart
+// SERVER — the include is a named value, because everything that returns this
+// entity must use the same one (see the warning below)
+final supportTicketInclude = SupportTicket.include(
+  comments: TicketComment.includeList(),
+  events: TicketEvent.includeList(),
+);
+
+final supportTicketCrudConfig = DwCrudConfig<SupportTicket>(
+  table: SupportTicket.t,
+  getListConfig: DwGetModelListConfig(
+    accessFilter: _ticketAccessFilter,
+    include: supportTicketInclude,
+  ),
+  saveConfig: DwSaveConfig<SupportTicket>(
+    allowSave: _allowTicketSave,
+    afterSaveTransform: _reloadTicketGraph,   // re-reads with the include
+  ),
+);
+```
+
+**The depth of the graph is exactly the depth the screen thinks in.** A flat list of children that
+an extension sorts into place on the client is **cheaper** than a second level of nesting: nesting
+a child inside its sibling means the same rows travel twice. A reply is a comment with a
+`parentCommentId` — let it arrive in `comments` and let `repliesOf(comment)` find its owner.
+Go two levels deep only when the second level genuinely holds different rows.
+
+**Live changes to a child do not come as a new graph.** The server publishes the changed child
+**flat**, and the client folds it into its parent by foreign key — `DwRelationUpdatesConfig` in the
+list's config:
+
+```dart
+/// The zone's single query: tickets with everything hanging off them.
+final projectTicketsProvider =
+    Provider.family<AsyncValue<List<SupportTicket>>, int>(
+  (ref, projectId) => ref.watch(
+    dw.repo.modelList<SupportTicket>(
+      customConfig: DwModelListStateConfig<SupportTicket>(
+        backendFilter: AppBackendFilters.projectId.equals(projectId),
+        relationUpdatesConfigs: _ticketRelationUpdates,
+      ),
+    ),
+  ),
+);
+
+/// ⚠️ Declared **once, at the top level** — see the trap below.
+final _ticketRelationUpdates =
+    <DwRelationUpdatesConfig<SupportTicket, SerializableModel>>[
+  DwRelationUpdatesConfig<SupportTicket, TicketComment>(
+    relationKey: 'ticketId',
+    copyWithRelatedModels: (ticket, updates) => ticket.copyWith(
+      comments: updates.mergedInto(ticket.comments, (comment) => comment.id),
+    ),
+  ),
+  DwRelationUpdatesConfig<SupportTicket, TicketEvent>(
+    relationKey: 'ticketId',
+    copyWithRelatedModels: (ticket, updates) => ticket.copyWith(
+      events: updates.mergedInto(ticket.events, (event) => event.id),
+    ),
+  ),
+];
+
+/// Changed rows replace, new ones are appended, deleted ones disappear. Nothing
+/// has to be filtered by parent here — the framework already selected this
+/// parent's updates by `relationKey`.
+extension RelatedModelUpdates on List<DwModelWrapper> {
+  List<Related> mergedInto<Related>(
+    List<Related>? currentItems,
+    int? Function(Related item) idOf,
+  ) {
+    final updatedIds = map((update) => update.modelId).toSet();
+    return [
+      ...?currentItems?.where((item) => !updatedIds.contains(idOf(item))),
+      ...where((update) => !update.isDeleted).map((u) => u.model as Related),
+    ];
+  }
+}
+```
+
+`parentIdsGetter:` is the extra argument for a child that hangs off a **nested** level (a reply
+whose `relationKey` points at a comment, not at the ticket): it tells the framework which ids on the
+parent count as owners.
+
+> **Trap: the list of relation configs is compared by identity.** `DwModelListStateConfig` is a
+> family key, and it compares `relationUpdatesConfigs` as a **list reference**. Built in place — in
+> a provider body, in `build` — it yields a *new* family key on every rebuild: a re-fetch, lost
+> state, an endless redraw. Nothing throws; the app just behaves strangely. Declare the list once,
+> as a top-level `final`, and hand that same instance in.
+
+### ⚠️ A flat parent on the wire erases the graph
+
+**`DwSingleModelState` and `DwModelListState` both *replace* the model with whatever arrives.** So a
+parent that leaves the server **without** its include — the answer to a save, a publication from a
+worker, an `afterUpdates` entry written by a neighbouring config — blanks the nested lists for
+**every** subscriber holding it. The screen then shows a ticket with no conversation and no history
+and **reports no error at all**: on the client a relation that does not exist and a relation that
+was not requested are the same `null`.
+
+This is not hypothetical. One production project caught it in the field and wrote the reason into
+its config as a comment; the next project met it on its very first `include`.
+
+**The rule: a model that has an include leaves the server only with it.** All three exits, not just
+the obvious one:
+
+- the answer to `saveModel` → `afterSaveTransform` re-reads the row with the same include
+  (`currentModel` at that point holds the flat row that was written);
+- anything put into `beforeUpdates`/`afterUpdates`, including by a *child's* config;
+- anything sent over the socket — `broadcastTo`, `sendUpdates`, `sendUpdatesToUser`, from a worker
+  included.
+
+**Children travel flat and need no re-read** — `DwRelationUpdatesConfig` puts them where they
+belong. It is the parent, and only the parent, that has to be reloaded.
+
+Give that reload a name and let everything use it:
+
+```dart
+/// Every ticket leaving the server is read from here — see the rule above.
+Future<SupportTicket?> loadTicketGraph(
+  Session session,
+  int ticketId, {
+  Transaction? transaction,
+}) => SupportTicket.db.findById(
+      session,
+      ticketId,
+      include: supportTicketInclude,
+      transaction: transaction,
+    );
+```
+
+**The review check, and it is countable:** the number of places a parent goes out equals the number
+of calls to that loader. A `DwModelWrapper(object: <parent>)` built straight from a model in hand is
+the bug — wherever it sits, and however innocuous the hook that writes it looks.
+
 ## 4. Actions from the UI — `dw.action`
 
 **Why:** a single wrapper for user actions (taps, submits): automatic loading state, error handling (with a report to alerting — see `label`), confirmations. The callback receives a `BuildContext`. Don't wrap things in a raw `() async {}`/`onPressed`.
@@ -133,6 +313,20 @@ final deleteAction = dw.action<bool>(
 
 > The real name is **`DwUiAction`** (46+ usages). There is no `DwCallback` in the project.
 > Declining the confirm dialog cancels the action entirely (no notifications, no follow-up). A custom dialog is `DwConfig.confirmDialogBuilder`. Action errors automatically reach alerting with context (route, screen features, `label`) — see the framework's error-reporting doc.
+
+**`dw.action` says what to write an action with; where it lives is `dartway-clean-code` §1.9b —
+in the widget that owns the button.** Not a callback handed down from a parent, and not a screen-wide
+`busy` flag: `DwActionBuilder` computes busy per button already.
+
+> **The honest limitation, and it is a compromise, not a design.** A widget test cannot observe a
+> write. `dw.repo.saveModel` reaches the static `DwRepository.saveModel`, which calls
+> `dw.endpointCaller`, and that is a `late final` set in `DwCore.init` — there is no seam to fake.
+> While the write hung on a callback from above, a test could at least assert what arrived in the
+> callback; a feature that saves for itself gives a test nothing to hold. **So do not keep a
+> callback alive as a test seam** — that trade buys a weaker screen for a weaker test. What covers
+> the write is an integration test over the CRUD config on the server, where the rule being
+> protected actually lives; the widget test covers what the screen *shows*. When this bites, say so
+> — a repository fake is a framework request, not something to work around in an app.
 
 ## 4a. Derived state — a provider, not assembly in the widget
 
@@ -198,6 +392,28 @@ screen watches anyway. A local copy of server truth is a second source that can 
 **Don't introduce shims over the framework API.** `ref.saveModel(...)` forwarding the call to
 `dw.repo.saveModel(...)` adds nothing but hides the real API: on a production project 82 calls lived on such a
 pass-through, and half the team didn't know what they were calling.
+
+**One provider answers one question — it does not serve one screen.** The rule above is easy to
+honour and still get backwards: a provider that assembles *everything the screen will need* passes
+every test in this section (it is a provider, it holds a pure function, nothing is stitched in
+`build`) and yet puts the screen straight back into prop-drilling. Once the top has decided
+everything, the widgets below it have nothing left to ask, and every value reaches them as a
+constructor argument.
+
+The symptoms, in order of how reliably they give it away:
+
+- **the name.** `<Screen>Snapshot`, `<Screen>State`, `<Screen>ViewModel` — named after a place in
+  the UI rather than after a question. A provider named for what it answers cannot grow this way:
+  nothing else fits under `openTaskCountProvider`;
+- **the audience.** Fields that fewer than half of the consumers read. A seventeen-field object
+  serving six widgets is six providers that have not been written yet;
+- **the arity.** Derived from a **single** model — not a provider at all. That is an extension on
+  the model (`dartway-clean-code` §1.3a): `ticket.openComments`, `ticket.canBeClosed`. It needs no
+  container, no family key and no lifecycle, and it is reachable from the model through the dot at
+  any depth of the tree.
+
+A provider earns its existence when the answer draws on **several sources** (§4a above) or has to
+be cached across rebuilds. Everything a widget could have asked for itself, it asks for itself.
 
 ### Overriding a provider in a test
 
@@ -447,8 +663,11 @@ Neighbouring forms: `pickAndUploadImage()` (returns a `DwCloudFile` with size an
 - [ ] Data — only `dw.repo`: reads are the `dw.repo.model/maybeModel/modelList` providers under `ref.watch/read/refresh`; writes are `dw.repo.saveModel/deleteModel`. No `ref.watchModel`, no `DwRepository.`, no repositories, no manual `Future`s, no direct client.
 - [ ] Create and Update — one `saveModel` (not two different methods).
 - [ ] `AsyncValue` lists — through `dwBuildListAsync(loadingItemsCount:)`, not a scattering of `when`.
-- [ ] Narrowing by query — `backendFilter`; local filtering you do yourself with `.where` in the widget (the framework doesn't provide it).
-- [ ] Actions from the UI — `dw.action((context) async {...})`, not a raw `onPressed`/`() async {}`.
+- [ ] Narrowing by query — `backendFilter`; local filtering you do yourself with `.where` in the widget (the framework doesn't provide it). The count that matters is **distinct configs**, not `modelList` calls: reading broadly and picking locally is right when it saves a request (§3).
+- [ ] An entity and what hangs off it — **one** read: relations declared in the YAML, raised with `include`, folded live by `DwRelationUpdatesConfig`, and that config list is a top-level `final` (§3a). No stitching flat lists by foreign key in the widget.
+- [ ] Does a parent with an `include` leave the server anywhere **without** it — a save response, an `afterUpdates`, a socket send? That silently blanks the nested lists on every client (§3a).
+- [ ] Actions from the UI — `dw.action((context) async {...})`, not a raw `onPressed`/`() async {}`, and written **in the widget that owns the button** (`dartway-clean-code` §1.9b).
+- [ ] A provider answers **one question**, not one screen — no `<Screen>Snapshot`; derived from a single model is an extension on that model (§4a).
 - [ ] Notifications — `dw.notify.success/warning/error/info`, not `SnackBar`/`ScaffoldMessenger`.
 - [ ] Local screen state — survives a restart? `dw.plugins.prefs`, not a store over `raw`. Belongs to an entity? `providerFamily(keyFor:)`, not `provider` per id.
 - [ ] Profile — `ref.watchUserProfile`/`readUserProfile` (getters), not `watchModel<UserProfile>()`. Signed out is a legal answer, or you want `.select` — `dw.userProfileProvider` / `dw.requireUserProfileProvider`. Only the id — `dw.signedInUserIdProvider`.

--- a/toolkit/skills/dartway-feature-scaffold/SKILL.md
+++ b/toolkit/skills/dartway-feature-scaffold/SKILL.md
@@ -5,7 +5,10 @@ description: >-
   navigation → UI entry point → state/logic via the data layer and Riverpod → backend CRUD configs
   → models/DB → tests. Feature structure (entry point + widgets + logic), isolation (import the
   entry point only), domain/app/ui_kit boundaries, the `DwFeatureSpec` feature spec in the feature's
-  own file. Use when adding new functionality, a screen, a flow, or a model.
+  own file. A widget that decides something by a domain model is a feature (however small); one that
+  only lays out what it was handed is a block in lib/shared/ — and a feature must be constructible
+  from its address (identifiers and models), never from lists, maps and callbacks its parent assembled.
+  Use when adding new functionality, a screen, a flow, or a model.
 ---
 
 # DartWay — building a feature (end-to-end)
@@ -59,15 +62,29 @@ app/community_events/                  // group
 
 **Behaviour two features share is one more feature.** No new kind of entity is introduced: the card has exactly the same single public file as the screen.
 
-**A widget with no story of its own is a building block, and blocks live in `lib/shared/`** — never in a `common/`/`shared/`/`widgets/` folder inside a zone. The line is not how many places use it but whether there is anything to tell:
+**A widget with no story of its own is a building block, and blocks live in `lib/shared/`** — never in a `common/`/`shared/`/`widgets/` folder inside a zone. The line is not how many places use it:
 
 | | Where | Described by |
 |---|---|---|
-| **Feature** — product behaviour you can name in a user's words (a screen, a dialog, a flow, a block on a screen) | a zone: `app/`, `admin/`, `auth/`, `common/` | `DwFeatureSpec` |
-| **Building block** — a widget/helper features draw with: a form field, a badge row, a layout wrapper, an extension on a model | `lib/shared/` | a doc comment over the class |
+| **Feature** — it reads a domain model and **decides** something by it: shows different things in different states, picks a label, hides a button, opens a dialog, saves | a zone: `app/`, `admin/`, `auth/`, `common/` | `DwFeatureSpec` |
+| **Building block** — it **arranges what it was handed**: a row, an inset, a wrapper, a form field, a badge, an extension on a model | `lib/shared/` | a doc comment over the class |
 | **Layer** — presentation, infrastructure, localisation | `ui_kit/`, `core/`, `l10n/` | — |
 
-**Split small: that is the recommendation, not a tolerated evil.** Every feature brings a passport, so the finer the cut, the denser the description of the interface — one big feature is described in generalities, ten small ones each carry their own `behaviors` and `knownIssues`. A single consumer is not a sign of an internal; the sign of an internal is that there is nothing to tell (a slice of layout extracted so `build` stops growing).
+**Split small: that is the recommendation, not a tolerated evil.** Every feature brings a passport, so the finer the cut, the denser the description of the interface — one big feature is described in generalities, ten small ones each carry their own `behaviors` and `knownIssues`.
+
+**"Is there anything to tell?" is not a criterion — it is a request for taste, and it loses.** It is
+written above, and a zone still grew into four large features with ten-file `widgets/` folders under
+them, each answering "well, nothing much" about the parts. The criterion in the table is the one to
+apply, and it is answered by looking at the file: **does this widget decide anything by the domain,
+or does it lay out what it was given?**
+
+- decides → a feature, with its own folder and its own passport, however small it is. A card in a
+  list, one row of work, one question and its answer — each is a feature;
+- lays out → a block.
+
+**The consequence: a feature's `widgets/` holds blocks only.** A file in `widgets/` that imports the
+client package to `switch` over a model, choose a label from a state, or fire an action is a feature
+standing in the wrong place — move it up beside its neighbours and give it a passport.
 
 **Not a feature:** app-wide registries and infrastructure (the feature catalog, analytics, push initializers) — that is `lib/core/`; a helper several features share — `lib/shared/`. The sign that the placement is wrong: the file sits in one feature's `logic/` and is imported from other features — then all of them are reaching into its internals.
 
@@ -178,7 +195,10 @@ two public files, hides the widget in `widgets/`, and names a screen without nam
 see `dartway-clean-code` §1.3, which this convention is the answer to.
 
 ### 3. State & Logic
-Decide what data the UI needs. Data access goes through `dw.repo` only: reads via the `dw.repo.model`/`maybeModel`/`modelList` providers under the native `ref` (`ref.watch(...)` reactively, `ref.read(....future)` one-off), writes via the `dw.repo.saveModel`/`deleteModel` methods. For complex scenarios or reuse inside the feature — a Riverpod provider. Local state — Riverpod + StatefulWidget + flutter_hooks. Describe every user action (create/edit/delete) before wiring it to the backend.
+Decide what data the UI needs — for the **zone**, not per widget. An entity and everything hanging
+off it is one read (`include` on the server, `DwRelationUpdatesConfig` for live child updates — see
+`dartway-data-layer` §3a), and each widget then asks that same provider for itself rather than
+receiving pre-chewed lists from above (`dartway-clean-code` §1.9a). Data access goes through `dw.repo` only: reads via the `dw.repo.model`/`maybeModel`/`modelList` providers under the native `ref` (`ref.watch(...)` reactively, `ref.read(....future)` one-off), writes via the `dw.repo.saveModel`/`deleteModel` methods. For complex scenarios or reuse inside the feature — a Riverpod provider. Local state — Riverpod + StatefulWidget + flutter_hooks. Describe every user action (create/edit/delete) before wiring it to the backend.
 
 ### 4. Backend (CRUD configs)
 Every user action maps onto the CRUD layer — no arbitrary endpoints. Use `SaveConfig`/`DeleteConfig`/`GetModelConfig`/`GetListConfig`, wrap responses in `DwModelWrapper`. The configs hold permissions, validations, pre/post processing, side effects. Details — the `dartway-crud-config` skill.
@@ -242,6 +262,27 @@ Write one sentence per item: what is wrong and what it costs. This is a pointer 
 **Write the spec from what the code does, not from what was intended.** While you phrase verifiable statements you find things nobody ever claimed — that is how it surfaced that the events block on the home screen does not sort them by date while the screen does.
 
 The spec lives on a widget, which is another reason the entry point is one. A feature published as an extension or a bare function (`context.showInviteDialog()`) has nothing to attach the spec to — the checker cannot ask it for one, and the feature ends up with no description at all. If you meet one, that is what to fix: move the presentation into a static method on the widget (see "Showing a feature that is not a route") and the spec has a home.
+
+### A feature has to be constructible from its address
+
+The ceremony is checked — the spec is there, `id` is well-formed, the behaviours are verifiable —
+and **what the spec describes is not**. A widget with an exemplary fourteen-behaviour passport once
+had nowhere it could be placed except inside the one parent that already held its four ready-made
+lists and six callbacks. The passport was true and the feature did not exist: it was a piece of its
+parent's layout with a description attached.
+
+**The test, and it takes one attempt:** write the call. Can you construct this widget in the router,
+in a `showDialog`, in a `ListView.builder` — with nothing in hand but identifiers and domain models?
+
+- yes → a feature. It fetches the rest itself (`dartway-data-layer` §3, §3a);
+- no → it is part of its parent's markup, and no passport is due. Either fold it back into the
+  parent, or make it a feature by taking the assembled data out of its constructor
+  (`dartway-clean-code` §1.9a).
+
+Unlike most of what is written here, this one is mechanical: **a constructor that requires a
+`Function`, a `Map<…, …>` or a `List<…>` of a derived type is the shape to look for.** A `List` of a
+domain model is not automatically wrong (a card list takes its items), but a list the parent had to
+compute is.
 
 ## Entry point example
 

--- a/toolkit/skills/dartway-finish/SKILL.md
+++ b/toolkit/skills/dartway-finish/SKILL.md
@@ -38,7 +38,12 @@ Run the detectors **over the changed files only** (not over the whole repo). For
 - `ref.invalidate(...)` used for refreshing.
 - `GlobalKey().currentState/currentContext` used to look things up in the tree.
 - Outer `padding`/`margin` at the top level of a widget's `build`.
-- A private widget class (`class _Foo extends ...Widget`) **with value for reuse/testing** inside a feature's public file (a trivial local helper for a single screen is fine, see `dartway-clean-code` 1.8).
+- A private widget class (`class _Foo extends ...Widget`) inside a feature's public file that **has a `State` or takes a callback** — a slice of layout with neither is fine (`dartway-clean-code` §1.8).
+- A feature's constructor carrying **data its parent computed**: ready-made lists, a `Map`, a flag derivable from a model already passed, or more than one callback. The question per parameter is "could the widget have got this itself?" (§1.9a), and the check on the whole is "can I construct it from identifiers and models alone?" (`dartway-feature-scaffold`).
+- An action handed **downwards** as a callback instead of being written with `dw.action` in the widget that owns the button; a screen-wide `busy` flag duplicating `DwActionBuilder` (§1.9b).
+- A file in a feature's `widgets/` that imports the client package to switch over a model, pick a label, or fire an action — that is a feature standing in the wrong place (`dartway-feature-scaffold`, "Groups").
+- A provider named after a screen (`<Screen>Snapshot`/`State`/`ViewModel`) whose fields fewer than half its consumers read; anything derived from a **single** model belongs on that model as an extension (`dartway-data-layer` §4a).
+- Several `modelList` calls of related types stitched together by foreign key in the widget — the graph arrives with the model (`dartway-data-layer` §3a).
 - Naming shorter than 2 words; the forbidden `id`/`data`/`info`/`obj`/`temp`/`val`/`item`/`x`.
 - Specials (`dartway-data-layer`): `SnackBar`/`ScaffoldMessenger` instead of `dw.notify.*`; `watchModel<UserProfile>()` instead of `ref.watchUserProfile`; a raw `onPressed`/`() async {}` instead of `dw.action`; raw `Color`/`TextStyle`/`BorderRadius`/`context.theme` in features instead of the UI Kit; `router.go()`/string routes instead of enum routes and context extensions (`dartway-navigation`).
 - Feature isolation: importing a non-entry-point file of another feature.
@@ -51,6 +56,7 @@ Run the detectors **over the changed files only** (not over the whole repo). For
 - A model without a `DwCrudConfig`, or not registered in `crudConfigurations`.
 - A direct field update (e.g. `balance`) instead of an Event model in transactional/money logic.
 - Swallowed errors in config callbacks; nullable "for the UI's sake" in `.spy.yaml`.
+- A model with an `include` leaving the server **without** it — a save response with no `afterSaveTransform` re-read, a `DwModelWrapper(object: parent)` written straight into `afterUpdates`, a worker's `sendUpdates` with the flat row. The client replaces its copy wholesale, so the nested lists are blanked on every device with no error anywhere (`dartway-data-layer` §3a). Countable: places the parent goes out vs calls to the loader that carries the include.
 
 ### A.3 Checking the description (it lives in the code)
 
@@ -74,7 +80,9 @@ Check separately, by eye, the things that only break at runtime:
   including `disabled`: when adding or removing such a parameter, check how the widget looks disabled
   and while the action is running.
 - **Provider family keys.** A family keyed by an object compared by identity silently
-  creates a new provider on every build.
+  creates a new provider on every build. The framework's own key has the same edge: a
+  `DwModelListStateConfig` compares `relationUpdatesConfigs` **by list reference**, so that list must be a
+  top-level `final` and not assembled in place (`dartway-data-layer` §3a).
 
 ### A.3b Tests are part of the refactoring surface
 


### PR DESCRIPTION
A zone written as "one container on top, dumb widgets below" — seven flat
modelList calls stitched by hand, a seventeen-field snapshot, fifteen-parameter
widgets, six hand-offs between a button and saveModel — broke no rule in the
contract and passed every check. These are the rules that would have stopped it.

dartway-data-layer:
- §3 counts round trips, not filters: identical configs are one provider, so
  reading broadly and picking locally is right when it saves a request, and
  splitting a screen into small features costs nothing on the wire;
- new §3a on relations: the graph arrives with the model (include on the
  server, DwRelationUpdatesConfig for live child updates), the depth is the
  depth the screen thinks in, and the config list must be a top-level final
  because it is compared by list identity;
- and the trap that has no error attached: a parent leaving the server without
  its include replaces every subscriber's copy with a childless one;
- §4a: one provider answers one question, not one screen — a <Screen>Snapshot
  is prop-drilling with a provider in front of it, and anything derived from a
  single model is an extension on that model;
- §4: where an action lives, plus an honest note that a write from a leaf is
  not covered by a widget test — named as the compromise it is.

dartway-clean-code:
- §1.8's exception no longer rests on "trivial": a private widget class has no
  State and takes no callbacks;
- §1.9a: a feature's constructor is its address, not its data;
- §1.9b: the action is written in the widget that owns the button, and there
  is no screen-wide busy flag.

dartway-feature-scaffold: a widget that decides something by a domain model is
a feature however small, one that lays out what it was handed is a block — and
a feature has to be constructible from identifiers and models alone.

dartway-crud-config and dartway-finish pick up the matching cross-checks.
