### PR TITLE
fix(deploy): a declared file reaches the container, and the override reaches the deploy

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -287,14 +287,25 @@ the API address a second time, and nothing compares the two copies — the image
 successfully against yesterday's API, which is the failure mode with no error message. A warning
 rather than an error, because only the build block reintroduces the duplicate.
 
-`run` updates the checkout, rebuilds, applies migrations and restarts, then polls every public URL.
-It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders infrastructure on
-every push turns a routine change into an infrastructure one.
+The override is **never copied to the server**. Every Compose call the CLI issues names it explicitly
+— `docker compose -f docker-compose.yml -f deploy/compose.override.yml …` — so the file being merged
+is the one in the checkout, which `git reset --hard` refreshes on every deploy. It used to be copied
+to `docker-compose.override.yml` beside the rendered file, the name Compose loads on its own, on the
+grounds that nothing then has to remember the flag; but there is nobody to forget it, since every
+invocation is built in one place, and the price was a second copy that a deploy silently preferred
+over the committed one for as long as `setup` was not re-run. A server carrying that copy has it
+moved to `docker-compose.override.yml.retired` on the next `setup` or `run` — renamed rather than
+deleted, in case somebody edited it on the box while debugging.
+
+`run` retires that copy, updates the checkout, rebuilds, applies migrations and restarts, then polls
+every public URL. It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders
+infrastructure on every push turns a routine change into an infrastructure one.
 
 `secret` moves credentials between the maintainer's `passwords.yaml` and a server, one environment
 at a time: `push` sends `shared` plus that environment, `pull` brings back what the server has and
 the file lacks, `list` shows names only. `set` stores one value, `put-file` uploads a whole file — a
-service-account JSON and the like — and `init` creates the store and fills in the keys that are just
+service-account JSON and the like, which reaches the container only once it is also named under
+`requires.files` — and `init` creates the store and fills in the keys that are just
 random strings, which `setup` has already done by the time you would think to run it. Values travel on
 stdin, never as arguments, so they appear in neither shell history nor a remote process list. Two
 guards refuse a push that would lose information — one for keys the server has and the file does not,
@@ -323,7 +334,8 @@ The rest are the flags worth knowing before you need them:
 | `host`, `ssh_user`, `deploy_user`, `os` | always |
 | `repo`, `branch` | always |
 | `ssl_email`, `web_app_domain` | always |
-| `requires.secrets`, `requires.files` | to have `check` catch a credential nobody delivered |
+| `requires.secrets` | to have `check` catch a credential nobody delivered |
+| `requires.files` | a credential that is a whole file. Each entry is delivered with `secret put-file` and **mounted read-only at `/app/config/<name>`** in the server container, beside `passwords.yaml` — the application reads it as `config/<name>`. `check` asserts the mount, not the delivery: it asks the server for the configuration Compose will actually run and looks for the file in it, because "the file is on the machine" is green exactly where the deploy is red. An entry is a file name, not a pattern or a path — a mount names one path on each side |
 | `registry_mirror` | pulling base images through a mirror |
 | `firewall_ports` | a port beyond SSH, 80 and 443 |
 | `server_entrypoint` | only when the Dockerfile declares `ENTRYPOINT` in shell form — that form ignores the arguments `docker compose run` appends, so migrations would silently start an ordinary server instead. Setting it is also what tells `check` the shell form is deliberate |

--- a/example/dartway_example_server/Dockerfile
+++ b/example/dartway_example_server/Dockerfile
@@ -21,8 +21,10 @@ RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
 COPY --from=build /server /app/server
-# The Serverpod configuration is source, not something the deploy renders; only
-# passwords.yaml is mounted over this directory at runtime.
+# The Serverpod configuration is source, not something the deploy renders. What
+# arrives over this directory at runtime comes from the server's secret store:
+# passwords.yaml, and every file named under `requires.files` in
+# deploy/config.yaml, each mounted read-only under its own name.
 COPY --from=build /workspace/dartway_example_server/config/ /app/config/
 COPY --from=build /workspace/dartway_example_server/web/ /app/web/
 COPY --from=build /workspace/dartway_example_server/migrations/ /app/migrations/

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## 0.8.0
 
