### PR TITLE
fix(router): a route under a parameterized parent knows that it is open

### DIFF
--- a/packages/dartway_router/CHANGELOG.md
+++ b/packages/dartway_router/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.1.2 - 2026-08-19
+
+### Fixed
+
+`isActive` no longer answers `false` for the route that is open.
+
+The check compared the router **template** against the current **address**, so
+a route with a parameterized segment anywhere in its chain never matched:
+`/project/:projectId/issues` was compared with `/project/7/issues` and the
+method answered "not active" without a warning — a navigation item simply
+never lit up. Path parameters are now taken from
+`GoRouterState.pathParameters` and the comparison runs per path segment.
+
+The semantics around it are unchanged: a route stays active while a descendant
+of it is open (a parent tab keeps its highlight on a nested page), a route is
+not active merely because its path is a string prefix of the location (`/news`
+at `/newsletter`), and a zone root with an empty path is active at its own
+address only.
+
 ## 1.1.1 - 2026-07-12
 
 ### Fixed

--- a/packages/dartway_router/README.md
+++ b/packages/dartway_router/README.md
@@ -674,7 +674,9 @@ Extension on `DwNavigationRoute` providing:
 
 - `routePath` - Route path (relative for child routes)
 - `fullPath` - Full path from root
-- `isActive(context)` - Check if route is currently active
+- `isActive(context)` - Check if route is currently active. Path parameters
+  are resolved against the current location, and a route stays active while
+  one of its child routes is open
 
 ## Examples
 

