### PR TITLE
docs(toolkit): a finding says what it cost, and the tracker keeps the count

### DIFF
--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -170,8 +170,32 @@ So before an issue is created:
    language the journal itself is kept in does not follow the entry there.
 3. **Search the tracker first.** Three projects meeting one API gap is one issue with three voices,
    not three issues.
-4. **Show the text and wait for a yes.** This is the only irreversible step the journal has — an
+4. **Label what it did to you** — the two labels below, and they are part of the text you show.
+5. **Show the text and wait for a yes.** This is the only irreversible step the journal has — an
    issue exists publicly from the moment it is created, and deleting it does not un-index it.
+
+#### The two labels
+
+**`impact:` — what the finding did to this project, not how bad it feels.** The value is remembered,
+not judged: an hour ago you either gave up on something, wrote a workaround, or simply noticed. A
+scale of severities asks for an estimate instead, and an estimate drifts between one session and the
+next until the field means nothing.
+
+| Label | What actually happened |
+|---|---|
+| `impact:blocks` | It could not be worked around. Either the project cannot do what it has to, or the workaround cost more than the feature and the feature was dropped |
+| `impact:workaround` | It was worked around, and the code carries the marker to prove it. The cost is known and dated: the day the fix lands upstream, that code starts duplicating the framework |
+| `impact:friction` | It works, but the API pushes you to write the wrong thing, or the documentation says something untrue. Nobody was blocked and there was nothing to work around |
+
+**`silent` — it breaks with no error attached.** Orthogonal to impact, and it is the label that
+moves a decision: a `friction` that quietly corrupts data outranks a `blocks` that crashes on the
+first run, because the loud one gets fixed the day it appears. It is visible; the other one is
+found by eye, months later, if at all.
+
+**A gap another project has already filed gets a comment, not a second issue** (rule 3 above): your
+impact in one line, and the label rises to the worst voice on the issue if yours is worse. That is
+also the whole of who-met-this — the account that wrote the line is who to talk to when it closes,
+and GitHub records it without being asked. Nothing about your codebase travels with it, by rule 1.
 
 ### A workaround over a `dartway_*` API also leaves a marker in the code
 

--- a/toolkit/skills/dartway-finish/SKILL.md
+++ b/toolkit/skills/dartway-finish/SKILL.md
@@ -134,8 +134,10 @@ managed files cannot be fixed here — they are overwritten on update (see `CLAU
   for filing, and one that has an issue is reported by its state rather than by what the file says —
   `gh issue view` answers that, the file does not. An issue that has closed is the signal to delete
   the entry, and to re-check the workaround it stood for if there was one. What to strip and restate
-  before filing is in `CLAUDE.md`, "Where an entry goes when it leaves this project"; the step is a
-  proposal like every other one here, never a push that happens on its own.
+  before filing is in `CLAUDE.md`, "Where an entry goes when it leaves this project" — including the
+  `impact:` label, which is proposed with the text rather than left for someone to guess later,
+  because what the finding cost this project is known now and not afterwards. The step is a proposal
+  like every other one here, never a push that happens on its own.
 - **A workaround over a `dartway_*` API is written down twice** — the entry in `dartway_notes.md`,
   and a `TODO(dartway, checked: <ref>)` marker on the code itself (see `CLAUDE.md`, "Notes back to
   the framework"). The journal says what should change upstream; the marker says what to re-check


### PR DESCRIPTION
An issue filed from a project carried the diagnosis and the fix but not the one
thing only its author knew: whether the project was stopped by it, worked around
it, or merely noticed it. That fact is available for about an hour and then it is
gone — a week later nobody remembers whether a marker went into the code. Twelve
issues arrived that way, and putting the order back together meant re-reading
every body and guessing.

So the filing ritual gains a fourth step and the tracker gains four labels:

- `impact:blocks` / `impact:workaround` / `impact:friction` — remembered, not
  judged. A severity scale asks for an estimate, and estimates drift between
  sessions until the field says nothing;
- `silent` — breaks with no error attached, orthogonal to impact and the label
  that actually moves a decision: a `friction` that quietly corrupts data
  outranks a `blocks` that crashes on the first run, because the loud one is
  fixed the day it appears.

Who met it needs no mechanism of its own. A second project comments with its own
impact instead of opening a second issue, the label rises to the worst voice, and
the account that wrote the line is who to talk to when it closes — GitHub records
that without being asked, and nothing about the codebase travels with it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