+- **A file declared in `requires.files` is now mounted into the container, and `deploy check` asks
+  whether the application can see it.** The mechanism was wired halfway: `secret put-file` delivered
+  the file, `check` confirmed it was on the server, and the rendered compose file mounted exactly one
+  thing — `passwords.yaml`. Twenty-one checks passed and the deploy died applying migrations, because
+  the application could not find a file that was demonstrably on the machine. Every declared file is
+  now mounted read-only at `/app/config/<name>` beside `passwords.yaml`, so the application reads it
+  as `config/<name>`. An entry has to be a file name: a pattern is refused at render time rather than
+  turned into a mount Docker takes literally and satisfies with a directory called `*.json`.
+
+  The check changed with it, because the wrong question is the more expensive half. It used to ask
+  "is the file on the server?" while the deploy dies on "can the application see it?", and a check
+  that is green where the deploy is red is worse than no check — people read it and stop looking. It
+  now asks the server for the configuration Compose will actually run (`docker compose config`, the
+  rendered file merged with the project's override) and looks for the file's own path among the
+  backend's mounts. It deliberately stops short of starting a container: `compose run` builds the
+  image when it is absent, which would turn a check into a ten-minute build, and probing the
+  container that happens to be up answers about the previous deploy rather than the one about to
+  happen.
+
+- **`run` no longer deploys a setup-time copy of the project's compose override.** `setup` used to
+  copy `deploy/compose.override.yml` to `docker-compose.override.yml` next to the rendered file — the
+  name Compose loads on its own — so that no later call had to remember a `-f` flag. There is nobody
+  to forget it: every Compose invocation is built by the CLI in one place. The price was a second
+  copy that a deploy silently preferred over the committed one, so a merged change to the override
+  did nothing while the run printed the very commit that made it and the checkout on the server
+  visibly held the new file. Compose is now given `-f docker-compose.yml -f deploy/compose.override.yml`,
+  and the checkout — refreshed by the `git reset --hard` a deploy already performs — is the only copy.
+
+  **A server that already has the copy gets it retired**, by `setup` and by `run` alike, since a
+  leftover would otherwise be merged into every deploy forever and be harder to see than before. It
+  is renamed to `docker-compose.override.yml.retired` rather than deleted: the file is normally a
+  stale copy of a committed one and worth nothing, but a server may carry a hand edit made while
+  debugging, and losing that silently would be its own bug. The step is idempotent and says nothing
+  on a server that never had the copy.
+
 - The comment the deploy template writes into a project's `docker-compose.yml` — the one
   explaining why `$$` is spelled that way — was in Russian, and it shipped into every
   generated file. It is in English now.

--- a/packages/dartway_cli/lib/src/commands/deploy_run.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_run.dart
@@ -121,6 +121,11 @@ Future<int> runDeploy(Command<int> command, ArgResults results) async {
         stdout.writeln('  now at ${revision.firstLine}');
       }
     }
+    // Says nothing on a server that has nothing to retire, which is every
+    // server after the first deploy that did.
+    if (step.id == 'retire-override-copy' && result.stdout.trim().isNotEmpty) {
+      stdout.writeln('  ${result.stdout.trim()}');
+    }
   }
 
   stdout.writeln('\nServices');

--- a/packages/dartway_cli/lib/src/commands/deploy_setup.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_setup.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
+import '../deploy/compose_files.dart';
 import '../deploy/deploy_target.dart';
 import '../deploy/renderer.dart';
 import '../deploy/secret_store.dart';