--- a/packages/dartway_router/lib/src/navigation_zones/dw_navigation_route_extension.dart
+++ b/packages/dartway_router/lib/src/navigation_zones/dw_navigation_route_extension.dart
@@ -66,10 +66,25 @@ extension DwNavigationRouteExtension on DwNavigationRoute {
 
   /// Checks if this route is currently active in the navigation stack.
   ///
-  /// Returns `true` if the current location matches this route's [fullPath]
-  /// exactly, or if the current location starts with this route's full path
-  /// followed by a '/'. This allows detection of active routes even when
-  /// nested child routes are active.
+  /// Returns `true` when the current location is this route's own address, or
+  /// an address nested under it — a parent route stays active while one of its
+  /// children is on screen, which is what keeps a navigation item highlighted
+  /// on a nested page.
+  ///
+  /// Path parameters are resolved before the comparison: [fullPath] is a
+  /// template (`/project/:projectId/issues`) while the location is a concrete
+  /// address (`/project/7/issues`), so every `:param` segment is compared
+  /// against [GoRouterState.pathParameters] instead of being matched
+  /// literally. A parameter the current location does not carry leaves the
+  /// route inactive — its value is unknown, so this route cannot be the open
+  /// one.
+  ///
+  /// The comparison runs per path segment, so a route is never active merely
+  /// because its path is a string prefix of the location: `/news` is not
+  /// active at `/newsletter`.
+  ///
+  /// A zone root with an empty path (`/`) is active at its own address only,
+  /// never as the ancestor of every route in its zone.
   ///
   /// Example:
   /// ```dart
@@ -81,7 +96,25 @@ extension DwNavigationRouteExtension on DwNavigationRoute {
   /// This is useful for highlighting active items in navigation menus or
   /// bottom navigation bars.
   bool isActive(BuildContext context) {
-    final location = GoRouterState.of(context).uri.path;
-    return location == fullPath || location.startsWith('$fullPath/');
+    final state = GoRouterState.of(context);
+    final location = state.uri.pathSegments;
+    final template = fullPath
+        .split('/')
+        .where((segment) => segment.isNotEmpty)
+        .toList();
+
+    if (template.isEmpty) return location.isEmpty;
+    if (template.length > location.length) return false;
+
+    for (var i = 0; i < template.length; i++) {
+      final segment = template[i];
+      final expected = segment.startsWith(':')
+          ? state.pathParameters[segment.substring(1)]
+          : segment;
+
+      if (expected != location[i]) return false;
+    }
+
+    return true;
   }
 }

--- a/packages/dartway_router/pubspec.yaml
+++ b/packages/dartway_router/pubspec.yaml
@@ -2,7 +2,7 @@ name: dartway_router
 description: >
   Opinionated wrapper around go_router that makes routing explicit,
   predictable, and scalable for real-world Flutter apps.
-version: 1.1.1
+version: 1.1.2
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_router/test/dw_navigation_route_extension_test.dart
+++ b/packages/dartway_router/test/dw_navigation_route_extension_test.dart
@@ -77,7 +77,96 @@ class NestedPage extends StatelessWidget {
 
 // Test params
 enum TestParams<T> with DwNavigationParamsMixin<T> {
-  userId<int>();
+  userId<int>(),
+  projectId<int>();
+}
+
+// A branch with a parameterized ancestor (`/project/:projectId`) plus plain
+// roots, used to check what `isActive` answers at a concrete address.
+enum ParameterizedRoutes implements DwNavigationRoute<TestRouterState> {
+  home(DwNavigationRouteDescriptor.zoneRoot(pageWidget: LabeledPage('home'))),
+  project(
+    DwNavigationRouteDescriptor.parameterized(
+      pageWidget: LabeledPage('project'),
+      parameter: TestParams.projectId,
+      parent: home,
+      extraPathSegment: 'project',
+    ),
+  ),
+  issues(
+    DwNavigationRouteDescriptor.simple(
+      pageWidget: LabeledPage('issues'),
+      parent: project,
+    ),
+  ),
+  milestones(
+    DwNavigationRouteDescriptor.simple(
+      pageWidget: LabeledPage('milestones'),
+      parent: project,
+    ),
+  ),
+  settings(
+    DwNavigationRouteDescriptor.simple(pageWidget: LabeledPage('settings')),
+  ),
+  notifications(
+    DwNavigationRouteDescriptor.simple(
+      pageWidget: LabeledPage('notifications'),
+      parent: settings,
+    ),
+  ),
+  news(DwNavigationRouteDescriptor.simple(pageWidget: LabeledPage('news'))),
+  newsletter(
+    DwNavigationRouteDescriptor.simple(pageWidget: LabeledPage('newsletter')),
+  );
+
+  const ParameterizedRoutes(this.descriptor);
+
+  @override
+  final DwNavigationRouteDescriptor<TestRouterState> descriptor;
+
+  @override
+  String get zoneRoot => '';
+
+  @override
+  DwShellRoutePageBuilder? get shellRouteBuilder => null;
+
+  @override
+  DwStatefulShellRouteBuilder? get statefulShellRouteBuilder => null;
+
+  @override
+  List<DwNavigationGuard<TestRouterState>> get zoneGuards => [];
+}
+
+/// A page that renders its own name, so a test can reach its [BuildContext].
+class LabeledPage extends StatelessWidget {
+  const LabeledPage(this.label, {super.key});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => Text(label);
+}
+
+/// Builds the real router over [ParameterizedRoutes], opens [location] and
+/// returns the context of the page labelled [leafLabel].
+///
+/// The router is built by [DwRouter] on purpose: the paths under test are the
+/// ones the framework itself generates from the descriptors.
+Future<BuildContext> pumpRouterAt(
+  WidgetTester tester,
+  String location,
+  String leafLabel,
+) async {
+  final router = DwRouter<TestRouterState>(
+    navigationZones: [ParameterizedRoutes.values],
+    pageBuilder: DwPageBuilder.material,
+    options: DwGoRouterOptions(initialLocation: location),
+  );
+
+  await tester.pumpWidget(MaterialApp.router(routerConfig: router.router));
+  await tester.pumpAndSettle();
+
+  return tester.element(find.text(leafLabel));
 }
 
 void main() {
@@ -215,6 +304,90 @@ void main() {
         // fullPath should be '/extra/nested' which matches the actual route
         expect(TestRoutes.nested.fullPath, '/extra/nested');
         expect(TestRoutes.nested.isActive(context), isTrue);
+      });
+    });
+
+    group('isActive under a parameterized ancestor', () {
+      testWidgets('the open route is active at its concrete address',
+          (tester) async {
+        final context = await pumpRouterAt(
+          tester,
+          '/project/7/issues',
+          'issues',
+        );
+
+        // The route is declared as a template; the location is an address.
+        expect(
+          ParameterizedRoutes.issues.fullPath,
+          '/project/:projectId/issues',
+        );
+        expect(ParameterizedRoutes.issues.isActive(context), isTrue);
+      });
+
+      testWidgets('the parameterized parent stays active under a child',
+          (tester) async {
+        final context = await pumpRouterAt(
+          tester,
+          '/project/7/issues',
+          'issues',
+        );
+
+        expect(ParameterizedRoutes.project.isActive(context), isTrue);
+      });
+
+      testWidgets('a sibling under the same parent is not active',
+          (tester) async {
+        final context = await pumpRouterAt(
+          tester,
+          '/project/7/issues',
+          'issues',
+        );
+
+        expect(ParameterizedRoutes.milestones.isActive(context), isFalse);
+        expect(ParameterizedRoutes.settings.isActive(context), isFalse);
+      });
+
+      testWidgets('a parameterized route is active at its own address',
+          (tester) async {
+        final context = await pumpRouterAt(tester, '/project/7', 'project');
+
+        expect(ParameterizedRoutes.project.isActive(context), isTrue);
+        expect(ParameterizedRoutes.issues.isActive(context), isFalse);
+      });
+    });
+
+    group('isActive without a parameterized ancestor', () {
+      testWidgets('a parent stays active while its child is open',
+          (tester) async {
+        final context = await pumpRouterAt(
+          tester,
+          '/settings/notifications',
+          'notifications',
+        );
+
+        expect(ParameterizedRoutes.notifications.isActive(context), isTrue);
+        expect(ParameterizedRoutes.settings.isActive(context), isTrue);
+        expect(ParameterizedRoutes.news.isActive(context), isFalse);
+      });
+
+      testWidgets('a string prefix of the location is not an active route',
+          (tester) async {
+        final context = await pumpRouterAt(tester, '/newsletter', 'newsletter');
+
+        expect(ParameterizedRoutes.newsletter.isActive(context), isTrue);
+        // '/news' is a string prefix of '/newsletter' but not a path ancestor.
+        expect(ParameterizedRoutes.news.isActive(context), isFalse);
+      });
+
+      testWidgets('the zone root is active at its own address only',
+          (tester) async {
+        final atRoot = await pumpRouterAt(tester, '/', 'home');
+        expect(ParameterizedRoutes.home.isActive(atRoot), isTrue);
+
+        final atSettings = await pumpRouterAt(tester, '/settings', 'settings');
+        // The zone root has an empty path: it is not the ancestor of the zone.
+        expect(ParameterizedRoutes.home.isActive(atSettings), isFalse);
+        expect(ParameterizedRoutes.settings.isActive(atSettings), isTrue);
       });
     });
   });


