### PR TITLE
chore: the last Russian in the tree, including the line that shipped

### DIFF
--- a/example/dartway_example_flutter/lib/ui_kit/3_special/auth/checkbox_form_field.dart
+++ b/example/dartway_example_flutter/lib/ui_kit/3_special/auth/checkbox_form_field.dart
@@ -33,7 +33,7 @@ class CheckboxFormField extends StatelessWidget {
       enabled: enabled,
       validator: (v) => validator?.call(v ?? false),
       builder: (fieldState) {
-        // --- Синхронизация внешних изменений VN -> FormFieldState ---
+        // --- Propagating outside changes: VN -> FormFieldState ---
         if ((fieldState.value ?? false) != value) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (fieldState.mounted) fieldState.didChange(value);

--- a/example/dartway_example_flutter/lib/ui_kit/utils/formatters.dart
+++ b/example/dartway_example_flutter/lib/ui_kit/utils/formatters.dart
@@ -1,6 +1,6 @@
 part of '../ui_kit.dart';
 
-/// Маска российского номера: +7 (###) ###-##-##
+/// Russian phone mask: +7 (###) ###-##-##
 class RuPhoneMaskFormatter extends TextInputFormatter {
   static const String _prefix = '+7 (';
 
@@ -14,7 +14,8 @@ class RuPhoneMaskFormatter extends TextInputFormatter {
     final raw = newValue.text;
     var digits = raw.replaceAll(RegExp(r'\D'), '');
 
-    // Убираем ведущие 7/8, если пользователь вставил номер с кодом страны/междугородним.
+    // Drop a leading 7/8 — the user may have pasted the number with a
+    // country or trunk code in front of it.
     if (raw.startsWith('+7') && digits.startsWith('7')) {
       digits = digits.substring(1);
     } else if (digits.startsWith('8')) {
@@ -61,53 +62,3 @@ class RuPhoneMaskFormatter extends TextInputFormatter {
     return b.toString();
   }
 }
-
-// class RuPhoneMaskFormatter extends TextInputFormatter {
-//   static const _prefix = '+7 (';
-//   static const _maxDigits = 10; // после кода страны
-
-//   String _format(String digits) {
-//     final b = StringBuffer(_prefix);
-//     final d =
-//         digits.length > _maxDigits ? digits.substring(0, _maxDigits) : digits;
-//     if (d.isNotEmpty) {
-//       b.write(d.substring(0, d.length.clamp(0, 3)));
-//     }
-//     if (d.length > 3) {
-//       b.write(') ');
-//       b.write(d.substring(3, d.length.clamp(3, 6)));
-//     }
-//     if (d.length > 6) {
-//       b.write('-');
-//       b.write(d.substring(6, d.length.clamp(6, 8)));
-//     }
-//     if (d.length > 8) {
-//       b.write('-');
-//       b.write(d.substring(8, d.length.clamp(8, 10)));
-//     }
-//     return b.toString();
-//   }
-
-//   @override
-//   TextEditingValue formatEditUpdate(
-//       TextEditingValue oldValue, TextEditingValue newValue) {
-//     // Все цифры из ввода
-//     var digits = newValue.text.replaceAll(RegExp(r'\D'), '');
-
-//     // Нормализация: 8XXXXXXXXXX -> 7XXXXXXXXXX
-//     if (digits.startsWith('8')) {
-//       digits = '7${digits.substring(1)}';
-//     }
-//     // Отбрасываем ведущую 7 (код страны) — дальше форматируем только 10 цифр номера
-//     if (digits.startsWith('7')) {
-//       digits = digits.substring(1);
-//     }
-
-//     final text = _format(digits);
-//     return TextEditingValue(
-//       text: text,
-//       selection: TextSelection.collapsed(offset: text.length),
-//       composing: TextRange.empty,
-//     );
-//   }
-// }

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.0
 
+- The comment the deploy template writes into a project's `docker-compose.yml` — the one
+  explaining why `$$` is spelled that way — was in Russian, and it shipped into every
+  generated file. It is in English now.
+
 - **`--notes-tracker owner/repo`: the framework journal gets somewhere to go.** `dartway_notes.md`
   collects what the framework got wrong, and until now that was the end of it — the file is
   git-ignored and lives on one machine, so an entry travelled only when somebody remembered it. The

--- a/packages/dartway_cli/lib/src/deploy/templates.dart
+++ b/packages/dartway_cli/lib/src/deploy/templates.dart
@@ -119,8 +119,8 @@ services:
     entrypoint: /bin/sh
     command:
       - -c
-      # \$\$ — так Compose передаёт вниз буквальный доллар, не подставляя
-      # переменную. YAML-escape вида \\\$ здесь недопустим и роняет разбор файла.
+      # \$\$ is how Compose passes a literal dollar down instead of
+      # substituting a variable. A YAML-style escape is invalid here and breaks parsing.
       - "trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; sleep 12h & wait \$\${!}; done"
 
 volumes:


### PR DESCRIPTION
A scan for Cyrillic across the tracked sources — the proper one, since `git grep`
matches the bytes of an em dash and reports every file in the repository — left
three places after the audit skill was translated. All three are comments, and
one of them is not ours to keep quiet about:

- `dartway_cli`'s deploy template carries the comment explaining why `$$` is
  spelled that way **inside the generated `docker-compose.yml`**, so it was not a
  comment in our code but a line delivered into every project that deploys;
- the example's `checkbox_form_field` and `formatters` carry theirs in the UI kit
  of the canonical project, which is the code people read to learn the framework.

`formatters.dart` also held forty-nine commented-out lines: an earlier version of
the same class, kept beside the working one. Deleted rather than translated — the
example teaches by being read, and what it was teaching there is that dead code
may stay.

`dartway_cli` is at `0.8.0` on master against `0.7.0` on `stable`, so the pending
release already carries a bump and this entry joins that section instead of
moving the version again.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