@@ -69,7 +70,10 @@ Future<int> runSetup(Command<int> command, ArgResults results) async {
     stdout.writeln(
       override == null
           ? 'No deploy/compose.override.yml.'
-          : 'Would upload deploy/compose.override.yml.',
+          : 'deploy/compose.override.yml is merged straight from the '
+                'checkout — every Compose call names it, so nothing is '
+                'uploaded and a committed change to it takes effect on the '
+                'next run.',
     );
     final snippets = renderer.nginxSnippets;
     stdout.writeln(
@@ -290,21 +294,18 @@ chmod 600 '${target.appDir}/.env'
     return 1;
   }
 
-  final override = renderer.composeOverride;
-  if (override != null) {
-    if (!await step(
-      'Compose override',
-      // Written under the name Compose loads on its own next to
-      // docker-compose.yml, so every later `docker compose` call picks it up
-      // without a -f flag to remember.
-      () => ssh.runAsWithInput(
-        target.deployUser,
-        "cat > '${target.appDir}/docker-compose.override.yml'",
-        override.readAsStringSync(),
-      ),
-    )) {
-      return 1;
-    }
+  // The project's override is not copied anywhere. Every Compose call names
+  // deploy/compose.override.yml inside the checkout, which the deploy's
+  // `git reset --hard` refreshes. A copy taken here would freeze the file as
+  // it was on the day setup last ran — and Compose would prefer it.
+  if (!await step(
+    'Retire the setup-time compose override copy',
+    () => ssh.runAs(
+      target.deployUser,
+      DwComposeFiles.retireLegacyCopyIn(target.appDir),
+    ),
+  )) {
+    return 1;
   }
 
   for (final entry in renderer.nginxSnippets.entries) {
@@ -346,11 +347,12 @@ fi
     () => ssh.runAs(target.deployUser, '''
 set -e
 cd '${target.appDir}'
-if docker compose run --rm -T --entrypoint sh certbot -c \\
+${DwComposeFiles.selectFiles}
+if ${DwComposeFiles.invoke} run --rm -T --entrypoint sh certbot -c \\
   "test -f /etc/letsencrypt/live/$certName/fullchain.pem" </dev/null; then
   exit 0
 fi
-docker compose run --rm -T --entrypoint sh certbot -c "
+${DwComposeFiles.invoke} run --rm -T --entrypoint sh certbot -c "
   mkdir -p /etc/letsencrypt/live/$certName
   openssl req -x509 -nodes -newkey rsa:2048 -days 1 \\
     -keyout /etc/letsencrypt/live/$certName/privkey.pem \\

--- a/packages/dartway_cli/lib/src/deploy/compose_files.dart
+++ b/packages/dartway_cli/lib/src/deploy/compose_files.dart
@@ -1,0 +1,68 @@
+/// The Compose files a deployment merges, and the one way of invoking Compose
+/// with them.
+///
+/// The project's override is named explicitly on every call rather than copied
+/// next to the rendered file under the name Compose loads on its own. The copy
+/// was made once, by `setup`, and nothing refreshed it — so a committed change
+/// to `deploy/compose.override.yml` had no effect on a deploy, while the run
+/// printed the very commit that made it. Naming the file from the checkout
+/// makes `git reset --hard` refresh it, which is what a reader already expects
+/// the checkout to do.
+///
+/// Nobody has to remember the flag: every `docker compose` the CLI issues is
+/// built here.
+class DwComposeFiles {
+  const DwComposeFiles._();
+
+  /// Rendered by `dartway deploy setup` into the checkout root.
+  static const String rendered = 'docker-compose.yml';
+
+  /// The project's own override, as committed. Relative to the checkout root,
+  /// which is where Compose runs.
+  static const String projectOverride = 'deploy/compose.override.yml';
+
+  /// The copy `setup` used to write next to [rendered]. Compose loads a file
+  /// under this name automatically, so a leftover from an older CLI keeps
+  /// being merged into every deploy — see [retireLegacyCopyIn].
+  static const String legacyCopy = 'docker-compose.override.yml';
+
+  /// Where [legacyCopy] is moved to. Any name Compose does not load on its own
+  /// would do; this one says what happened.
+  static const String retiredCopy = 'docker-compose.override.yml.retired';
+
+  /// Shell variable holding the `-f` flags.
+  static const String _variable = 'dw_compose_files';
+
+  /// Sets [_variable]. Assumes the working directory is the checkout root.
+  ///
+  /// `if`/`fi` rather than `[ -f x ] && …`: the latter exits non-zero when the
+  /// override is absent, which aborts any caller running under `set -e`.
+  static const String selectFiles =
+      "$_variable='-f $rendered'; "
+      "if [ -f '$projectOverride' ]; then "
+      '$_variable="\$$_variable -f $projectOverride"; '
+      'fi';
+
+  /// The invocation itself, once [selectFiles] has run. Unquoted on purpose:
+  /// the variable holds several arguments and has to split into them.
+  static const String invoke = 'docker compose \$$_variable';
+
+  /// A complete command: enter [appDir], pick the files, run Compose.
+  static String commandIn(String appDir, String arguments) =>
+      "cd '$appDir' && $selectFiles && $invoke $arguments";
+
+  /// Removes the automatically loaded copy an older CLI left in [appDir].
+  ///
+  /// Renamed rather than deleted: the file is normally a stale copy of a
+  /// committed one and worth nothing, but a server may carry a hand edit made
+  /// while debugging, and losing that silently would be its own bug. Idempotent
+  /// — a server that never had the copy, or that has already been through this,
+  /// finds nothing to move and says nothing.
+  static String retireLegacyCopyIn(String appDir) =>
+      "cd '$appDir' && "
+      "if [ -f '$legacyCopy' ]; then "
+      "mv -f '$legacyCopy' '$retiredCopy' && "
+      "echo 'Retired $legacyCopy (now $retiredCopy): the deploy reads "
+      "$projectOverride from the checkout instead.'; "
+      'fi';
+}

--- a/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'compose_files.dart';
 import 'deploy_target.dart';
 import 'serverpod_config.dart';
 import 'ssh_runner.dart';
@@ -41,8 +42,19 @@ class DwDeployRunner {
 
   String get _appDir => target.appDir;
 
+  /// Every Compose call of a deployment goes through here, which is why the
+  /// project's override can be named explicitly instead of copied to the
+  /// server under the name Compose picks up on its own.
   String _compose(String arguments) =>
-      "cd '$_appDir' && docker compose $arguments";
+      DwComposeFiles.commandIn(_appDir, arguments);
+
+  /// Moves aside the automatically loaded override copy older CLIs wrote.
+  ///
+  /// A server that has one merges it into every deploy, silently and forever,
+  /// while the committed override it was copied from goes on being ignored.
+  /// Idempotent, and a no-op on a server that never had the copy.
+  Future<DwSshResult> retireOverrideCopy() =>
+      ssh.runAs(target.deployUser, DwComposeFiles.retireLegacyCopyIn(_appDir));
 
   /// Brings the checkout to the tip of the deployment branch.
   ///
@@ -96,6 +108,11 @@ class DwDeployRunner {
   );
 
   List<DwDeployStep> steps({required bool skipGitUpdate}) => [
+    DwDeployStep(
+      id: 'retire-override-copy',
+      title: 'Retire the setup-time compose override copy',
+      run: retireOverrideCopy,
+    ),
     if (!skipGitUpdate)
       DwDeployStep(
         id: 'update-checkout',

--- a/packages/dartway_cli/lib/src/deploy/remote_checks.dart
+++ b/packages/dartway_cli/lib/src/deploy/remote_checks.dart
@@ -1,9 +1,13 @@
 import 'dart:io';
 
+import 'package:yaml/yaml.dart';
+
 import '../checker/dw_check_type.dart';
+import 'compose_files.dart';
 import 'deploy_check.dart';
 import 'master_passwords_file.dart';
 import 'secret_store.dart';
+import 'templates.dart';
 
 /// Checks that need the network: DNS, and the server itself over SSH.
 const List<DwDeployCheck> dwRemoteDeployChecks = [
@@ -48,7 +52,7 @@ const List<DwDeployCheck> dwRemoteDeployChecks = [
   ),
   DwDeployCheck(
     id: 'secret-files',
-    title: 'Declared secret files are delivered',
+    title: 'Declared secret files reach the application',
     stage: DwDeployCheckStage.remote,
     severity: DwCheckSeverity.error,
     requiresSsh: true,
@@ -208,37 +212,142 @@ Future<DwDeployVerdict> _checkRuntimeSecrets(DwDeployContext context) async {
   );
 }
 
+/// Whether a declared file is where the application will look for it.
+///
+/// "Is it on the server?" is the question this check used to ask, and it is
+/// not the one the deploy dies on. A file can be delivered to the runtime
+/// store, reported present, and still be invisible from inside the container —
+/// which is a green check standing directly in front of a red deploy, and
+/// worse than no check at all, because people read it.
+///
+/// So the answer comes from the configuration Compose itself will run: the
+/// rendered file on the server merged with the project's override, asked for
+/// on the server, with the file's own path in it. A bind mount of a file that
+/// exists is visibility; there is nothing further to establish.
+///
+/// It stops short of running a container. `docker compose run` builds the
+/// image when it is absent, which would turn a check into a ten-minute build,
+/// and probing the container that happens to be up answers about the *previous*
+/// deploy rather than the one about to happen.
 Future<DwDeployVerdict> _checkSecretFiles(DwDeployContext context) async {
-  final patterns = context.target.requiredSecretFiles;
-  if (patterns.isEmpty) {
+  final declared = context.target.requiredSecretFiles;
+  if (declared.isEmpty) {
     return const DwDeployVerdict.pass('none declared');
   }
 
-  final directory = context.target.runtimeConfigDir;
-  final result = await context.ssh!.runAs(
-    context.target.deployUser,
-    "ls -1 '$directory' 2>/dev/null || true",
-  );
-  final entries = result.stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .where((line) => line.isNotEmpty)
+  final store = DwSecretStore(ssh: context.ssh!, target: context.target);
+
+  // A mount names one path on each side, and the store is flat. An entry that
+  // is a pattern or a path can be delivered but never mounted, so it is a
+  // failure here rather than a surprise on the server.
+  final unmountable = declared
+      .where(
+        (name) =>
+            name.contains('*') || name.contains('?') || name.contains('/'),
+      )
       .toList();
-
-  final missing = patterns.where((pattern) {
-    final expression = RegExp(
-      '^${pattern.split('*').map(RegExp.escape).join('.*')}\$',
+  if (unmountable.isNotEmpty) {
+    return DwDeployVerdict.fail(
+      'not file names: ${unmountable.join(', ')}',
+      fix:
+          'Each requires.files entry names one file in the runtime store, and '
+          'that file is mounted into the container under the same name. '
+          'Name it exactly, the way "dartway deploy secret put-file" stored it.',
     );
-    return !entries.any(expression.hasMatch);
-  }).toList();
+  }
 
-  if (missing.isEmpty) {
-    return DwDeployVerdict.pass('${patterns.length} file(s) present');
+  final delivered = (await store.listFiles()).toSet();
+  final undelivered = declared
+      .where((name) => !delivered.contains(name))
+      .toList();
+  if (undelivered.isNotEmpty) {
+    return DwDeployVerdict.fail(
+      'missing in ${store.directory}: ${undelivered.join(', ')}',
+      fix: 'Deliver them with "dartway deploy secret put-file".',
+    );
+  }
+
+  final configuration = await context.ssh!.runAs(
+    context.target.deployUser,
+    DwComposeFiles.commandIn(context.target.appDir, 'config --no-interpolate'),
+  );
+  if (!configuration.ok) {
+    return DwDeployVerdict.fail(
+      'cannot read the compose configuration in ${context.target.appDir}: '
+      '${configuration.firstLine}',
+      fix:
+          'The deploy runs whatever this command prints, so until it answers, '
+          'nothing can be said about what the container will see. A server '
+          'with no rendered ${DwComposeFiles.rendered} needs '
+          '"dartway deploy setup --env ${context.target.environment}"; '
+          'otherwise the fault is in ${DwComposeFiles.projectOverride}, which '
+          'Compose merges over it.',
+    );
+  }
+
+  final Map<String, String> mounts;
+  try {
+    mounts = _backendMounts(configuration.stdout);
+  } on YamlException catch (error) {
+    return DwDeployVerdict.fail(
+      'the compose configuration is unreadable: ${error.message}',
+      fix:
+          'Report this: "docker compose config" produced something unexpected.',
+    );
+  }
+
+  final unmounted = declared
+      .where((name) => !mounts.containsKey('${store.directory}/$name'))
+      .toList();
+  if (unmounted.isEmpty) {
+    final where = declared
+        .map((name) => '$name -> ${mounts['${store.directory}/$name']}')
+        .join(', ');
+    return DwDeployVerdict.pass('${declared.length} file(s) mounted: $where');
   }
   return DwDeployVerdict.fail(
-    'missing in $directory: ${missing.join(', ')}',
-    fix: 'Deliver them with "dartway deploy secret put-file".',
+    'delivered but not mounted into the backend: ${unmounted.join(', ')}',
+    fix:
+        'The file is on the server and the container cannot see it, which is '
+        'the shape of a deploy that passes every check and then dies applying '
+        'migrations. The rendered ${DwComposeFiles.rendered} on the server '
+        'predates the mount — re-render it with "dartway deploy setup --env '
+        '${context.target.environment}", which is idempotent and safe on a '
+        'live server. Each declared file is then mounted read-only at '
+        '$dwContainerConfigDir/<name>.',
   );
+}
+
+/// Bind-mount sources of the backend service, mapped to where they land inside
+/// the container, as Compose itself resolves them.
+///
+/// Both spellings are accepted: `docker compose config` normalises volumes to
+/// the long form, but a short `source:target:ro` string from an older Compose
+/// must not read as "nothing is mounted".
+Map<String, String> _backendMounts(String configuration) {
+  final document = loadYaml(configuration);
+  final services = document is YamlMap ? document['services'] : null;
+  final backend = services is YamlMap ? services['backend'] : null;
+  final volumes = backend is YamlMap ? backend['volumes'] : null;
+  final mounts = <String, String>{};
+  if (volumes is! YamlList) {
+    return mounts;
+  }
+  for (final entry in volumes) {
+    if (entry is YamlMap) {
+      final source = entry['source'];
+      final target = entry['target'];
+      if (source != null && target != null) {
+        mounts[source.toString()] = target.toString();
+      }
+    } else if (entry is String) {
+      final parts = entry.split(':');
+      if (parts.length >= 2) {
+        mounts[parts[0]] = parts[1];
+      }
+    }
+  }
+  return mounts;
 }
 
 /// Compares key names only. A routine check has no business moving secret

--- a/packages/dartway_cli/lib/src/deploy/renderer.dart
+++ b/packages/dartway_cli/lib/src/deploy/renderer.dart
@@ -49,7 +49,39 @@ class DwInfraRenderer {
     // after the API host, which is the one guaranteed to exist.
     DwTemplateToken.certName: serverpod.apiServer.publicHost ?? '',
     DwTemplateToken.registryPrefix: _registryPrefix,
+    DwTemplateToken.secretFileMounts: secretFileMounts,
   };
+
+  /// One read-only mount per file declared under `requires.files`.
+  ///
+  /// Appended to the `passwords.yaml` line rather than given a line of its
+  /// own, so a deployment declaring no files renders exactly the compose file
+  /// it rendered before.
+  String get secretFileMounts {
+    const indent = '\n      - ';
+    return [
+      for (final name in target.requiredSecretFiles)
+        '$indent${target.runtimeConfigDir}/${_mountable(name)}'
+            ':$dwContainerConfigDir/$name:ro',
+    ].join();
+  }
+
+  /// A declared file is mounted by name, so the name has to be one.
+  ///
+  /// The store is flat — `secret put-file` writes a basename into it — and a
+  /// bind mount names one path on each side. A pattern would render a mount
+  /// Docker takes literally, creating a directory called `*.json` inside the
+  /// container: the same silent failure one step further along.
+  String _mountable(String name) {
+    if (name.contains('*') || name.contains('?') || name.contains('/')) {
+      throw StateError(
+        'requires.files entry "$name" is not a file name. Each entry names one '
+        'file in the runtime store, and that file is what gets mounted into '
+        'the container; a pattern or a path cannot be.',
+      );
+    }
+    return name;
+  }
 
   /// Replaces every token and refuses to return text that still holds one.
   ///

--- a/packages/dartway_cli/lib/src/deploy/templates.dart
+++ b/packages/dartway_cli/lib/src/deploy/templates.dart
@@ -24,10 +24,19 @@ enum DwTemplateToken {
   webServerDomain,
   webAppDomain,
   certName,
-  registryPrefix;
+  registryPrefix,
+  secretFileMounts;
 
   String get placeholder => '__${name.toUpperCase()}__';
 }
+
+/// Where the server image keeps its configuration, and therefore where the
+/// runtime store's files are mounted.
+///
+/// The image works from `/app` and reads its configuration from `/app/config`,
+/// so a file mounted here is reached as `config/<name>` by the application
+/// without a path having to be configured anywhere.
+const String dwContainerConfigDir = '/app/config';
 
 /// The compose file every DartWay deployment starts from.
 ///
@@ -75,8 +84,12 @@ services:
       - "__APIPORT__"
       - "__INSIGHTSPORT__"
       - "__WEBSERVERPORT__"
+    # Every file declared under `requires.files` in deploy/config.yaml is
+    # mounted here beside passwords.yaml. Delivering one to the server is only
+    # half of it: a file the container cannot see is a file the application
+    # does not have.
     volumes:
-      - __RUNTIMECONFIGDIR__/passwords.yaml:/app/config/passwords.yaml:ro
+      - __RUNTIMECONFIGDIR__/passwords.yaml:/app/config/passwords.yaml:ro__SECRETFILEMOUNTS__
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/dartway_cli/test/deploy_compose_files_test.dart
+++ b/packages/dartway_cli/test/deploy_compose_files_test.dart
@@ -1,0 +1,367 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/deploy/compose_files.dart';
+import 'package:dartway_cli/src/deploy/deploy_check.dart';
+import 'package:dartway_cli/src/deploy/deploy_runner.dart';
+import 'package:dartway_cli/src/deploy/deploy_target.dart';
+import 'package:dartway_cli/src/deploy/remote_checks.dart';
+import 'package:dartway_cli/src/deploy/renderer.dart';
+import 'package:dartway_cli/src/deploy/serverpod_config.dart';
+import 'package:dartway_cli/src/deploy/ssh_runner.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// An SSH runner that answers from a script instead of a server.
+///
+/// Matched by substring, in declaration order: a deploy command is a shell
+/// one-liner, and what a test cares about is the fragment it contains.
+class _ScriptedSsh extends DwSshRunner {
+  _ScriptedSsh(this.answers)
+    : super(host: '203.0.113.10', user: 'root', identityFile: null);
+
+  final List<(String, DwSshResult)> answers;
+  final List<String> issued = [];
+
+  @override
+  Future<DwSshResult> run(String command) async {
+    issued.add(command);
+    for (final (fragment, result) in answers) {
+      if (command.contains(fragment)) {
+        return result;
+      }
+    }
+    return const DwSshResult(exitCode: 0, stdout: '', stderr: '');
+  }
+
+  @override
+  Future<DwSshResult> runAs(String deployUser, String command) => run(command);
+}
+
+DwSshResult _ok(String stdout) =>
+    DwSshResult(exitCode: 0, stdout: stdout, stderr: '');
+
+DwSshResult _failed(String stderr) =>
+    DwSshResult(exitCode: 1, stdout: '', stderr: stderr);
+
+DwDeployTarget _target({List<String> files = const []}) => DwDeployTarget(
+  environment: 'staging',
+  host: '203.0.113.10',
+  sshUser: 'root',
+  deployUser: 'deployer',
+  os: 'ubuntu',
+  repo: 'git@github.com:acme/shop.git',
+  branch: 'master',
+  sslEmail: 'ops@example.com',
+  webAppDomain: 'app.example.com',
+  requiredSecretFiles: files,
+);
+
+DwServerpodConfig _serverpod() => DwServerpodConfig(
+  environment: 'staging',
+  relativePath: 'shop_server/config/staging.yaml',
+  apiServer: DwServerEndpoint(
+    name: 'apiServer',
+    port: 8080,
+    publicHost: 'api.example.com',
+    publicPort: 443,
+    publicScheme: 'https',
+  ),
+  insightsServer: null,
+  webServer: null,
+  databaseHost: 'postgres',
+  databasePort: 5432,
+  databaseName: 'shop',
+  databaseUser: 'shop',
+  redisEnabled: false,
+  redisHost: null,
+);
+
+/// The compose configuration a server answers with, given the mounts of the
+/// backend service.
+String _composeConfiguration(List<String> mounts) =>
+    '''
+name: shop
+services:
+  backend:
+    volumes:
+${mounts.map((mount) => '      - type: bind\n        source: ${mount.split(':').first}\n        target: ${mount.split(':')[1]}\n        read_only: true').join('\n')}
+''';
+
+void main() {
+  const store = '/home/deployer/.config/shop';
+  const appDir = '/home/deployer/shop';
+
+  group('the compose command names the project override', () {
+    test('every deploy step passes deploy/compose.override.yml', () async {
+      final ssh = _ScriptedSsh(const []);
+      final runner = DwDeployRunner(
+        ssh: ssh,
+        target: _target(),
+        serverpod: _serverpod(),
+        stdout: stdout,
+      );
+
+      await runner.build();
+      await runner.applyMigrations();
+      await runner.up();
+      await runner.restartProxy();
+      await runner.status();
+
+      expect(ssh.issued, hasLength(5));
+      for (final command in ssh.issued) {
+        expect(command, contains("cd '$appDir'"));
+        expect(command, contains('-f docker-compose.yml'));
+        expect(command, contains('-f deploy/compose.override.yml'));
+      }
+    });
+
+    test('the override is used only when the checkout carries one', () {
+      // Naming a file that is not there makes Compose refuse to run at all,
+      // so the flag is added by the server, not assumed here.
+      expect(
+        DwComposeFiles.commandIn(appDir, 'build'),
+        contains("if [ -f 'deploy/compose.override.yml' ]"),
+      );
+    });
+
+    test('migrations still read their stdin from nowhere', () async {
+      final ssh = _ScriptedSsh(const []);
+      await DwDeployRunner(
+        ssh: ssh,
+        target: _target(),
+        serverpod: _serverpod(),
+        stdout: stdout,
+      ).applyMigrations();
+
+      expect(ssh.issued.single, endsWith('</dev/null'));
+    });
+  });
+
+  group('retiring the copy an older setup left behind', () {
+    test('a deployment always offers to move it aside', () {
+      final steps = DwDeployRunner(
+        ssh: _ScriptedSsh(const []),
+        target: _target(),
+        serverpod: _serverpod(),
+        stdout: stdout,
+      ).steps(skipGitUpdate: true);
+
+      expect(steps.first.id, 'retire-override-copy');
+    });
+
+    test('is idempotent, and a no-op where the copy never existed', () async {
+      // Shell is the only place this can be judged: the whole point is what
+      // happens on a server that has the file, and on one that never did.
+      try {
+        Process.runSync('sh', ['-c', 'true']);
+      } on ProcessException {
+        markTestSkipped('no POSIX shell on this machine');
+        return;
+      }
+
+      final root = Directory.systemTemp.createTempSync('dw_override_');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final dir = root.path.replaceAll(r'\', '/');
+      final script = DwComposeFiles.retireLegacyCopyIn(dir);
+
+      // A server that never had the copy.
+      final clean = Process.runSync('sh', ['-c', script]);
+      expect(clean.exitCode, 0);
+      expect(clean.stdout.toString().trim(), isEmpty);
+
+      // A server that has one, twice over.
+      File(
+        p.join(root.path, DwComposeFiles.legacyCopy),
+      ).writeAsStringSync('services:\n  backend:\n    restart: always\n');
+
+      final first = Process.runSync('sh', ['-c', script]);
+      expect(first.exitCode, 0);
+      expect(first.stdout.toString(), contains('Retired'));
+
+      final second = Process.runSync('sh', ['-c', script]);
+      expect(second.exitCode, 0);
+      expect(second.stdout.toString().trim(), isEmpty);
+
+      expect(
+        File(p.join(root.path, DwComposeFiles.legacyCopy)).existsSync(),
+        isFalse,
+      );
+      expect(
+        File(p.join(root.path, DwComposeFiles.retiredCopy)).readAsStringSync(),
+        contains('restart: always'),
+      );
+    });
+  });
+
+  group('requires.files becomes a mount', () {
+    String render({List<String> files = const []}) => DwInfraRenderer(
+      projectRoot: Directory.systemTemp,
+      target: _target(files: files),
+      serverpod: _serverpod(),
+      serverPackage: 'shop_server',
+      flutterPackage: 'shop_flutter',
+    ).composeFile;
+
+    test('a declared file is mounted read-only beside passwords.yaml', () {
+      final compose = render(files: ['firebase-service-account.json']);
+
+      expect(
+        compose,
+        contains(
+          '- $store/firebase-service-account.json:'
+          '/app/config/firebase-service-account.json:ro',
+        ),
+      );
+    });
+
+    test('declaring nothing renders the compose file unchanged', () {
+      expect(
+        render(),
+        contains(
+          '- $store/passwords.yaml:/app/config/passwords.yaml:ro\n'
+          '    depends_on:',
+        ),
+      );
+    });
+
+    test('a pattern is refused rather than mounted literally', () {
+      expect(
+        () => render(files: ['*.json']),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('is not a file name'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('the secret-files check asks whether the container sees the file', () {
+    final check = dwRemoteDeployChecks.firstWhere(
+      (c) => c.id == 'secret-files',
+    );
+
+    DwDeployContext contextWith(
+      DwSshRunner ssh, {
+      List<String> files = const [],
+    }) => DwDeployContext(
+      projectRoot: Directory.systemTemp,
+      serverPackage: 'shop_server',
+      flutterPackage: 'shop_flutter',
+      target: _target(files: files),
+      serverpod: _serverpod(),
+      ssh: ssh,
+    );
+
+    test(
+      'passes when the delivered file is mounted into the backend',
+      () async {
+        final ssh = _ScriptedSsh([
+          ("ls -1 '$store'", _ok('passwords.yaml\nfirebase.json\n')),
+          (
+            'config --no-interpolate',
+            _ok(
+              _composeConfiguration([
+                '$store/passwords.yaml:/app/config/passwords.yaml',
+                '$store/firebase.json:/app/config/firebase.json',
+              ]),
+            ),
+          ),
+        ]);
+
+        final verdict = await check.evaluate(
+          contextWith(ssh, files: ['firebase.json']),
+        );
+
+        expect(verdict.passed, isTrue);
+        expect(verdict.detail, contains('/app/config/firebase.json'));
+      },
+    );
+
+    // The bug this check exists for: green on "the file is on the server",
+    // red on "the application can find it".
+    test('fails when the file is on the server but mounted nowhere', () async {
+      final ssh = _ScriptedSsh([
+        ("ls -1 '$store'", _ok('passwords.yaml\nfirebase.json\n')),
+        (
+          'config --no-interpolate',
+          _ok(
+            _composeConfiguration([
+              '$store/passwords.yaml:/app/config/passwords.yaml',
+            ]),
+          ),
+        ),
+      ]);
+
+      final verdict = await check.evaluate(
+        contextWith(ssh, files: ['firebase.json']),
+      );
+
+      expect(verdict.passed, isFalse);
+      expect(verdict.detail, contains('not mounted'));
+      expect(verdict.fix, contains('dartway deploy setup'));
+    });
+
+    test(
+      'asks Compose the question with the project override in hand',
+      () async {
+        final ssh = _ScriptedSsh([
+          ("ls -1 '$store'", _ok('firebase.json\n')),
+          ('config --no-interpolate', _ok(_composeConfiguration(const []))),
+        ]);
+
+        await check.evaluate(contextWith(ssh, files: ['firebase.json']));
+
+        final configuration = ssh.issued.last;
+        expect(configuration, contains('-f deploy/compose.override.yml'));
+        expect(configuration, contains("cd '$appDir'"));
+      },
+    );
+
+    test('reports an undelivered file before anything else', () async {
+      final ssh = _ScriptedSsh([("ls -1 '$store'", _ok('passwords.yaml\n'))]);
+
+      final verdict = await check.evaluate(
+        contextWith(ssh, files: ['firebase.json']),
+      );
+
+      expect(verdict.passed, isFalse);
+      expect(verdict.fix, contains('put-file'));
+    });
+
+    test('a configuration it cannot read is a failure, not a pass', () async {
+      final ssh = _ScriptedSsh([
+        ("ls -1 '$store'", _ok('firebase.json\n')),
+        (
+          'config --no-interpolate',
+          _failed('no configuration file provided: not found'),
+        ),
+      ]);
+
+      final verdict = await check.evaluate(
+        contextWith(ssh, files: ['firebase.json']),
+      );
+
+      expect(verdict.passed, isFalse);
+      expect(verdict.detail, contains('cannot read the compose configuration'));
+    });
+
+    test('declaring nothing is not a finding', () async {
+      final verdict = await check.evaluate(contextWith(_ScriptedSsh(const [])));
+
+      expect(verdict.passed, isTrue);
+      expect(verdict.detail, 'none declared');
+    });
+
+    test('a pattern cannot be mounted, and says so', () async {
+      final verdict = await check.evaluate(
+        contextWith(_ScriptedSsh(const []), files: ['*.json']),
+      );
+
+      expect(verdict.passed, isFalse);
+      expect(verdict.detail, contains('not file names'));
+    });
+  });
+}

--- a/template/dartway_starter_server/Dockerfile
+++ b/template/dartway_starter_server/Dockerfile
@@ -21,8 +21,10 @@ RUN apk add --no-cache ca-certificates
 
 WORKDIR /app
 COPY --from=build /server /app/server
-# The Serverpod configuration is source, not something the deploy renders; only
-# passwords.yaml is mounted over this directory at runtime.
+# The Serverpod configuration is source, not something the deploy renders. What
+# arrives over this directory at runtime comes from the server's secret store:
+# passwords.yaml, and every file named under `requires.files` in
+# deploy/config.yaml, each mounted read-only under its own name.
 COPY --from=build /workspace/dartway_starter_server/config/ /app/config/
 COPY --from=build /workspace/dartway_starter_server/web/ /app/web/
 COPY --from=build /workspace/dartway_starter_server/migrations/ /app/migrations/

--- a/template/deploy/README.md
+++ b/template/deploy/README.md
@@ -21,7 +21,7 @@ dartway deploy secret --help                # runtime secrets on the server
 | `../dartway_starter_server/config/<env>.yaml` | the **application**: domains, ports, database, Redis — read by the deploy, never written |
 | `../dartway_starter_server/Dockerfile` | the server image, built from the project root |
 | `../dartway_starter_flutter/Dockerfile` | the web image; the deploy passes it `DW_BACKEND_URL` |
-| `compose.override.yml` | anything this project adds to a standard deployment — create it when that happens |
+| `compose.override.yml` | anything this project adds to a standard deployment — create it when that happens. Read from the checkout on every deploy, so a committed change to it takes effect on the next `run` |
 | `nginx.d/{http,api,app}/*.conf` | extra Nginx directives, if any are ever needed |
 
 A domain appears in exactly one of the first two, and `dartway deploy check`
@@ -32,7 +32,9 @@ domain down a second time, and `check` warns about it.
 
 `docker-compose.yml` and `nginx.conf` are rendered by `setup` on the server and
 are not part of this repository — a deploy that re-renders infrastructure on
-every push turns a routine change into an infrastructure one.
+every push turns a routine change into an infrastructure one. `compose.override.yml`
+is the opposite: it is never copied to the server, only named on every Compose
+call, so the file the deploy merges is the committed one.
 
 ## Secrets
 
@@ -42,6 +44,13 @@ environment needs is `passwords.yaml.example`. Values for a deployed
 environment live on the server, outside the checkout, so the `git reset --hard`
 a deploy performs cannot touch them; `dartway deploy secret push/pull` moves
 them between the two.
+
+A credential that is a whole file — a service-account JSON, an `.env` for some
+integration — goes to the server with `dartway deploy secret put-file` and is
+named under `requires.files` in `config.yaml`. The deploy mounts each declared
+file read-only at `/app/config/<name>` in the server container, so the
+application reads it as `config/<name>`, and `dartway deploy check` asserts that
+the mount is really there rather than only that the file reached the machine.
 
 > `serviceSecret` is also the key other credentials are encrypted with, where a
 > project encrypts any. Rotating it makes them unreadable. Rotate deliberately.

--- a/template/deploy/config.yaml.example
+++ b/template/deploy/config.yaml.example
@@ -40,6 +40,12 @@ staging:
   # Optional. Credentials nobody can generate — an API token, a service account
   # file. Listing them turns "the container starts and immediately dies" into a
   # pre-deploy error.
+  #
+  # `files` are delivered with `dartway deploy secret put-file` and mounted
+  # read-only into the server container at /app/config/<name>, beside
+  # passwords.yaml — so the application reaches one as `config/<name>`. Each
+  # entry is a file name exactly as the store holds it: a pattern or a path
+  # cannot be mounted, and is refused rather than rendered.
   # requires:
   #   secrets:
   #     - firebaseServiceAccountKey


### PR DESCRIPTION
Two bugs, fixed together because the second hides the first: a project that
worked around the first by editing its compose override watched the workaround
do nothing, and spent two deploys finding out why.

**A file declared in `requires.files` was delivered, checked, and never
mounted.** `secret put-file` put it on the server, `deploy check` confirmed it
was there, and the rendered compose file mounted exactly one thing —
`passwords.yaml`. Twenty-one checks passed and the deploy died applying
migrations, because the application could not find a file that was demonstrably
on the machine. Every declared file is now mounted read-only beside
`passwords.yaml`.

**The check asked the wrong question, and that is the more expensive half.** "Is
the file on the server?" is not "can the application see it?", and a check that
is green where the deploy is red is worse than no check: people read it and stop
looking. It now asks the server for the configuration Compose will actually run
and looks for the file among the backend's mounts. It stops short of starting a
container deliberately — `compose run` builds the image when it is absent, which
would turn a check into a ten-minute build, and probing the container that
happens to be up answers about the previous deploy rather than the one about to
happen.

**`run` deployed a setup-time copy of the project's override.** `setup` copied
`deploy/compose.override.yml` to the name Compose loads on its own, nothing ever
refreshed it, and the deploy silently preferred it over the committed file. The
copy existed so that no later call had to remember a `-f` flag — but there is
nobody to forget it, since every Compose invocation is built by the CLI in one
place. It is built in one place now for real, and the checkout is the only copy.

**A server that already carries the leftover gets it retired** — renamed rather
than deleted, by `setup` and by `run` alike. Deleting is what you want for a
stale copy of a committed file, and wrong for the hand edit somebody made while
debugging; renaming ends the silence either way. A server that never had one
says nothing.

Two things the issues did not name. `setup` had a second `docker compose` call —
the TLS bootstrap — which now shares the same file selection, so `setup` and
`run` cannot disagree about which override is in force. And `requires.files`
silently accepted glob patterns: nothing documented it, the store holds
basenames, and a bind mount needs one path on each side, so a pattern rendered a
mount Docker satisfies with a directory called `*.json`. Patterns are refused at
render time now. A deployment that declared one was already broken in the way
this commit describes; its check will start failing, correctly.

Closes #91
Closes #92

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
