### PR TITLE
fix(lints): a skeleton default is not a stored row, and the rule now knows it

### DIFF
--- a/docs/2-core/models.md
+++ b/docs/2-core/models.md
@@ -86,8 +86,11 @@ request.copyWith(status: RequestStatus.approved);  // assignee untouched
 ```
 
 `model_rebuild_by_constructor` ([`dartway_lints`](../5-tooling/conventions-checker.md), warning) says
-this in the editor: a model constructor passed a non-null `id:` is a rebuild, because a row being
-created has no id yet — it comes back from the database.
+this in the editor: a model constructor passed a real `id:` is a rebuild, because a row being created
+has no id yet — it comes back from the database. Two ids are not real and the rule skips both:
+`null`, and `dw.repo.mockModelId` — the sentinel a
+[skeleton default](../3-flutter/data-layer.md#placeholder-models-must-be-registered) carries, where
+there is no row to rebuild.
 
 ## Relations: `?` means "not loaded", the FK means "required"
 

--- a/docs/3-flutter/data-layer.md
+++ b/docs/3-flutter/data-layer.md
@@ -135,6 +135,12 @@ dw.repo.setupRepository(
 );
 ```
 
+This is the one place an app builds a model field by field with an id in hand, and it is not a
+rebuild: `mockModelId` is a sentinel, the instance is invented from nothing, and there is no stored
+row to copy from. `model_rebuild_by_constructor` reads the sentinel and stays silent, so
+`core/default_models.dart` needs no `// ignore_for_file:` — see
+[models](../2-core/models.md#an-existing-row-is-rebuilt-with-copywith-never-field-by-field).
+
 Skip it for a model and the failure is immediate and total, because this registration is not only
 about skeletons: `setupRepository` also maps the Dart type to the class name the CRUD endpoints
 speak. So:

--- a/example/dartway_example_flutter/lib/core/default_models.dart
+++ b/example/dartway_example_flutter/lib/core/default_models.dart
@@ -1,11 +1,9 @@
 // The one place a model is legitimately built field by field with an id in
-// hand. `model_rebuild_by_constructor` reads an id as "this row already exists,
-// rebuild it with copyWith", and here there is no row and nothing to copy from:
-// `mockModelId` is a synthetic constant, and the instance is invented from
-// nothing to give the skeleton a shape. Every other id passed to a model
-// constructor in an app is the rule's case, not this one.
-//
-// ignore_for_file: model_rebuild_by_constructor
+// hand. There is no row here and nothing to copy from: `mockModelId` is a
+// synthetic constant, and the instance is invented from nothing to give the
+// skeleton a shape. `model_rebuild_by_constructor` reads the sentinel and stays
+// silent by itself — no `ignore_for_file` to carry. Every other id passed to a
+// model constructor in an app is the rule's case, not this one.
 
 import 'package:dartway_example_flutter/core/app_settings/app_setting_key.dart';
 import 'package:dartway_example_flutter/core/dw_core.dart';

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -284,7 +284,7 @@ packages:
       path: "../../packages/dartway_lints"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   dartway_push_client:
     dependency: "direct overridden"
     description:

--- a/packages/dartway_lints/CHANGELOG.md
+++ b/packages/dartway_lints/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.3.1
+
+`model_rebuild_by_constructor` no longer reports a skeleton default. A construction whose `id:` is
+`dw.repo.mockModelId` — the sentinel `setupRepository(defaultModel:)` instances carry — is out of the
+rule's scope: a stored row is a model with a real id, and a skeleton default is not a row. There is
+nothing there to rebuild with `copyWith`, because there is no row to copy from; the instance is
+invented from nothing to give a loading skeleton its shape.
+
+The bug was not noise in one project's file. `setupRepository(defaultModel:)` is the framework's own
+API and every project registers one default per model, so the rule produced exactly as many warnings
+as an app has models — 17 in one of them — in the one file where it had nothing to say. The framework
+shipped its own template with an `// ignore_for_file:` on top of that file, which is the shape of the
+problem rather than a fix: a rule guaranteed to be loud where it must be silent teaches people to
+scroll past its output. Both `example/` and `template/` have dropped the ignore.
+
+The exemption is keyed on the sentinel's value, not on the `defaultModel:` argument position. The
+value travels — through a helper that builds the instance, through defaults registered in a loop —
+while the argument position only covers the call written inline; and a *real* id handed to
+`setupRepository` pins a stored row as a skeleton, which is worth a warning rather than an exemption.
+The sentinel is matched by name, for the reason `forbidden_provider_scope` matches `ProviderScope` by
+name: an unresolved reference must not make the rule fire, since firing is the failure being fixed.
+
+The rule's message now names the reason it fired, so the exemption is visible from the warning: *a
+stored row is a model with a real id.*
+
 ## 0.3.0
 
 `model_rebuild_by_constructor`: a Serverpod model constructor called with a non-null `id:` is a

--- a/packages/dartway_lints/README.md
+++ b/packages/dartway_lints/README.md
@@ -38,9 +38,9 @@ Custom lint rules enforcing [DartWay](https://dartway.dev) conventions.
   constructor argument.
 
 - **model_rebuild_by_constructor** (warning) — a Serverpod model constructor
-  called with a non-null `id:`. A row being created never passes one (the id
-  comes back from the database), so the call is rebuilding a row that already
-  exists — and rebuilding is `copyWith`'s job.
+  called with a real `id:`. A row being created never passes one (the id comes
+  back from the database), so the call is rebuilding a row that already exists —
+  and rebuilding is `copyWith`'s job.
 
   Serverpod makes a field with `default=`, and any nullable field, an *optional*
   argument. A method that rebuilds a model by naming its fields therefore keeps
@@ -57,8 +57,12 @@ Custom lint rules enforcing [DartWay](https://dartway.dev) conventions.
   rather than `TableRow`, because the client half of a generated model — the
   half an application is written against — implements only the former.
   Serverpod's own output (`lib/src/protocol/`, `lib/src/generated/`) is left
-  alone. The one legitimate hand-built instance in a DartWay app is the mock in
-  `core/default_models.dart`, and the template ships it with an `// ignore_for_file:`.
+  alone, and so are the two ids that are not real: `null`, and
+  `dw.repo.mockModelId`. The second is the sentinel a skeleton default carries —
+  `setupRepository(defaultModel: …)` builds an instance from nothing to give a
+  loading skeleton its shape, and there is no row there to rebuild. That
+  exemption is what `core/default_models.dart` rests on; the file needs no
+  `// ignore_for_file:` and neither `example/` nor `template/` carries one.
 
 ## Testing
 
@@ -67,7 +71,8 @@ Custom lint rules enforcing [DartWay](https://dartway.dev) conventions.
 that must stay silent — `lib/ui_kit/` writing styles freely, a feature importing
 its neighbour one `../` away, `test/` building its own `ProviderScope`,
 `lib/src/protocol/` rebuilding a model field by field the way the generator
-does — are there to catch an over-eager rule.
+does, `lib/core/default_models.dart` registering skeleton defaults on the
+`mockModelId` sentinel — are there to catch an over-eager rule.
 
 ```bash
 cd example && dart run custom_lint   # fails on a missed or an unexpected lint

--- a/packages/dartway_lints/example/lib/app/model_rebuild_by_constructor.dart
+++ b/packages/dartway_lints/example/lib/app/model_rebuild_by_constructor.dart
@@ -3,6 +3,7 @@
 // on the day a field is added to the model — at which point the field silently
 // arrives as its default in every one of them.
 
+import '../core/dw_core.dart';
 import '../src/protocol/club_session.dart';
 
 class SessionEditor {
@@ -38,6 +39,30 @@ class SessionEditor {
   /// `id: null` is not rebuilding anything.
   ClubSession createExplicitDraft(String title) =>
       ClubSession(id: null, title: title);
+
+  /// A skeleton default written inline. The id is the sentinel, so there is no
+  /// row and nothing to copy from — see `lib/core/default_models.dart` for the
+  /// shape an application actually registers.
+  ClubSession skeleton() => ClubSession(
+    id: dw.repo.mockModelId,
+    title: 'Group workout',
+    isPublished: true,
+  );
+
+  /// The other spelling of the same sentinel, the one the framework uses
+  /// internally. The rule reads the trailing identifier, so both are exempt.
+  ClubSession skeletonByStatic() =>
+      ClubSession(id: DwRepository.mockModelId, title: 'Group workout');
+
+  /// A real id handed to `setupRepository` is still a rebuild: it pins a stored
+  /// row as the skeleton. The exemption is the sentinel's, not the argument
+  /// position's, which is why this one is reported.
+  void registerStoredRow(ClubSession session) {
+    dw.repo.setupRepository(
+      // expect_lint: model_rebuild_by_constructor
+      defaultModel: ClubSession(id: session.id, title: session.title),
+    );
+  }
 }
 
 /// `id:` is a common argument name, and on anything that is not a Serverpod

--- a/packages/dartway_lints/example/lib/core/default_models.dart
+++ b/packages/dartway_lints/example/lib/core/default_models.dart
@@ -1,0 +1,36 @@
+// The under-eager half of the fixture, and the reason the exemption exists: an
+// app registers one skeleton default per model, every one of them built field
+// by field with `id: dw.repo.mockModelId`. There is no row here to rebuild —
+// the instance is invented from nothing to give the loading skeleton a shape —
+// so not a single lint may fire in this file. custom_lint fails on an
+// unexpected report exactly as it does on a missing one.
+//
+// The file is deliberately free of `// ignore_for_file:`. That is what the
+// framework's own template used to carry, and a rule that has to be silenced
+// wherever the framework's own API is used is a rule people learn to scroll
+// past.
+
+import '../src/protocol/club_session.dart';
+import 'dw_core.dart';
+
+class DefaultModels {
+  static void initRepository() {
+    dw.repo.setupRepository(
+      defaultModel: ClubSession(
+        id: dw.repo.mockModelId,
+        title: 'Group workout',
+        description: 'One hour group workout',
+        isPublished: true,
+      ),
+    );
+
+    // The sentinel travels with the value: the instance is built in a helper
+    // and registered somewhere else entirely. An exemption keyed on the
+    // `defaultModel:` argument position would report this one, which is why the
+    // rule reads the id instead.
+    dw.repo.setupRepository(defaultModel: _archivedSessionSkeleton());
+  }
+
+  static ClubSession _archivedSessionSkeleton() =>
+      ClubSession(id: dw.repo.mockModelId, title: 'Archived session');
+}

--- a/packages/dartway_lints/example/lib/core/dw_core.dart
+++ b/packages/dartway_lints/example/lib/core/dw_core.dart
@@ -1,0 +1,38 @@
+// A hand-written stand-in for the part of `dartway_serverpod_core_flutter` the
+// skeleton-defaults fixture is written against: the `dw` root, its `repo`
+// facade, the `mockModelId` sentinel and `setupRepository`.
+//
+// Stubbed rather than depended on, because the rule matches the sentinel by
+// name and nothing else — see `ModelRebuildByConstructorRule`. Pulling the real
+// core in would drag riverpod, the serverpod client half and four workspace
+// packages into a fixture that resolves standalone, and would still prove the
+// same thing: that a construction whose `id:` reads `dw.repo.mockModelId` is
+// left alone.
+
+import 'package:serverpod_client/serverpod_client.dart';
+
+class DwRepo {
+  const DwRepo();
+
+  /// Placeholder id for the instance a list skeleton is shaped from.
+  int get mockModelId => 0;
+
+  void setupRepository<T extends SerializableModel>({required T defaultModel}) {
+    // The real one registers the instance; the fixture only has to compile.
+  }
+}
+
+class DwCore {
+  const DwCore();
+
+  DwRepo get repo => const DwRepo();
+}
+
+const dw = DwCore();
+
+/// The static `dw.repo.mockModelId` delegates to. Not exported by the framework
+/// — it is here because the rule accepts either spelling, and a fixture is
+/// where that is worth stating.
+class DwRepository {
+  static const int mockModelId = 0;
+}

--- a/packages/dartway_lints/example/pubspec.lock
+++ b/packages/dartway_lints/example/pubspec.lock
@@ -175,7 +175,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   fake_async:
     dependency: transitive
     description:

--- a/packages/dartway_lints/lib/dartway_lints.dart
+++ b/packages/dartway_lints/lib/dartway_lints.dart
@@ -189,13 +189,22 @@ class ForbiddenProviderScopeRule extends DartLintRule {
 /// never opened the file. A rule living in a comment at the far end of the
 /// system is not a rule.
 ///
-/// The signal is a non-null `id:`. A row being created never passes one — the
-/// id comes back from the database — so a call that does pass one is rebuilding
+/// The signal is a real `id:`. A row being created never passes one — the id
+/// comes back from the database — so a call that does pass one is rebuilding
 /// something that already exists, and `copyWith` is what rebuilds it. Nothing
 /// is lost by the ban: `copyWith` can clear a nullable field too, because the
 /// generated one takes `Object? field = _Undefined` and tests
 /// `field is T? ? field : this.field`, which tells "not passed" apart from
 /// "passed null".
+///
+/// Two ids are not real, and neither is a rebuild: `null`, which says out loud
+/// that the row does not exist yet, and `dw.repo.mockModelId`, the sentinel a
+/// skeleton default carries. The second one is why the exemption exists at all
+/// — `setupRepository(defaultModel:)` is the framework's own API, and every
+/// project registers one default per model, so without it the rule reported a
+/// warning per model in the one file where it had nothing to say. A rule that
+/// is guaranteed to be loud where it must be silent teaches people to scroll
+/// past its output.
 ///
 /// Matched through `SerializableModel` rather than through `TableRow`: on the
 /// server a model implements both, but the **client** half of the same
@@ -209,13 +218,15 @@ class ModelRebuildByConstructorRule extends DartLintRule {
   static const _code = LintCode(
     name: 'model_rebuild_by_constructor',
     problemMessage:
-        'This rebuilds a stored model by listing its fields: a passed id means '
-        'the row already exists. A field with default= or a nullable field is '
-        'an optional argument, so the next one added to the model is not a '
+        'A stored row is a model with a real id, and this rebuilds one by '
+        'listing its fields. A field with default= or a nullable field is an '
+        'optional argument, so the next one added to the model is not a '
         'compile error here — it is a silent default.',
     correctionMessage:
         'Rebuild it with copyWith. Clearing a nullable field works too: pass '
-        'null, and the sentinel tells that apart from not passing it.',
+        'null, and the sentinel tells that apart from not passing it. A '
+        'skeleton default is not a row — build it with '
+        'id: dw.repo.mockModelId.',
     errorSeverity: DiagnosticSeverity.WARNING,
   );
 
@@ -237,11 +248,46 @@ class ModelRebuildByConstructorRule extends DartLintRule {
       // one shape of a field-by-field call that is not a rebuild.
       if (idArgument.expression is NullLiteral) return;
 
+      // The skeleton default: an id that is the sentinel is not an id.
+      if (_isMockModelId(idArgument.expression)) return;
+
       if (!_isSerializableModel(node.staticType)) return;
 
       reporter.atNode(node.constructorName, code);
     });
   }
+
+  /// The sentinel a skeleton default carries in place of an id, spelled
+  /// `dw.repo.mockModelId` in application code (`DwRepository.mockModelId` is
+  /// the static it delegates to, and lives inside the framework).
+  static const _mockModelIdName = 'mockModelId';
+
+  /// Matched by name rather than by resolved element, for the same reason
+  /// `forbidden_provider_scope` matches `ProviderScope` by name: an unresolved
+  /// reference would make the rule fire, and firing is the failure mode being
+  /// fixed here. The trade — a variable of one's own called `mockModelId`
+  /// silences the rule for that one call — costs nothing next to a warning on
+  /// every model of every project that uses `setupRepository`.
+  ///
+  /// Deliberately not widened to "any construction passed as the
+  /// `defaultModel:` argument of `setupRepository`". The sentinel travels with
+  /// the value — through a helper that builds the instance, through a list of
+  /// defaults registered in a loop — while the argument position only catches
+  /// the call written inline; and a *real* id handed to `setupRepository` is a
+  /// stored row pinned as a skeleton, which is worth seeing rather than
+  /// silencing.
+  static bool _isMockModelId(Expression expression) =>
+      _tailName(expression) == _mockModelIdName;
+
+  /// The last identifier of a reference, whatever shape it arrives in:
+  /// `mockModelId`, `DwRepository.mockModelId` (a prefixed identifier),
+  /// `dw.repo.mockModelId` (a property access on a prefixed identifier).
+  static String? _tailName(Expression expression) => switch (expression) {
+    SimpleIdentifier(:final name) => name,
+    PrefixedIdentifier(:final identifier) => identifier.name,
+    PropertyAccess(:final propertyName) => propertyName.name,
+    _ => null,
+  };
 
   static NamedExpression? _idArgument(ArgumentList argumentList) {
     for (final argument in argumentList.arguments) {

--- a/packages/dartway_lints/pubspec.yaml
+++ b/packages/dartway_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_lints
 description: "Custom lint rules enforcing DartWay conventions: the UI kit as the single source of styles, relative imports kept short, ProviderScope left to the app bootstrap and tests, and a stored model rebuilt with copyWith rather than field by field."
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/template/dartway_starter_flutter/lib/core/default_models.dart
+++ b/template/dartway_starter_flutter/lib/core/default_models.dart
@@ -1,11 +1,9 @@
 // The one place a model is legitimately built field by field with an id in
-// hand. `model_rebuild_by_constructor` reads an id as "this row already exists,
-// rebuild it with copyWith", and here there is no row and nothing to copy from:
-// `mockModelId` is a synthetic constant, and the instance is invented from
-// nothing to give the skeleton a shape. Every other id passed to a model
-// constructor in your app is the rule's case, not this one.
-//
-// ignore_for_file: model_rebuild_by_constructor
+// hand. There is no row here and nothing to copy from: `mockModelId` is a
+// synthetic constant, and the instance is invented from nothing to give the
+// skeleton a shape. `model_rebuild_by_constructor` reads the sentinel and stays
+// silent by itself — no `ignore_for_file` to carry. Every other id passed to a
+// model constructor in your app is the rule's case, not this one.
 
 import 'package:dartway_starter_flutter/core/dw_core.dart';
 import 'package:dartway_starter_client/dartway_starter_client.dart';

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -277,7 +277,7 @@ packages:
       path: "../../packages/dartway_lints"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   dartway_router:
     dependency: "direct main"
     description:

--- a/toolkit/skills/dartway-clean-code/SKILL.md
+++ b/toolkit/skills/dartway-clean-code/SKILL.md
@@ -524,10 +524,11 @@ request.copyWith(assigneeProfileId: null);
 ```
 
 **`model_rebuild_by_constructor`** (`dartway_lints`, warning) says this in the editor: a constructor
-call on a Serverpod model that is passed a non-null `id:` is a rebuild, because a row being created
-never carries an id — it comes back from the database. The one legitimate exception in a DartWay app
-is `core/default_models.dart`, where mock instances are invented from nothing with a synthetic id;
-it carries an `// ignore_for_file:` that says so.
+call on a Serverpod model that is passed a real `id:` is a rebuild, because a row being created never
+carries an id — it comes back from the database. The one legitimate hand-built instance in a DartWay
+app is the skeleton default in `core/default_models.dart`, invented from nothing with a synthetic id;
+the rule knows that sentinel — a construction whose `id:` is `dw.repo.mockModelId` is not a row and
+is left alone, so the file needs no `// ignore_for_file:`.
 
 **A doc comment is not a rule.** The method in that project had an honest request written above it —
 *"anything added to the model belongs here too"* — and it changed nothing, because the field was

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -72,6 +72,8 @@ dw.repo.setupRepository(
 );
 ```
 
+This is the one model construction in your app that names an id without rebuilding a row: `mockModelId` is a sentinel and the instance is invented from nothing, which `model_rebuild_by_constructor` knows — the file needs no `// ignore_for_file:`.
+
 The skeleton is drawn from your own widget built on that instance — that's why it resembles the future content rather than a generic shimmer. Without registration the very first `dwBuildListAsync` fails at runtime: `Default Objects Repository doesn't contain a model of type X`.
 
 **The placeholder is built in the loading state only**, so a widget test of a list screen that hands the builder a ready `AsyncData` does not have to stand up the default models — if a test does need them, that test is really exercising the loading state.


### PR DESCRIPTION
`model_rebuild_by_constructor` reads an `id:` passed to a model constructor as
"this row already exists, rebuild it with `copyWith`". A skeleton default is
built with `id: dw.repo.mockModelId` — there is no row and nothing to copy from,
only a sentinel giving the placeholder a shape. The rule fired on every one of
them.

That is not one project's inconvenience: `setupRepository(defaultModel:)` is the
framework's own API, so every project collects exactly as many warnings as it has
models — seventeen in one of them. A rule guaranteed to be loud precisely where
it must be silent teaches people to scroll past the linter.

**Both skeletons were already carrying `// ignore_for_file:
model_rebuild_by_constructor`** — the false positive was known, and the answer
shipped into every project `dartway create` produces was to silence the rule in
that file. Removing those two lines is what proves this fix: `custom_lint` is
clean in `example/`, in `template/` and in the rule's own fixture, with nothing
suppressed.

The exemption is the sentinel's **value**, not the argument position. The value
travels — through a helper that builds the instance, through defaults registered
in a loop — while a position only catches the call written inline; and a *real*
id handed to `setupRepository` pins a stored row as a placeholder, which is worth
seeing rather than silencing. It is matched by name, for the reason
`forbidden_provider_scope` matches `ProviderScope` by name: an unresolved
reference must not make the rule fire, and firing is the failure being fixed.

The fixture gained both directions — a skeleton default that must stay silent,
including the spelling through a helper, and a real id inside
`setupRepository(defaultModel:)` that must still be reported. The rule's own
message says the reason now: a stored row is a model with a real id.

Four places described the rule as "a non-null `id:`" or pointed at the
`ignore_for_file` — two toolkit skills and two doc pages — and say the sentinel
instead.

Closes #76

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
