### PR TITLE
fix(push): a tap on the web reaches the screen, by a path and a fallback behind it

### DIFF
--- a/docs/3-flutter/push-notifications.md
+++ b/docs/3-flutter/push-notifications.md
@@ -121,6 +121,20 @@ worker (there is a template in `dartway_push_firebase`), and the RuStore
 `project_id` and notification icon in the Android manifest. Each package's README
 lists its own.
 
+### The tap, on web
+
+Two independent paths carry it. The server puts the in-app path into
+`webpush.fcm_options.link`, so a tap opens the right screen even with no service
+worker of yours — in a new tab, every time. The template's `notificationclick`
+handler is the one worth having: it focuses a tab that is already open and hands
+the path to the router.
+
+The template takes the click by registering before `firebase.messaging()` and
+calling `stopImmediatePropagation()`, because the SDK installs a handler of its
+own in there and stops propagation the same way. Swapping those two lines costs
+the in-app path and reports nothing: the tap keeps working through the fallback,
+in a new tab, and no error is raised anywhere.
+
 ## See also
 
 - [Plugins](plugins.md) — how `dw.plugins.<name>` works, and why the accessor

--- a/docs/4-server/push-delivery.md
+++ b/docs/4-server/push-delivery.md
@@ -140,6 +140,17 @@ await dwPushDispatcher!.send(
 `sendToEveryone(page: ...)` pages through a whole user base with a callback of
 yours, keeping one message and one deduplication key for the campaign.
 
+**Where the tap should land travels in `data`, under `dwPushLinkDataKey`.** The
+app half reads it back under the same name, and on web the transport hands the
+same value to FCM a second time as `webpush.fcm_options.link` — so a tap opens
+the right screen even in an app whose service worker never got a
+`notificationclick` handler. It is an in-app path (`/chats/12`), not a URL; the
+browser resolves it against the app's own origin.
+
+```dart
+data: {dwPushLinkDataKey: '/chats/$channelId'},
+```
+
 Underneath, enqueue is idempotent on a stable `deduplicationKey`, enforced by a
 unique index as the last guard, so triggering the same logical campaign twice
 does not double-send:

--- a/example/dartway_example_server/lib/src/crud/news_post_crud_config.dart
+++ b/example/dartway_example_server/lib/src/crud/news_post_crud_config.dart
@@ -1,3 +1,4 @@
+import 'package:dartway_push_server/dartway_push_server.dart';
 import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:dartway_example_server/src/dartway/dartway_core.dart';
@@ -78,7 +79,12 @@ final newsPostCrudConfig = DwCrudConfig<NewsPost>(
         category: ExamplePushCategories.newsPost,
         title: post.title,
         body: post.text,
-        data: {'news_post_id': '${post.id}'},
+        // Where the tap lands. `dwPushLinkDataKey` is read back by the app
+        // half under the same name, and on web the transport hands it to FCM a
+        // second time as `webpush.fcm_options.link` — so the notification
+        // opens the news screen even in a browser whose service worker never
+        // took the click.
+        data: {dwPushLinkDataKey: '/news', 'news_post_id': '${post.id}'},
         // Stable, so publishing the same post twice — a retried request, a
         // double tap — does not notify the club twice.
         deduplicationKey: 'news_post:${post.id}',

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.
-  dartway_push_server: ^0.2.0
+  dartway_push_server: ^0.3.0
 
   http: ^1.5.0
 

--- a/packages/dartway_push/dartway_push_firebase/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_firebase/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.1
+
+- **The service worker template's `notificationclick` handler now runs.** It sat
+  after `firebase.messaging()`, and the listener the SDK installs in there stops
+  propagation — so ours never fired, on any browser: a tap opened the app at its
+  root with nothing in the console to say why. It is registered first now and
+  stops the SDK's the same way. 0.1.0 described this behaviour; this is the
+  release that has it.
+
 ## 0.1.0
 
 First release: FCM behind the `DwPushClientProvider` contract.

--- a/packages/dartway_push/dartway_push_firebase/README.md
+++ b/packages/dartway_push/dartway_push_firebase/README.md
@@ -25,9 +25,13 @@ FCM and nothing more.
 - **`android/app/google-services.json`** and **`ios/Runner/GoogleService-Info.plist`**, plus the
   Google Services Gradle plugin. Standard FlutterFire setup.
 - **Web:** copy `web/firebase-messaging-sw.template.js` from this package to your app's
-  `web/firebase-messaging-sw.js` and fill in the config. Without it a closed tab shows nothing;
-  without its `notificationclick` handler every notification opens the app at its root. Pass
-  `webVapidKey` — the browser issues no token without one.
+  `web/firebase-messaging-sw.js` and fill in the config. Without it a closed tab shows nothing.
+  **Copy it as it stands** — the handler is registered before `firebase.messaging()` and calls
+  `stopImmediatePropagation()` on purpose: the SDK installs its own `notificationclick` listener
+  in that call and stops propagation itself, so a handler placed after it never runs. Without the
+  template a tap still reaches the right screen, through `webpush.fcm_options.link`, but in a new
+  tab instead of the one already open. Pass `webVapidKey` — the browser issues no token without
+  one.
 
 ## Notes that cost an afternoon each
 

--- a/packages/dartway_push/dartway_push_firebase/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_firebase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_push_firebase
 description: "Firebase Cloud Messaging transport for DartWay push: tokens, permissions and notification taps on Android, iOS and web, behind the dw.plugins.push contract."
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_push/dartway_push_firebase/web/firebase-messaging-sw.template.js
+++ b/packages/dartway_push/dartway_push_firebase/web/firebase-messaging-sw.template.js
@@ -8,6 +8,14 @@
 // Without this file the browser shows nothing while the tab is closed. Without
 // its `notificationclick` handler it shows the notification and then opens the
 // app at its root, whatever the notification was about.
+//
+// The order of the two blocks below is load-bearing, and getting it wrong fails
+// silently. `firebase.messaging()` registers a `notificationclick` listener of
+// the SDK's own, and that listener calls `stopImmediatePropagation()` — so a
+// handler registered after it never runs, on any browser, and looks exactly
+// like an event that does not arrive. Ours is registered first and stops the
+// SDK's in the same way, because it does the same job better: the SDK opens a
+// tab, ours reuses one that is already open.
 
 importScripts('https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/10.12.0/firebase-messaging-compat.js');
@@ -21,11 +29,12 @@ firebase.initializeApp({
   appId: 'REPLACE_ME',
 });
 
-// FCM displays notification payloads in the background by itself. Adding a
-// `showNotification` call here would produce a second, duplicate notification.
-firebase.messaging();
-
 self.addEventListener('notificationclick', (event) => {
+  // The SDK's own handler is registered by `firebase.messaging()` below and
+  // would otherwise run after this one. It navigates to `fcm_options.link` in a
+  // fresh tab; this handler reuses an open one, so it wins outright.
+  event.stopImmediatePropagation();
+
   // The path was built by the server and travels in the message data under
   // `link` — the one client that cannot build its own route, because this code
   // runs outside Flutter with no router in reach.
@@ -51,3 +60,7 @@ self.addEventListener('notificationclick', (event) => {
       }),
   );
 });
+
+// FCM displays notification payloads in the background by itself. Adding a
+// `showNotification` call here would produce a second, duplicate notification.
+firebase.messaging();

--- a/packages/dartway_push/dartway_push_flutter/test/dw_push_wire_keys_test.dart
+++ b/packages/dartway_push/dartway_push_flutter/test/dw_push_wire_keys_test.dart
@@ -1,14 +1,14 @@
-import 'package:dartway_push_server/dartway_push_server.dart';
-import 'package:test/test.dart';
+import 'package:dartway_push_flutter/dartway_push_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('push data keys', () {
     // Pinned against the literals, deliberately — not against the constants in
-    // `dartway_push_flutter`, which the server must not depend on. The two
+    // `dartway_push_server`, which the app half must not depend on. The two
     // halves of the module are held together by these strings, and a rename on
     // one side fails a test on the other instead of producing a notification
     // that arrives and shows nothing.
-    test('are the wire contract with the app half', () {
+    test('are the wire contract with the server half', () {
       expect(dwPushTitleDataKey, 'push_title');
       expect(dwPushBodyDataKey, 'push_body');
       expect(dwPushImageUrlDataKey, 'image_url');
@@ -17,9 +17,9 @@ void main() {
   });
 
   group('push provider identifiers', () {
-    test('are the values a device reports at registration', () {
-      expect(DwPushProviders.fcm, 'fcm');
-      expect(DwPushProviders.ruStore, 'rustore');
+    test('are the values this device reports at registration', () {
+      expect(DwPushProviderIds.fcm, 'fcm');
+      expect(DwPushProviderIds.ruStore, 'rustore');
     });
   });
 }

--- a/packages/dartway_push/dartway_push_server/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_server/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.3.0
+
+Web click-through no longer rests on the app's service worker alone.
+
+- **`dwPushLinkDataKey` joins the wire keys.** The in-app path a payload carries
+  under `link` is now named on the server as it already was on the app half.
+  `DwFcmPushProvider` reads it and sets `webpush.fcm_options.link`, so FCM
+  navigates a tap by itself when the app has no `notificationclick` handler of
+  its own — or has one that never runs.
+- The `webpush` block is no longer skipped for a message that has a link but
+  neither an image nor an icon, and its `notification` is emitted only when it
+  has something to say rather than as an empty object.
+- **The wire keys are pinned on both halves now.** The Flutter side asserted the
+  constants rather than the literals, so a rename there broke nothing — which is
+  the one thing that test exists to prevent.
+
 ## 0.2.0
 
 The half of push that faces the app: a device can now register its token, and

--- a/packages/dartway_push/dartway_push_server/lib/dartway_push_server.dart
+++ b/packages/dartway_push/dartway_push_server/lib/dartway_push_server.dart
@@ -14,6 +14,7 @@ export 'src/push/dw_push_provider_utils.dart'
     show
         dwPushBodyDataKey,
         dwPushImageUrlDataKey,
+        dwPushLinkDataKey,
         dwPushSafeExceptionCode,
         dwPushTitleDataKey;
 export 'src/push/dw_push_queue.dart';

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_fcm_push_provider.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_fcm_push_provider.dart
@@ -61,11 +61,14 @@ final class DwFcmPushProviderConfig {
   final Duration requestTimeout;
 
   bool get isConfigured => projectId != null && serviceAccountJson != null;
+}
 
-  static String? _trimToNull(String? value) {
-    final normalized = value?.trim();
-    return normalized == null || normalized.isEmpty ? null : normalized;
-  }
+/// A blank string is an absent one everywhere in this file: an empty icon, an
+/// empty project id or an empty link are all "not set", and none of them may
+/// reach the payload as `""`.
+String? _trimToNull(String? value) {
+  final normalized = value?.trim();
+  return normalized == null || normalized.isEmpty ? null : normalized;
 }
 
 /// Firebase Cloud Messaging HTTP v1 provider.
@@ -171,6 +174,12 @@ final class DwFcmPushProvider implements DwPushProvider {
     final androidIcon = config.androidIcon;
     final androidColor = config.androidColor;
     final webpushIcon = config.webpushIcon;
+    // The same path the app half reads out of `data`, handed to FCM a second
+    // time. On the web this is what makes the browser navigate on its own, so
+    // that click-through no longer depends solely on a `notificationclick`
+    // handler in the service worker — an event that does not arrive in every
+    // browser and OS combination.
+    final link = _trimToNull(request.data[dwPushLinkDataKey]);
 
     return {
       'message': {
@@ -198,12 +207,14 @@ final class DwFcmPushProvider implements DwPushProvider {
           },
           if (imageUrl != null) 'fcm_options': {'image': imageUrl},
         },
-        if (imageUrl != null || webpushIcon != null)
+        if (imageUrl != null || webpushIcon != null || link != null)
           'webpush': {
-            'notification': {
-              'image': ?imageUrl,
-              'icon': ?webpushIcon,
-            },
+            if (imageUrl != null || webpushIcon != null)
+              'notification': {
+                'image': ?imageUrl,
+                'icon': ?webpushIcon,
+              },
+            if (link != null) 'fcm_options': {'link': link},
           },
       },
     };

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_provider_utils.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_provider_utils.dart
@@ -19,6 +19,21 @@ const dwPushImageUrlDataKey = 'image_url';
 const dwPushTitleDataKey = 'push_title';
 const dwPushBodyDataKey = 'push_body';
 
+/// Where a ready-made in-app path is carried, for the one client that cannot
+/// build its own: on the web a service worker handles the click outside
+/// Flutter, with no router in reach.
+///
+/// Part of the same wire contract — `dartway_push_flutter` declares the literal
+/// too, and both sides pin it against the string.
+///
+/// FCM reads this value a **second** time, out of `webpush.fcm_options.link`,
+/// where `DwFcmPushProvider` copies it. That is deliberate: it gives web
+/// click-through two independent paths to the same destination, because the
+/// `notificationclick` event a service worker relies on does not arrive in
+/// every browser and OS combination — and no test shows it, since delivery is
+/// green either way.
+const dwPushLinkDataKey = 'link';
+
 String dwPushTruncateProviderBody(String body) =>
     body.length > dwPushMaximumProviderBodyLength
     ? '${body.substring(0, dwPushMaximumProviderBodyLength)}...'

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_push_server
 description: "Server side of the DartWay push module — a Serverpod module: a compact, reliable push delivery queue with worker, retries, dedup and built-in FCM/RuStore providers. Optional; add it only when an app needs push."
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/dartway/dartway
 
 resolution: workspace

--- a/packages/dartway_push/dartway_push_server/test/push/dw_fcm_push_provider_test.dart
+++ b/packages/dartway_push/dartway_push_server/test/push/dw_fcm_push_provider_test.dart
@@ -34,6 +34,7 @@ void main() {
               },
               'data': {
                 'course_id': '42',
+                'link': '/courses/42',
                 'image_url': 'https://cdn.example.com/banner.png',
               },
               'android': {
@@ -47,6 +48,7 @@ void main() {
               },
               'webpush': {
                 'notification': {'image': 'https://cdn.example.com/banner.png'},
+                'fcm_options': {'link': '/courses/42'},
               },
             },
           });
@@ -91,6 +93,7 @@ void main() {
             },
             'data': {
               'course_id': '42',
+              'link': '/courses/42',
               'image_url': 'https://cdn.example.com/banner.png',
             },
             'android': {
@@ -111,6 +114,7 @@ void main() {
                 'image': 'https://cdn.example.com/banner.png',
                 'icon': '/icons/push.png',
               },
+              'fcm_options': {'link': '/courses/42'},
             },
           },
         });
