### PR TITLE
docs(toolkit): the seam a widget test needs is the client, not the store

### DIFF
--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_repo_local_store.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/domain/dw_repo_local_store.dart
@@ -10,7 +10,7 @@ import 'dw_repo_local_writes.dart';
 /// ```dart
 /// dw = DwCore(
 ///   config: ..., client: ..., dwAlerts: ..., getUserId: ...,
-///   plugins: [DwOffline(store: MyLocalStore())],
+///   plugins: [DwOfflinePlugin(config: offlineConfig)],
 /// );
 /// ```
 ///

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repo.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repo.dart
@@ -30,7 +30,7 @@ class DwRepo {
 
   /// The local copy of reads, or `null` when the app declared no store.
   ///
-  /// Declared with the core — `DwCore(plugins: [DwOffline(...)])` — and read
+  /// Declared with the core — `DwCore(plugins: [DwOfflinePlugin(...)])` — and read
   /// here; there is no setter, because a store assigned after startup outlives
   /// the core it belongs to. Registration alone caches nothing: each list or
   /// single config must select [DwRepoReadStrategy.networkFirstWithSnapshot]

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -320,15 +320,29 @@ final deleteAction = dw.action<bool>(
 in the widget that owns the button.** Not a callback handed down from a parent, and not a screen-wide
 `busy` flag: `DwActionBuilder` computes busy per button already.
 
-> **The honest limitation, and it is a compromise, not a design.** A widget test cannot observe a
-> write. `dw.repo.saveModel` reaches the static `DwRepository.saveModel`, which calls
-> `dw.endpointCaller`, and that is a `late final` set in `DwCore.init` — there is no seam to fake.
-> While the write hung on a callback from above, a test could at least assert what arrived in the
-> callback; a feature that saves for itself gives a test nothing to hold. **So do not keep a
-> callback alive as a test seam** — that trade buys a weaker screen for a weaker test. What covers
-> the write is an integration test over the CRUD config on the server, where the rule being
-> protected actually lives; the widget test covers what the screen *shows*. When this bites, say so
-> — a repository fake is a framework request, not something to work around in an app.
+> **What a widget test over a self-writing feature covers, and where its seam is.** A feature that
+> saves for itself gives a test no callback to assert on. That seam went with the parameter, and
+> bringing it back is the wrong trade: **do not keep a callback alive as a test seam** — it buys a
+> weaker screen for a weaker test.
+>
+> The seam is one level down, and it is the same one the framework uses on itself: **the Serverpod
+> `client` handed to `DwCore`**. `dw.endpointCaller` is derived from it in the constructor, so a
+> client whose `callServerEndpoint` you override answers for the whole CRUD surface — the core's own
+> write tests count saves exactly that way. What that gets you is "the button reached `saveModel`
+> with this model", which is what a widget test should assert. What covers the **rule** is still an
+> integration test over the CRUD config on the server, where the rule lives.
+>
+> **The offline store is not that seam, and is documented not to be.** A write always goes to the
+> network first; `dw.repo.localWrites` is reached only after the call fails with a connection error.
+> Reaching for it to watch a save would force every save to declare itself queued, which is a lie
+> about intent.
+>
+> One thing to know before writing the test at all: the feature reaches `dw` **while building**, not
+> on the tap — `dw.action(...)` is constructed in `build`. So the core has to be up for the widget
+> to render, even in a test that never interacts. Without it the subtree does not build and the test
+> fails later at a finder ("found 0 widgets"), with the real cause in a separate exception block
+> above. Boot it from `setUpAll` through the app's own initializer, and keep that initializer
+> idempotent so no test file has to know whether another one booted the core first.
 
 ## 4a. Derived state — a provider, not assembly in the widget
 


### PR DESCRIPTION
The skill told every project that a write cannot be observed from a widget test,
because `dw.repo.saveModel` reaches `dw.endpointCaller` and that is a `late final`
with nothing to fake. The hop is right and the conclusion is wrong: the seam is
one level down. `endpointCaller` is derived in the constructor from the Serverpod
`client` the core is handed, so a client whose `callServerEndpoint` is overridden
answers for the whole CRUD surface — which is exactly how the core's own write
tests count saves.

This branch first claimed the seam was the offline write boundary. That was true
of the code it was written against and is not true of master: the offline work
inverted the order deliberately, and a write now always goes out by the one path
the core sends writes by, reaching local storage only after a connection error.
The contract says so in as many words — "not a place to observe or replace
repository behaviour" — so the honest text names neither the old limitation nor
the wrong seam.

What survives from the original: a callback kept alive as a test seam is still the
wrong trade, the rule is still covered by an integration test over the CRUD config
on the server, and a feature still reaches `dw` **while building** rather than on
the tap, so the core has to be up for the widget to render at all.

Also here, because it is the same sentence in a different file: two dartdoc
comments in the core showed `DwOffline(store: MyLocalStore())`. No such class
exists — it is `DwOfflinePlugin(config: ...)`. The toolkit and the docs already
had it right; only the code's own comments did not. No CHANGELOG entry and no
version move: the core is at `0.10.0` against `0.9.0` on `stable`, so this
correction ships inside a release that has not gone out yet.