### PR DESCRIPTION
`isActive` compared the router **template** with the current **address**:
`/project/:projectId/issues` against `/project/7/issues`. The two never match,
so the method answered "not active" for the route that was on screen — with no
exception and nothing in the console.

The API invited this on its own main scenario. The doc comment offers exactly
this use ("highlighting active items in navigation menus"), parameterized
routes are the whole point of `DwNavigationRouteDescriptor.parameterized`, and
both skeletons spend it the same way: `tabs.indexWhere((tab) =>
tab.route.isActive(context))`, which under a parameterized ancestor quietly
returns `-1`. A segmented control then shows the wrong item as selected, and a
control that will not re-emit its already-selected value leaves the user with a
button that does nothing.

Path parameters are now resolved before the comparison — each `:param` segment
is taken from `GoRouterState.pathParameters` — and the comparison runs per path
segment rather than over the string. Comparing decoded segments against decoded
parameters is the correct pairing: go_router percent-decodes path parameters
while `Uri.path` keeps the encoding, so substituting into the template as text
would break on any value carrying an encoded character.

Two behaviours are deliberately preserved rather than tidied, and both now have
tests that say so:

- **a parent stays active while a child is open.** That is what keeps a tab lit
  on a nested page, and the `topRoute?.name == name` shape suggested in the
  issue drops it;
- **a zone root with an empty path is active only at its own address.** It is
  not the ancestor of everything in its zone — a home tab highlighted on every
  screen would be wrong.

The package had no test for a route under a parameterized parent at all, which
is the main case. There are seven now, and the three covering the parameterized
route fail against the old implementation.

Closes #67

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