@@ -139,6 +143,64 @@ void main() {
       );
 
       expect(outcome.status, DwPushProviderStatus.accepted);
+    });
+
+    test(
+      'sends the web click-through link without an image or an icon',
+      () async {
+        final body = await _sentPayload(
+          _request(
+            target: 'device-token',
+            imageUrl: null,
+            data: const {'course_id': '42', dwPushLinkDataKey: '/courses/42'},
+          ),
+        );
+
+        // A link alone has to produce the webpush block: without it the whole
+        // click-through on the web falls back to the `notificationclick`
+        // handler in the service worker, and that event does not arrive in
+        // every browser and OS combination.
+        expect(body, {
+          'message': {
+            'token': 'device-token',
+            'notification': {
+              'title': 'Course unlocked',
+              'body': 'Open the app to continue',
+            },
+            'data': {'course_id': '42', 'link': '/courses/42'},
+            'apns': {
+              'payload': {
+                'aps': {'sound': 'default'},
+              },
+            },
+            'webpush': {
+              'fcm_options': {'link': '/courses/42'},
+            },
+          },
+        });
+      },
+    );
+
+    test('leaves fcm_options out of webpush when there is no link', () async {
+      final body = await _sentPayload(
+        _request(target: 'device-token', data: const {'course_id': '42'}),
+      );
+
+      expect(_message(body)['webpush'], {
+        'notification': {'image': 'https://cdn.example.com/banner.png'},
+      });
+    });
+
+    test('treats a blank link as no link at all', () async {
+      final body = await _sentPayload(
+        _request(
+          target: 'device-token',
+          imageUrl: null,
+          data: const {'course_id': '42', dwPushLinkDataKey: '   '},
+        ),
+      );
+
+      expect(_message(body).containsKey('webpush'), isFalse);
     });
 
     test(
@@ -534,7 +596,43 @@ DwFcmPushProvider _providerResponding({
   );
 }
 
-DwPushProviderRequest _request({required String target}) {
+/// Sends [request] through a provider that answers 200 and returns the FCM
+/// message body it composed.
+Future<Map<String, Object?>> _sentPayload(
+  DwPushProviderRequest request, {
+  DwFcmPushProviderConfig? config,
+}) async {
+  late final Map<String, Object?> sentBody;
+  final provider = DwFcmPushProvider(
+    config:
+        config ??
+        DwFcmPushProviderConfig(
+          projectId: 'demo-project',
+          serviceAccountJson: '{}',
+        ),
+    httpClient: _FakePushHttpClient((httpRequest) async {
+      sentBody = jsonDecode(httpRequest.body) as Map<String, Object?>;
+      return const _FakePushHttpResponse(statusCode: 200, body: '{}');
+    }),
+    accessTokenProvider: () async => 'ya29.test-access-token',
+  );
+
+  final outcome = await provider.send(_FakeSession(), request);
+  expect(outcome.status, DwPushProviderStatus.accepted);
+  return sentBody;
+}
+
+Map<String, Object?> _message(Map<String, Object?> body) =>
+    body['message']! as Map<String, Object?>;
+
+DwPushProviderRequest _request({
+  required String target,
+  String? imageUrl = 'https://cdn.example.com/banner.png',
+  Map<String, String> data = const {
+    'course_id': '42',
+    dwPushLinkDataKey: '/courses/42',
+  },
+}) {
   return DwPushProviderRequest(
     target: target,
     payload: DwPushPayload(
@@ -542,8 +640,8 @@ DwPushProviderRequest _request({required String target}) {
       category: 'news',
       title: 'Course unlocked',
       body: 'Open the app to continue',
-      imageUrl: 'https://cdn.example.com/banner.png',
-      data: {'course_id': '42'},
+      imageUrl: imageUrl,
+      data: data,
       expiresAt: DateTime.utc(2026, 7, 21, 12),
     ),
   );

--- a/toolkit/skills/dartway-push-delivery/SKILL.md
+++ b/toolkit/skills/dartway-push-delivery/SKILL.md
@@ -306,6 +306,23 @@ Rules that matter:
   config files, the web service worker (template in the firebase package), and
   the RuStore `project_id`/icon meta-data in the Android manifest.
 
+**On web the tap has two paths, and they are not equivalent.** The server sets
+`webpush.fcm_options.link` from the payload's `link` key, so a tap opens the
+right screen even in an app with no service worker of its own — that is the
+fallback, and it costs a fresh tab every time. The template's
+`notificationclick` handler is the path worth having: it focuses a tab that is
+already open and hands the path to the router. It takes the click by being
+registered **before** `firebase.messaging()` and calling
+`stopImmediatePropagation()`, because the SDK installs a listener of its own in
+there and stops propagation the same way — a handler placed after it never runs,
+on any browser, with nothing in the console. Copy the template as it stands and
+do not reorder those two blocks.
+
+**Check the tap on a device rather than from a metric.** `delivered` means FCM
+accepted the request. It says nothing about whether anything was shown, and less
+about where the tap went; the distance between "accepted" and "opened the right
+screen" is where this section comes from.
+
 ## Authorization
 
 The module ships no endpoints and no gating; the one thing it does ship — the


### PR DESCRIPTION
Web click-through rested on one mechanism, and that mechanism never ran.

The service worker template registered its `notificationclick` handler after
`firebase.messaging()`. That call installs a listener of the SDK's own, and the
SDK's listener calls `stopImmediatePropagation()` — so ours never fired, on any
browser, and the failure looked exactly like an event that does not arrive: two
declaration orders tried, a hand-made notification tried, nothing in the
console. Meanwhile the provider set `fcm_options` only for an image, never
`webpush.fcm_options.link`, so the SDK's handler had no link to navigate to
either and bailed out after closing the notification. Both paths were present
in the code and neither was connected.

Now both work, and they are not equivalent:

- **`webpush.fcm_options.link`** — the fallback. `dwPushLinkDataKey` joins the
  wire keys on the server, where the path already travelled as an unnamed entry
  in `data` because only the app half had a name for it. The provider reads it
  and hands FCM the same value a second time, so a tap reaches the right screen
  in an app that never installed a service worker of its own. It costs a fresh
  tab.
- **the template's handler** — the path worth having, because it focuses a tab
  that is already open. It is registered before `firebase.messaging()` now and
  stops the SDK's the same way the SDK was stopping it. The order is the whole
  of it, so the reason sits in the file, next to the two blocks it orders.

Also here, because they are the same bug seen from two sides: the `webpush`
block was skipped entirely for a message with a link but no image and no icon,
and its `notification` is now emitted only when it has something to say rather
than as an empty object.

The wire keys are pinned on both halves at last. The Flutter side asserted the
constants and not the literals, so a rename there broke nothing — while
`CLAUDE.md` stated that each side pins them with a test.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
