### PR TITLE
fix(deploy): a redeploy reaches the browser, and a secret document travels as a file

### DIFF
--- a/docs/4-server/push-delivery.md
+++ b/docs/4-server/push-delivery.md
@@ -69,6 +69,49 @@ dozen numbers you don't understand. The one knob worth knowing is
 `maxConcurrentDeliveries`: each in-flight send holds a database connection for
 the whole provider round-trip, so keep it a small fraction of your Postgres pool.
 
+## Where the credentials come from
+
+**Short values are passwords; a whole document is a file.** `fcmProjectId`,
+`rustorePushProjectId` and `rustorePushServiceToken` are a line each and live in
+`passwords.yaml`, delivered with `dartway deploy secret set`. FCM's service
+account is a couple of thousand characters of JSON and is not a password key at
+all: it goes to the server with `dartway deploy secret put-file`, is named under
+`requires.files` in `deploy/config.yaml`, and is read from
+`config/fcm-service-account.json` — a relative path that means the same file
+locally and inside the container, where the deploy mounts every declared file at
+`/app/config/<name>`.
+
+That is not tidiness. A document in `passwords.yaml` is a document in the master
+copy of **every** environment's secrets, and it has a silent failure attached:
+the value begins with `{`, so unquoted YAML parses it as a flow mapping rather
+than as a string, and what reaches the provider is not what was written.
+
+```yaml
+# <project>_server/config/passwords.yaml.example
+staging:
+  # Naming this key is what declares that this environment sends push. The
+  # credential itself is a file: `dartway deploy secret put-file
+  # fcm-service-account.json`, listed under requires.files in
+  # deploy/config.yaml.
+  fcmProjectId:
+```
+
+## Half-configuration is loud
+
+A provider's project id is its **declaration**. Once it is set, everything else
+that provider needs must be there too, or the config constructor throws
+`DwPushProviderConfigurationException` and the server does not start — naming
+what is missing and where it was looked for. A service account that is not a
+JSON object is refused the same way, so a truncated upload or a YAML value that
+lost its quotes is caught at boot rather than at the first send.
+
+`isConfigured == false` used to be the answer both to "we do not send push here"
+and to "the key never reached this environment". From inside a running server
+those are indistinguishable, and the second is normally discovered weeks later
+by somebody asking why a notification never arrived. An environment that
+genuinely wants no push declares nothing — no project id, no file — and
+`isConfigured` is false without anybody being misled.
+
 ## The domain seam
 
 Two objects carry your domain into the engine, and for most apps neither is much

--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -261,12 +261,12 @@ data volume under a different name than the rendered configuration would use, it
 instead of starting the stack — Compose would otherwise create an empty database beside the real one
 and serve it, which looks like a successful deploy of an application that has lost everything.
 
-`check` changes nothing and answers whether a deployment would work. Thirteen assertions on the
-working copy, seven over the network — including that every `publicHost` resolves to the deployment
+`check` changes nothing and answers whether a deployment would work. Fourteen assertions on the
+working copy, eight over the network — including that every `publicHost` resolves to the deployment
 host, which is the mistake that otherwise burns a Let's Encrypt rate limit before anyone notices.
 With the server unreachable it degrades: the SSH check fails, the rest report as skipped.
 
-Two of the local assertions are about the images. The rendered compose file builds both of them
+Two of the local assertions are about whether the images build at all. The rendered compose file builds both of them
 from the project root — `<project>_server/Dockerfile` and `<project>_flutter/Dockerfile`, named by
 convention rather than configured — so a project that never wrote one fails on the server, after the
 checkout has already moved. The other is the shape of the server image's `ENTRYPOINT`: migrations
@@ -279,6 +279,38 @@ The web image gets one build argument, `DW_BACKEND_URL`, and it comes from `publ
 Serverpod configuration. A web build compiles the API address into itself, so something has to
 supply it — having the deploy do it is what keeps the domain written down once. The template's
 `main.dart` reads it through `String.fromEnvironment` and falls back to localhost for a local run.
+
+**What the web image is allowed to let a browser keep is the other half of that image, and it fails
+silently.** A Flutter web build hashes nothing: `index.html`, `flutter_bootstrap.js`, `flutter.js`,
+`main.dart.js`, `main.dart.wasm` and everything under `assets/` are named identically in every
+build. The rule everyone reaches for — "fingerprinted assets are immutable, cache them for a year"
+— is correct for a bundler that puts a content hash in the name, and lands here on precisely the
+files that change on every deploy. A browser that took one under a long `max-age` does not ask
+again: it keeps running the previous build while the server serves the new one, with nothing to
+see on either side. It is the shape of failure a deploy cannot report, because from the deploy's
+point of view everything worked.
+
+So the template ships the serving configuration rather than leaving each project to invent one —
+`<project>_flutter/nginx.conf`, copied into the image by the Dockerfile beside it. It serves
+everything a build emits with `Cache-Control: no-cache` (the copy is kept and merely has to be
+confirmed, which with an ETag is a 304 rather than a download) and reserves the long-lived,
+immutable rule for names that genuinely carry a content hash.
+
+Two assertions guard it, and they ask different questions. `web-cache-policy` reads the
+configuration the web image is built with — the file it copies, or a heredoc written straight into
+the Dockerfile — resolves each Flutter entry point through Nginx's own `location` precedence, and
+warns when one of them would be served for reuse without revalidation. It warns rather than
+blocks: reading configuration text can miss an include outside the build context or a header some
+front proxy adds. `web-cache-headers` asks the deployed site itself, over HTTPS, exactly as a
+browser would, and errors on what it actually receives — there is nothing left to interpret in a
+response header. A path that answers 404 is not part of that build and says nothing about caching.
+
+**Fixing the configuration does not reach a browser that already holds a copy.** A response taken
+under `max-age=2592000` stays fresh there for the rest of the thirty days and the browser will not
+ask; no server-side change is capable of reaching it. Tell whoever you can reach to hard-reload or
+clear site data, and for the rest either wait the window out or move the app to a URL that was
+never poisoned. That asymmetry — cheap to prevent, impossible to revoke — is why these two
+assertions exist at all.
 
 `deploy/compose.override.yml` is where a project adds what a standard deployment does not have, and
 a third local assertion guards the one thing that does not belong in it: a `build` block for the
@@ -319,7 +351,7 @@ The rest are the flags worth knowing before you need them:
 | Subcommand | Flag | What it is for |
 |---|---|---|
 | `setup` | `--dry-run` | Print the rendered `docker-compose.yml` and `nginx.conf`, and what would be uploaded beside them, without touching the server. The way to review a template change |
-| `check` | `--local` | Skip DNS and the server; assert over the working copy only. The form that needs no SSH key and no host yet — the thirteen working-copy assertions still run, the seven network ones report as skipped |
+| `check` | `--local` | Skip DNS and the server; assert over the working copy only. The form that needs no SSH key and no host yet — the fourteen working-copy assertions still run, the eight network ones report as skipped |
 | `run` | `--dry-run` | Print the plan and change nothing |
 | `run` | `--skip-git-update` | Deploy what is already checked out on the server, without fetching. For a rebuild of the same commit — and the flag to suspect when a deploy "did not pick up" a push |
 | `secret push` | `--dry-run` | Report what would be sent, send nothing |
@@ -334,8 +366,8 @@ The rest are the flags worth knowing before you need them:
 | `host`, `ssh_user`, `deploy_user`, `os` | always |
 | `repo`, `branch` | always |
 | `ssl_email`, `web_app_domain` | always |
-| `requires.secrets` | to have `check` catch a credential nobody delivered |
-| `requires.files` | a credential that is a whole file. Each entry is delivered with `secret put-file` and **mounted read-only at `/app/config/<name>`** in the server container, beside `passwords.yaml` — the application reads it as `config/<name>`. `check` asserts the mount, not the delivery: it asks the server for the configuration Compose will actually run and looks for the file in it, because "the file is on the machine" is green exactly where the deploy is red. An entry is a file name, not a pattern or a path — a mount names one path on each side |
+| `requires.secrets` | to have `check` catch a credential nobody delivered. Short values only — a token, an identifier, a password |
+| `requires.files` | a credential that is a whole document — a service-account JSON, an `.env` for an integration. It belongs here rather than in `passwords.yaml` whatever its length: that file is the master copy of every environment's secrets, and an unquoted value starting with `{` is read by YAML as a mapping rather than as text. Each entry is delivered with `secret put-file` and **mounted read-only at `/app/config/<name>`** in the server container, beside `passwords.yaml` — the application reads it as `config/<name>`, the same path it reads locally. `check` asserts the mount, not the delivery: it asks the server for the configuration Compose will actually run and looks for the file in it, because "the file is on the machine" is green exactly where the deploy is red. An entry is a file name, not a pattern or a path — a mount names one path on each side |
 | `registry_mirror` | pulling base images through a mirror |
 | `firewall_ports` | a port beyond SSH, 80 and 443 |
 | `server_entrypoint` | only when the Dockerfile declares `ENTRYPOINT` in shell form — that form ignores the arguments `docker compose run` appends, so migrations would silently start an ordinary server instead. Setting it is also what tells `check` the shell form is deliberate |

--- a/example/dartway_example_flutter/Dockerfile
+++ b/example/dartway_example_flutter/Dockerfile
@@ -24,34 +24,11 @@ FROM nginx:alpine
 
 COPY --from=build /workspace/dartway_example_flutter/build/web /usr/share/nginx/html
 
-# This server block serves the build inside the container; the deployment's own
-# Nginx sits in front of it and terminates TLS.
-COPY <<'EOF' /etc/nginx/conf.d/default.conf
-server {
-  listen 80;
-  root /usr/share/nginx/html;
-  index index.html;
-
-  # A Flutter route is not a file: everything unknown is answered by the app.
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
-
-  location ~* \.(png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-  }
-
-  # The build's own files change on every deploy and carry no hash in the name,
-  # so a cached copy is a stale app that nobody can refresh out of.
-  location ~* \.(js|css|json|wasm)$ {
-    add_header Cache-Control "no-cache";
-  }
-
-  location = /index.html {
-    add_header Cache-Control "no-cache";
-  }
-}
-EOF
+# How the build is served, and above all what a browser may keep. A file of its
+# own rather than a heredoc: the caching split is the part of a deployment that
+# fails silently — a stale entry point serves the previous build to a browser
+# that never asks again — so it has to be readable, diffable, and something
+# `dartway deploy check` can interrogate.
+COPY dartway_example_flutter/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/example/dartway_example_flutter/nginx.conf
+++ b/example/dartway_example_flutter/nginx.conf
@@ -1,0 +1,54 @@
+# How the Flutter web build is served inside the `web` container. The
+# deployment's own Nginx sits in front of this one and terminates TLS; what is
+# decided here is what a browser is allowed to keep.
+#
+# **A Flutter web build hashes nothing.** `index.html`, `flutter_bootstrap.js`,
+# `flutter.js`, `main.dart.js`, `main.dart.wasm`, `flutter_service_worker.js`
+# and everything under `assets/` carry the same name in every build. The usual
+# "fingerprinted assets are immutable, cache them for a year" rule therefore
+# lands on exactly the files that change on every deploy: a browser that took
+# one under a long `max-age` does not ask again, so it keeps running the
+# previous build and no server-side change reaches it. Nothing in the deploy
+# reports this — the server serves the new bundle and the browser never
+# requests it.
+#
+# So the default here is revalidation, and the long-lived rule is narrowed to
+# paths that genuinely carry a content hash in the name.
+#
+# `dartway deploy check` reads this file and probes the deployed site for the
+# same property. Edit it deliberately.
+
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # What makes revalidation cheap: the browser asks, the server answers 304,
+  # and nothing is transferred. Without a validator, "no-cache" would mean a
+  # full download on every navigation.
+  etag on;
+
+  # A Flutter route is not a file: everything unknown is answered by the app.
+  #
+  # "no-cache" is not "no-store" — the copy is kept, it just may not be reused
+  # before the server has confirmed it. That is the correct policy for every
+  # file a Flutter build emits, because every one of them can change under the
+  # same name.
+  location / {
+    try_files $uri $uri/ /index.html;
+    add_header Cache-Control "no-cache";
+  }
+
+  # The one long-lived exception: a name that carries a content hash, which is
+  # only ever produced by a build step this project added — `app.9f2b1c4e.js`
+  # and the like. Such a URL changes when the bytes change, so the copy a
+  # browser holds can never be the wrong one.
+  #
+  # Quoted because the pattern contains braces, which Nginx would otherwise
+  # read as block delimiters. A project whose fingerprints look different
+  # (a dash, base32, a query parameter) edits the pattern here rather than
+  # widening the rule above.
+  location ~* "\.[0-9a-f]{8,}\.(js|css|wasm|json|png|jpe?g|gif|svg|webp|avif|ico|woff2?|otf|ttf)$" {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+}

--- a/example/dartway_example_server/lib/src/dartway/dartway_core.dart
+++ b/example/dartway_example_server/lib/src/dartway/dartway_core.dart
@@ -151,6 +151,14 @@ void initDartwayCore({
 /// Returns `null` — no engine, no worker — when the example has no FCM or
 /// RuStore credentials, which is the default. Because push is a separate module,
 /// an app that omits the dependency gets none of the `dw_push_*` tables at all.
+///
+/// Credentials arrive from two places, split by shape. `fcmProjectId` and the
+/// RuStore pair are short values and come out of `passwords`; FCM's service
+/// account is a whole JSON document and is read from
+/// `config/fcm-service-account.json`, which the deploy mounts into the
+/// container from the runtime store. Naming a project id is what declares that
+/// an environment sends push at all — declare it with the credential missing
+/// and the server refuses to start rather than going quietly silent.
 DwPush? _buildDwPush(Map<String, String> passwords) {
   final fcmConfig = DwFcmPushProviderConfig.fromPasswords(passwords);
   final ruStoreConfig = DwRuStorePushProviderConfig.fromPasswords(passwords);

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: "../../packages/dartway_push/dartway_push_server"
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   dartway_serverpod_core_server:
     dependency: "direct main"
     description:

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## 0.8.0
 
+- **The deploy templates now ship the configuration that serves a Flutter web build, and it caches
+  by what is actually hashed.** Nothing was shipped before, so every project wrote its own, and what
+  they wrote applied the rule everybody knows — "fingerprinted assets are immutable, cache them for
+  a year" — to a build that fingerprints nothing. `index.html`, `flutter_bootstrap.js`, `flutter.js`,
+  `main.dart.js`, `main.dart.wasm` and every file under `assets/` are named identically in every
+  build, so the immutable rule landed on precisely the files that change on every deploy. A browser
+  that took one under a long `max-age` never asks again: it goes on running the previous build while
+  the server serves the new one. In the reported case the served bundle carried a newer bridge
+  protocol and the browser ran the older one — half a day of diagnosis, and the expensive part was
+  the silence, since every check anyone thought to run said the right thing.
+
+  `<project>_flutter/nginx.conf` is now a file of its own beside the Dockerfile that copies it. It
+  serves everything a build emits with `Cache-Control: no-cache` — the copy is kept and merely has
+  to be confirmed, which with an ETag costs a 304 rather than a download — and keeps the long-lived,
+  immutable rule for names that genuinely carry a content hash.
+
+- **Two new assertions, and they ask different questions.** `web-cache-policy` (local, warning)
+  reads the configuration the web image is built with — the file it copies, or a heredoc written
+  straight into the Dockerfile, so a project that never split it out is judged too — resolves every
+  Flutter entry point through Nginx's own `location` precedence, and reports the ones that would be
+  served for reuse without revalidation. It warns rather than blocks, because reading configuration
+  text can miss an `include` outside the build context or a header a front proxy adds.
+  `web-cache-headers` (remote, error) asks the deployed site over HTTPS, exactly as a browser would,
+  and judges the header it was actually handed; a path answering 404 is not part of that build and
+  says nothing about caching. Neither is satisfied by a file being present — the failure this is
+  about is a server serving the right thing to a browser that will not ask for it.
+
+  Both spell out the half a fix does not cover: a browser already holding a copy taken under
+  `max-age=2592000` stays that way for the rest of the thirty days, and no server-side change
+  reaches it. Hard-reload for whoever you can reach; for the rest, wait the window out or move the
+  app to a URL that was never poisoned.
+
+- `requires.secrets` and `requires.files` are documented as a split by **shape**, not by importance:
+  a short value is a password, a whole document is a file. `config.yaml.example` had been suggesting
+  the opposite — `firebaseServiceAccountKey` under `secrets` — which is how a couple of thousand
+  characters of service-account JSON end up in the master copy of every environment's secrets, where
+  an unquoted leading `{` is read by YAML as a mapping rather than as text.
+
 - **A file declared in `requires.files` is now mounted into the container, and `deploy check` asks
   whether the application can see it.** The mechanism was wired halfway: `secret put-file` delivered
   the file, `check` confirmed it was on the server, and the rendered compose file mounted exactly one

--- a/packages/dartway_cli/lib/src/deploy/deploy_check.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_check.dart
@@ -7,6 +7,7 @@ import '../checker/dw_check_type.dart';
 import 'deploy_target.dart';
 import 'serverpod_config.dart';
 import 'ssh_runner.dart';
+import 'web_cache.dart';
 
 /// Where a check can run.
 ///
@@ -209,6 +210,17 @@ const List<DwDeployCheck> dwLocalDeployChecks = [
     stage: DwDeployCheckStage.local,
     severity: DwCheckSeverity.error,
     evaluate: _checkEntrypointForm,
+  ),
+  DwDeployCheck(
+    id: 'web-cache-policy',
+    title: 'The web image revalidates the files a build overwrites',
+    stage: DwDeployCheckStage.local,
+    // A reading of configuration text, and text can hide things from it — an
+    // `include` outside the build context, a header set by an entrypoint
+    // script. What was actually served is answered over the wire by
+    // "web-cache-headers", which is the one that errors.
+    severity: DwCheckSeverity.warning,
+    evaluate: _checkWebCachePolicy,
   ),
   DwDeployCheck(
     id: 'override-web-build',
@@ -548,3 +560,81 @@ Future<DwDeployVerdict> _checkDockerContext(DwDeployContext context) async {
         'secrets — is sent to the Docker daemon on every build.',
   );
 }
+
+/// A redeploy that does not reach the browser, caught while it is still a line
+/// of configuration.
+///
+/// A Flutter web build hashes nothing: `main.dart.js`, `flutter_bootstrap.js`,
+/// `flutter.js` and everything under `assets/` are named identically in every
+/// build. So "fingerprinted assets are immutable, cache them for a year" — a
+/// correct rule elsewhere — lands here on precisely the files that change on
+/// every deploy, and a browser that took one under a long `max-age` never asks
+/// again. The deploy succeeds, the server serves the new bundle, the browser
+/// runs the old one, and every check anyone thinks to run says the right thing.
+Future<DwDeployVerdict> _checkWebCachePolicy(DwDeployContext context) async {
+  final dockerfile = File(
+    p.join(context.projectRoot.path, context.flutterPackage, 'Dockerfile'),
+  );
+  if (!dockerfile.existsSync()) {
+    return const DwDeployVerdict.skip('no web Dockerfile');
+  }
+
+  final configuration = dwWebServingConfiguration(
+    projectRoot: context.projectRoot,
+    dockerfile: dockerfile,
+  );
+  if (configuration == null) {
+    return DwDeployVerdict.fail(
+      'the web image ships no serving configuration',
+      fix: _webCacheFix(context),
+    );
+  }
+
+  final policies = dwEntryPointPolicies(configuration);
+  final freely = policies.entries
+      .where((entry) => entry.value == DwCacheReuse.freely)
+      .map((entry) => entry.key)
+      .toList();
+  if (freely.isNotEmpty) {
+    return DwDeployVerdict.fail(
+      'cached without revalidation: ${freely.join(', ')}',
+      fix: _webCacheFix(context),
+    );
+  }
+
+  final unstated = policies.entries
+      .where((entry) => entry.value == DwCacheReuse.unstated)
+      .map((entry) => entry.key)
+      .toList();
+  if (unstated.isNotEmpty) {
+    return DwDeployVerdict.fail(
+      'no cache policy stated for: ${unstated.join(', ')}',
+      fix:
+          'Nothing here is wrong yet — with no Cache-Control the browser falls '
+          'back to a heuristic based on Last-Modified, which is short for a '
+          'file that has just been deployed. Nobody decided it, though, and '
+          'the first person to "add caching" reaches for the immutable '
+          'rule. ${_webCacheFix(context)}',
+    );
+  }
+
+  return DwDeployVerdict.pass(
+    '${policies.length} entry points revalidate before reuse',
+  );
+}
+
+String _webCacheFix(DwDeployContext context) =>
+    'Serve the build so that everything a Flutter build emits revalidates '
+    '("Cache-Control: no-cache" plus an ETag, which makes it a 304 rather than '
+    'a download) and reserve the long-lived, immutable rule for names that '
+    'genuinely carry a content hash. The canonical configuration ships with '
+    'the DartWay template as '
+    '${context.flutterPackage}/nginx.conf, copied into the image by the '
+    'Dockerfile beside it. '
+    'Fixing it does not un-poison a browser that already holds a copy: a '
+    'response taken under "max-age=2592000" stays fresh in that browser for the '
+    'rest of the thirty days and it will not ask. Tell the people you can reach '
+    'to hard-reload (Ctrl+Shift+R, or clear site data); for the ones you '
+    'cannot, either wait the window out or move the app to a URL that was never '
+    'poisoned — a URL the browser has not seen is the only thing that reaches '
+    'it.';

--- a/packages/dartway_cli/lib/src/deploy/remote_checks.dart
+++ b/packages/dartway_cli/lib/src/deploy/remote_checks.dart
@@ -8,6 +8,7 @@ import 'deploy_check.dart';
 import 'master_passwords_file.dart';
 import 'secret_store.dart';
 import 'templates.dart';
+import 'web_cache.dart';
 
 /// Checks that need the network: DNS, and the server itself over SSH.
 const List<DwDeployCheck> dwRemoteDeployChecks = [
@@ -65,6 +66,17 @@ const List<DwDeployCheck> dwRemoteDeployChecks = [
     severity: DwCheckSeverity.warning,
     requiresSsh: true,
     evaluate: _checkSecretsMatchMaster,
+  ),
+  DwDeployCheck(
+    id: 'web-cache-headers',
+    title: 'The deployed web app tells browsers to revalidate its entry points',
+    stage: DwDeployCheckStage.remote,
+    // An observation, not a reading: this is the header the browser was
+    // actually handed. There is nothing left to interpret, so it errors.
+    severity: DwCheckSeverity.error,
+    // HTTP, not SSH — the question is what the site answers, and the answer is
+    // the same one a browser gets.
+    evaluate: _checkWebCacheHeaders,
   ),
 ];
 
@@ -389,5 +401,97 @@ Future<DwDeployVerdict> _checkSecretsMatchMaster(
         'Adopt what the server has with "dartway deploy secret pull", or make '
         'the server match with "dartway deploy secret push". A push would '
         'drop the server-only keys.',
+  );
+}
+
+/// What the deployed site actually tells a browser to do with the files a
+/// build overwrites.
+///
+/// The reading of the configuration text is `web-cache-policy`, and it is not
+/// the same question. A configuration can be right while a CDN, an
+/// `add_header` in the front proxy, or an image nobody rebuilt says something
+/// else — and it is the response header, not the file, that decides whether a
+/// redeploy reaches anybody. So this asks the site itself, over HTTPS, exactly
+/// as a browser would.
+///
+/// It stops short of comparing bodies between deploys: what is being judged is
+/// the policy, not the contents, and a policy is visible in one HEAD.
+Future<DwDeployVerdict> _checkWebCacheHeaders(DwDeployContext context) async {
+  final domain = context.target.webAppDomain;
+  final client = HttpClient()
+    ..connectionTimeout = const Duration(seconds: 10)
+    // The certificate is somebody else's check. Refusing here would make this
+    // one silently skip on a server that has just been provisioned and still
+    // carries the one-day self-signed certificate `setup` installs — which is
+    // the deployment most likely to be serving a configuration nobody has
+    // looked at yet.
+    ..badCertificateCallback = (_, _, _) => true;
+
+  final freely = <String>[];
+  final unstated = <String>[];
+  var answered = 0;
+  try {
+    for (final path in dwProbedEntryPoints) {
+      final String? cacheControl;
+      try {
+        final request = await client.headUrl(Uri.https(domain, path));
+        final response = await request.close().timeout(
+          const Duration(seconds: 15),
+        );
+        await response.drain<void>();
+        // 404 means this build does not emit that path — a `--wasm` build has
+        // no main.dart.js — and says nothing about caching.
+        if (response.statusCode != 200) {
+          continue;
+        }
+        cacheControl = response.headers.value(HttpHeaders.cacheControlHeader);
+      } on Exception {
+        continue;
+      }
+      answered++;
+      switch (dwCacheReuse(cacheControl: cacheControl)) {
+        case DwCacheReuse.freely:
+          freely.add('$path: $cacheControl');
+        case DwCacheReuse.unstated:
+          unstated.add(path);
+        case DwCacheReuse.revalidated:
+          break;
+      }
+    }
+  } finally {
+    client.close(force: true);
+  }
+
+  if (answered == 0) {
+    return DwDeployVerdict.skip('nothing answered on https://$domain/');
+  }
+  if (freely.isEmpty) {
+    final note = unstated.isEmpty
+        ? ''
+        : ' (no policy stated for ${unstated.join(', ')} — the browser '
+              'falls back to a heuristic of its own)';
+    return DwDeployVerdict.pass(
+      '$answered entry point(s) revalidate before reuse$note',
+    );
+  }
+  return DwDeployVerdict.fail(
+    'served for reuse without revalidation: ${freely.join('; ')}',
+    fix:
+        'A Flutter web build hashes nothing — these names are identical in '
+        'every build — so this is a browser being told to keep the current '
+        'bundle and not ask again. The next deploy will not reach it, and '
+        'nothing will report that: the server serves the new files, the '
+        'browser never requests them. Serve every path a build emits with '
+        '"Cache-Control: no-cache" and an ETag, and keep the long-lived, '
+        'immutable rule for names that carry a content hash; the canonical '
+        'configuration ships with the DartWay template as '
+        '${context.flutterPackage}/nginx.conf. '
+        'Then deal with the copies already out there, because fixing the '
+        'server does not reach them: a response taken under a long max-age '
+        'stays fresh for the rest of that window and the browser will not ask. '
+        'Tell whoever you can reach to hard-reload or clear site data; for the '
+        'rest, wait the window out, or move the app to a URL that was never '
+        'poisoned — a URL a browser has not seen is the only thing that gets '
+        'through.',
   );
 }

--- a/packages/dartway_cli/lib/src/deploy/templates.dart
+++ b/packages/dartway_cli/lib/src/deploy/templates.dart
@@ -244,6 +244,11 @@ server {
     ssl_certificate     /etc/letsencrypt/live/__CERTNAME__/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/__CERTNAME__/privkey.pem;
 
+    # Caching for the web app is decided inside the web image and passed
+    # through from here. Do not add an `expires` in one of these snippets: a
+    # Flutter build reuses every one of its file names, so the rule would
+    # freeze exactly the files that change on every deploy, and the browsers
+    # that took a copy cannot be reached afterwards.
     include /etc/nginx/dartway/app/*.conf;
 
     location / {

--- a/packages/dartway_cli/lib/src/deploy/web_cache.dart
+++ b/packages/dartway_cli/lib/src/deploy/web_cache.dart
@@ -1,0 +1,332 @@
+/// What a browser is allowed to keep of a Flutter web build, and how to read
+/// that out of a serving configuration or off the wire.
+///
+/// The rule everything here rests on: **a Flutter web build hashes nothing.**
+/// `index.html`, `flutter_bootstrap.js`, `flutter.js`, `main.dart.js`,
+/// `main.dart.wasm`, `flutter_service_worker.js` and every file under `assets/`
+/// carry the same name in every build. The "fingerprinted assets are immutable"
+/// rule — correct for a bundler that puts a content hash in the name — lands on
+/// exactly the files that change on every deploy when applied here. A browser
+/// that took one under a long `max-age` does not ask again: it goes on running
+/// the previous build, the server goes on serving the new one, and nothing on
+/// either side reports a problem.
+library;
+
+import 'dart:io';
+
+/// Paths a Flutter web build serves under a name it will reuse in the next
+/// build. Every one of them has to be revalidated before reuse.
+///
+/// Not every build emits every path — a `--wasm` build has no `main.dart.js`,
+/// an older Flutter no `flutter_bootstrap.js` — so a probe that comes back 404
+/// means "not part of this build", not "a finding".
+const List<String> dwFlutterEntryPoints = [
+  '/',
+  '/index.html',
+  '/flutter_bootstrap.js',
+  '/main.dart.js',
+  '/main.dart.wasm',
+  '/flutter.js',
+  '/flutter_service_worker.js',
+  '/version.json',
+  '/manifest.json',
+  '/assets/AssetManifest.bin.json',
+  '/assets/FontManifest.json',
+  '/assets/fonts/MaterialIcons-Regular.otf',
+  '/assets/assets/images/logo.png',
+  '/icons/Icon-192.png',
+  '/favicon.png',
+  '/canvaskit/canvaskit.js',
+  '/canvaskit/canvaskit.wasm',
+];
+
+/// The subset worth asking a live server about.
+///
+/// One request each, and only paths a deployed build almost certainly has. The
+/// point is to catch a policy, not to enumerate a build.
+const List<String> dwProbedEntryPoints = [
+  '/',
+  '/flutter_bootstrap.js',
+  '/main.dart.js',
+  '/flutter.js',
+  '/version.json',
+  '/assets/AssetManifest.bin.json',
+];
+
+/// How a response may be reused.
+enum DwCacheReuse {
+  /// The copy may not be reused before the server has confirmed it.
+  revalidated,
+
+  /// The copy may be reused for a while without asking. Correct for a name
+  /// that carries a content hash, wrong for everything a Flutter build emits.
+  freely,
+
+  /// Nothing was said. The browser applies a heuristic of its own, derived
+  /// from `Last-Modified` — far less dangerous than a stated `max-age`, and
+  /// still nobody's decision.
+  unstated,
+}
+
+/// The reuse policy a `Cache-Control` value states.
+///
+/// [expires] is Nginx's `expires` directive, which is a second way of saying
+/// the same thing: `expires 1y` becomes `Cache-Control: max-age=31536000`, and
+/// `expires -1`/`epoch` becomes `no-cache`. When both are present Nginx emits
+/// both headers, and the permissive one is what a browser may act on — so the
+/// permissive one is what is judged.
+DwCacheReuse dwCacheReuse({String? cacheControl, String? expires}) {
+  final fromExpires = _reuseOfExpires(expires);
+  final fromHeader = _reuseOfCacheControl(cacheControl);
+  if (fromExpires == DwCacheReuse.freely || fromHeader == DwCacheReuse.freely) {
+    return DwCacheReuse.freely;
+  }
+  if (fromExpires == DwCacheReuse.revalidated ||
+      fromHeader == DwCacheReuse.revalidated) {
+    return DwCacheReuse.revalidated;
+  }
+  return DwCacheReuse.unstated;
+}
+
+DwCacheReuse _reuseOfCacheControl(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    return DwCacheReuse.unstated;
+  }
+  final directives = value.toLowerCase();
+  if (directives.contains('immutable')) {
+    return DwCacheReuse.freely;
+  }
+  if (directives.contains('no-store') ||
+      directives.contains('no-cache') ||
+      directives.contains('must-revalidate') ||
+      directives.contains('proxy-revalidate')) {
+    return DwCacheReuse.revalidated;
+  }
+  final maxAge = RegExp(r'(?<!s-)max-age\s*=\s*(\d+)').firstMatch(directives);
+  if (maxAge == null) {
+    return DwCacheReuse.unstated;
+  }
+  return int.parse(maxAge.group(1)!) > 0
+      ? DwCacheReuse.freely
+      : DwCacheReuse.revalidated;
+}
+
+DwCacheReuse _reuseOfExpires(String? value) {
+  final directive = value?.trim().toLowerCase();
+  if (directive == null || directive.isEmpty || directive == 'off') {
+    return DwCacheReuse.unstated;
+  }
+  if (directive == '-1' || directive == 'epoch' || directive == '0') {
+    return DwCacheReuse.revalidated;
+  }
+  return DwCacheReuse.freely;
+}
+
+/// One `location` block of an Nginx configuration.
+class DwNginxLocation {
+  const DwNginxLocation({
+    required this.modifier,
+    required this.pattern,
+    required this.body,
+  });
+
+  /// `=`, `^~`, `~`, `~*`, or empty for a plain prefix.
+  final String modifier;
+  final String pattern;
+  final String body;
+
+  bool get isRegex => modifier == '~' || modifier == '~*';
+  bool get isExact => modifier == '=';
+
+  bool matches(String path) {
+    if (isRegex) {
+      return RegExp(pattern, caseSensitive: modifier == '~').hasMatch(path);
+    }
+    if (isExact) {
+      return pattern == path;
+    }
+    return path.startsWith(pattern);
+  }
+
+  /// The reuse policy this block states, if it states one.
+  DwCacheReuse get reuse => dwCacheReuse(
+    cacheControl: _directiveValue(body, _cacheControlDirective),
+    expires: _directiveValue(body, _expiresDirective),
+  );
+
+  static final RegExp _cacheControlDirective = RegExp(
+    'add_header' r'\s+' '["\']?Cache-Control["\']?' r'\s+(.+?);',
+    caseSensitive: false,
+  );
+
+  static final RegExp _expiresDirective = RegExp(
+    r'(?:^|[;{\s])expires\s+([^;]+);',
+    caseSensitive: false,
+  );
+
+  static final RegExp _surroundingQuotes = RegExp('^["\']|["\']\$');
+
+  static String? _directiveValue(String body, RegExp pattern) {
+    final match = pattern.firstMatch(body);
+    if (match == null) {
+      return null;
+    }
+    return match.group(1)!.trim().replaceAll(_surroundingQuotes, '');
+  }
+}
+
+/// The `location` blocks of an Nginx configuration, in the order they appear.
+///
+/// Deliberately not a full Nginx parser: it reads the one construct that
+/// decides which rule a path falls under, and ignores everything else. A
+/// configuration it cannot make sense of yields no locations, which reads as
+/// "nothing is stated" rather than as a false verdict either way.
+List<DwNginxLocation> dwParseNginxLocations(String configuration) {
+  final locations = <DwNginxLocation>[];
+  for (final match in _locationHeader.allMatches(configuration)) {
+    final open = match.end - 1;
+    final close = _matchingBrace(configuration, open);
+    if (close == null) {
+      continue;
+    }
+    locations.add(
+      DwNginxLocation(
+        modifier: match.group(1) ?? '',
+        pattern: _unquote(match.group(2)!),
+        body: configuration.substring(open + 1, close),
+      ),
+    );
+  }
+  return locations;
+}
+
+final RegExp _locationHeader = RegExp(
+  r'(?:^|[\s;{}])location\s+(=|\^~|~\*|~)?\s*'
+  '("[^"]*"' r"|'[^']*'" r'|\S+)' r'\s*\{',
+  multiLine: true,
+);
+
+int? _matchingBrace(String text, int open) {
+  var depth = 0;
+  for (var index = open; index < text.length; index++) {
+    switch (text[index]) {
+      case '{':
+        depth++;
+      case '}':
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+    }
+  }
+  return null;
+}
+
+String _unquote(String value) {
+  if (value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'")))) {
+    return value.substring(1, value.length - 1);
+  }
+  return value;
+}
+
+/// The block that would serve [path], by Nginx's own precedence: an exact `=`
+/// match wins outright; otherwise the longest prefix is remembered, and it wins
+/// immediately when it is `^~`; failing that the first matching regex wins; and
+/// the remembered prefix is the fallback.
+DwNginxLocation? dwLocationFor(List<DwNginxLocation> locations, String path) {
+  DwNginxLocation? longestPrefix;
+  for (final location in locations) {
+    if (location.isExact && location.matches(path)) {
+      return location;
+    }
+    if (!location.isRegex && !location.isExact && location.matches(path)) {
+      if (longestPrefix == null ||
+          location.pattern.length > longestPrefix.pattern.length) {
+        longestPrefix = location;
+      }
+    }
+  }
+  if (longestPrefix != null && longestPrefix.modifier == '^~') {
+    return longestPrefix;
+  }
+  for (final location in locations) {
+    if (location.isRegex && location.matches(path)) {
+      return location;
+    }
+  }
+  return longestPrefix;
+}
+
+/// How each of [dwFlutterEntryPoints] would be served by [configuration].
+Map<String, DwCacheReuse> dwEntryPointPolicies(String configuration) {
+  final locations = dwParseNginxLocations(configuration);
+  return {
+    for (final path in dwFlutterEntryPoints)
+      path: dwLocationFor(locations, path)?.reuse ?? DwCacheReuse.unstated,
+  };
+}
+
+/// The Nginx configuration the web image is built with, gathered from the
+/// Dockerfile that builds it.
+///
+/// Two shapes are in the wild and both are read: a heredoc written straight
+/// into the image, and a `COPY <path> /etc/nginx/...` of a file in the build
+/// context. What comes back is the text, not the file — the check is about what
+/// the container ends up serving, and a file nothing copies serves nothing.
+String? dwWebServingConfiguration({
+  required Directory projectRoot,
+  required File dockerfile,
+}) {
+  if (!dockerfile.existsSync()) {
+    return null;
+  }
+  final text = dockerfile.readAsStringSync();
+  final buffer = StringBuffer();
+
+  for (final match in _copyHeredoc.allMatches(text)) {
+    if (!match.group(2)!.contains('/nginx/')) {
+      continue;
+    }
+    final terminator = match.group(1)!;
+    final end = text.indexOf(
+      RegExp('^$terminator\\s*\$', multiLine: true),
+      match.end,
+    );
+    buffer.writeln(
+      end == -1 ? text.substring(match.end) : text.substring(match.end, end),
+    );
+  }
+
+  for (final match in _copyFile.allMatches(text)) {
+    // `--from` copies out of a build stage, not out of the context — the path
+    // it names is inside another image and there is nothing here to read.
+    if (match.group(1)!.contains('--from')) {
+      continue;
+    }
+    if (!match.group(3)!.contains('/nginx/')) {
+      continue;
+    }
+    final source = File(
+      '${projectRoot.path}/${match.group(2)!}'.replaceAll(r'\', '/'),
+    );
+    if (source.existsSync()) {
+      buffer.writeln(source.readAsStringSync());
+    }
+  }
+
+  final gathered = buffer.toString().trim();
+  return gathered.isEmpty ? null : gathered;
+}
+
+final RegExp _copyHeredoc = RegExp(
+  r'COPY\s+<<\s*' '["\']?' r'(\w+)' '["\']?' r'\s+(\S+)',
+  caseSensitive: false,
+);
+
+final RegExp _copyFile = RegExp(
+  r'^\s*COPY\s+((?:--\S+\s+)*)([^\s<>-][^\s<>]*)\s+(\S+)\s*$',
+  caseSensitive: false,
+  multiLine: true,
+);

--- a/packages/dartway_cli/test/deploy_web_cache_test.dart
+++ b/packages/dartway_cli/test/deploy_web_cache_test.dart
@@ -1,0 +1,467 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/checker/dw_check_type.dart';
+import 'package:dartway_cli/src/deploy/deploy_check.dart';
+import 'package:dartway_cli/src/deploy/deploy_target.dart';
+import 'package:dartway_cli/src/deploy/remote_checks.dart';
+import 'package:dartway_cli/src/deploy/serverpod_config.dart';
+import 'package:dartway_cli/src/deploy/web_cache.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// The configuration the template ships, and the two ways of getting it wrong
+/// that this whole file exists for: a rule that says "immutable" over a name a
+/// Flutter build reuses, and a configuration that says nothing at all.
+const String _shippedConfiguration = '''
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+  etag on;
+
+  location / {
+    try_files \$uri \$uri/ /index.html;
+    add_header Cache-Control "no-cache";
+  }
+
+  location ~* "\\.[0-9a-f]{8,}\\.(js|css|wasm|json|png|jpe?g|gif|svg|webp|avif|ico|woff2?|otf|ttf)\$" {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+}
+''';
+
+/// The rule as projects keep writing it: correct for a bundler that
+/// fingerprints, wrong for a build that does not.
+const String _immutableAssetsConfiguration = '''
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files \$uri \$uri/ /index.html;
+  }
+
+  location ~* \\.(png|jpg|jpeg|gif|ico|svg|woff|woff2)\$ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+
+  location ~* \\.(js|css|json|wasm)\$ {
+    expires 30d;
+  }
+}
+''';
+
+void main() {
+  group('cache-control reading', () {
+    test('no-cache and friends mean the copy has to be confirmed', () {
+      for (final value in [
+        'no-cache',
+        'no-store',
+        'public, must-revalidate',
+        'max-age=0',
+        'private, max-age=0, must-revalidate',
+      ]) {
+        expect(
+          dwCacheReuse(cacheControl: value),
+          DwCacheReuse.revalidated,
+          reason: value,
+        );
+      }
+    });
+
+    test('a positive max-age or "immutable" means it is reused unasked', () {
+      for (final value in [
+        'public, max-age=2592000',
+        'max-age=31536000, immutable',
+        'public, max-age=31536000',
+      ]) {
+        expect(
+          dwCacheReuse(cacheControl: value),
+          DwCacheReuse.freely,
+          reason: value,
+        );
+      }
+    });
+
+    // "immutable" beside a zero max-age is a contradiction someone wrote by
+    // hand; the permissive half is the one a browser can act on.
+    test('immutable wins over anything softer beside it', () {
+      expect(
+        dwCacheReuse(cacheControl: 'no-cache, immutable'),
+        DwCacheReuse.freely,
+      );
+    });
+
+    test('s-maxage alone is about a shared cache, not this browser', () {
+      expect(dwCacheReuse(cacheControl: 's-maxage=600'), DwCacheReuse.unstated);
+    });
+
+    test('nothing said is its own answer', () {
+      expect(dwCacheReuse(), DwCacheReuse.unstated);
+      expect(dwCacheReuse(cacheControl: '  '), DwCacheReuse.unstated);
+    });
+
+    test('nginx "expires" is read as the Cache-Control it becomes', () {
+      expect(dwCacheReuse(expires: '1y'), DwCacheReuse.freely);
+      expect(dwCacheReuse(expires: '30d'), DwCacheReuse.freely);
+      expect(dwCacheReuse(expires: '-1'), DwCacheReuse.revalidated);
+      expect(dwCacheReuse(expires: 'epoch'), DwCacheReuse.revalidated);
+      expect(dwCacheReuse(expires: 'off'), DwCacheReuse.unstated);
+    });
+
+    // Both headers go out, and a browser may act on the permissive one.
+    test('the permissive half of a contradictory pair decides', () {
+      expect(
+        dwCacheReuse(cacheControl: 'no-cache', expires: '1y'),
+        DwCacheReuse.freely,
+      );
+    });
+  });
+
+  group('location matching', () {
+    final locations = dwParseNginxLocations(_shippedConfiguration);
+
+    test('the shipped configuration parses into its two blocks', () {
+      expect(locations, hasLength(2));
+      expect(locations.first.pattern, '/');
+      expect(locations.last.isRegex, isTrue);
+    });
+
+    test('a quoted regex pattern survives its braces', () {
+      expect(locations.last.pattern, contains('{8,}'));
+    });
+
+    test('a regex beats a prefix, as nginx has it', () {
+      final chosen = dwLocationFor(locations, '/app.9f2b1c4e.js');
+      expect(chosen!.isRegex, isTrue);
+      expect(chosen.reuse, DwCacheReuse.freely);
+    });
+
+    test('an unhashed name falls through to the prefix block', () {
+      final chosen = dwLocationFor(locations, '/main.dart.js');
+      expect(chosen!.pattern, '/');
+      expect(chosen.reuse, DwCacheReuse.revalidated);
+    });
+
+    test('an exact match wins outright', () {
+      final withExact = dwParseNginxLocations('''
+server {
+  location / { add_header Cache-Control "public, max-age=600"; }
+  location = /index.html { add_header Cache-Control "no-cache"; }
+  location ~* \\.html\$ { add_header Cache-Control "public, max-age=99"; }
+}
+''');
+      expect(
+        dwLocationFor(withExact, '/index.html')!.reuse,
+        DwCacheReuse.revalidated,
+      );
+    });
+
+    test('a ^~ prefix stops the regexes from being consulted', () {
+      final withCaret = dwParseNginxLocations('''
+server {
+  location ^~ /assets/ { add_header Cache-Control "no-cache"; }
+  location ~* \\.png\$ { expires 1y; }
+}
+''');
+      expect(
+        dwLocationFor(withCaret, '/assets/logo.png')!.reuse,
+        DwCacheReuse.revalidated,
+      );
+      expect(dwLocationFor(withCaret, '/logo.png')!.reuse, DwCacheReuse.freely);
+    });
+
+    test('the longest prefix wins among prefixes', () {
+      final prefixes = dwParseNginxLocations('''
+server {
+  location / { add_header Cache-Control "no-cache"; }
+  location /canvaskit/ { expires 1y; }
+}
+''');
+      expect(
+        dwLocationFor(prefixes, '/canvaskit/canvaskit.wasm')!.reuse,
+        DwCacheReuse.freely,
+      );
+    });
+  });
+
+  group('entry-point policies', () {
+    test('the shipped configuration revalidates every entry point', () {
+      final policies = dwEntryPointPolicies(_shippedConfiguration);
+      expect(policies, hasLength(dwFlutterEntryPoints.length));
+      expect(
+        policies.values.every((reuse) => reuse == DwCacheReuse.revalidated),
+        isTrue,
+        reason: policies.toString(),
+      );
+    });
+
+    // The bug this file is named after: a rule that is right for a
+    // fingerprinting bundler, applied to a build that fingerprints nothing.
+    test('"immutable assets" lands on the files a build overwrites', () {
+      final policies = dwEntryPointPolicies(_immutableAssetsConfiguration);
+      final freely = policies.entries
+          .where((entry) => entry.value == DwCacheReuse.freely)
+          .map((entry) => entry.key)
+          .toSet();
+      expect(freely, contains('/main.dart.js'));
+      expect(freely, contains('/flutter_bootstrap.js'));
+      expect(freely, contains('/assets/assets/images/logo.png'));
+      expect(freely, contains('/icons/Icon-192.png'));
+      // And an extension the list happens to omit — `.otf` here — falls
+      // through to a block that says nothing, which is the other half of why
+      // hand-written rules of this shape are so hard to reason about.
+      expect(
+        policies['/assets/fonts/MaterialIcons-Regular.otf'],
+        DwCacheReuse.unstated,
+      );
+      // index.html itself is untouched by both rules, which is exactly why the
+      // failure is invisible: the shell reloads, the code it loads does not.
+      expect(policies['/index.html'], DwCacheReuse.unstated);
+    });
+
+    test('a configuration with no cache rules states nothing', () {
+      final policies = dwEntryPointPolicies('''
+server {
+  listen 80;
+  location / { try_files \$uri \$uri/ /index.html; }
+}
+''');
+      expect(
+        policies.values.every((reuse) => reuse == DwCacheReuse.unstated),
+        isTrue,
+      );
+    });
+
+    test('every probed path is one of the declared entry points', () {
+      expect(dwProbedEntryPoints, everyElement(isIn(dwFlutterEntryPoints)));
+    });
+  });
+
+  group('where the web image gets its serving configuration', () {
+    late Directory root;
+
+    setUp(() => root = Directory.systemTemp.createTempSync('dw_web_cache'));
+    tearDown(() => root.deleteSync(recursive: true));
+
+    File dockerfile(String contents) {
+      final file = File(p.join(root.path, 'Dockerfile'));
+      file.writeAsStringSync(contents);
+      return file;
+    }
+
+    test('a copied file is read from the build context', () {
+      final conf = File(p.join(root.path, 'app_flutter', 'nginx.conf'))
+        ..parent.createSync(recursive: true);
+      conf.writeAsStringSync(_shippedConfiguration);
+
+      final gathered = dwWebServingConfiguration(
+        projectRoot: root,
+        dockerfile: dockerfile('''
+FROM nginx:alpine
+COPY --from=build /workspace/app_flutter/build/web /usr/share/nginx/html
+COPY app_flutter/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+'''),
+      );
+      expect(gathered, contains('location /'));
+      expect(
+        dwEntryPointPolicies(gathered!)['/main.dart.js'],
+        DwCacheReuse.revalidated,
+      );
+    });
+
+    // The `COPY --from=build` line above names a path under /usr/share, and a
+    // build stage rather than the context. Reading it as a serving
+    // configuration would mean reading the compiled bundle.
+    test('a stage copy is not mistaken for a configuration', () {
+      expect(
+        dwWebServingConfiguration(
+          projectRoot: root,
+          dockerfile: dockerfile(
+            'FROM nginx:alpine\n'
+            'COPY --from=build /workspace/web /etc/nginx/conf.d/default.conf\n',
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    // The older shape, still in every project generated before the split.
+    test('a heredoc written straight into the image is read too', () {
+      final gathered = dwWebServingConfiguration(
+        projectRoot: root,
+        dockerfile: dockerfile('''
+FROM nginx:alpine
+COPY <<'EOF' /etc/nginx/conf.d/default.conf
+$_immutableAssetsConfiguration
+EOF
+EXPOSE 80
+'''),
+      );
+      expect(gathered, contains('expires 1y'));
+      expect(
+        dwEntryPointPolicies(gathered!)['/main.dart.js'],
+        DwCacheReuse.freely,
+      );
+    });
+
+    test('a Dockerfile that serves nothing of its own yields nothing', () {
+      expect(
+        dwWebServingConfiguration(
+          projectRoot: root,
+          dockerfile: dockerfile('FROM nginx:alpine\nEXPOSE 80\n'),
+        ),
+        isNull,
+      );
+    });
+
+    test('a missing Dockerfile is not an empty one', () {
+      expect(
+        dwWebServingConfiguration(
+          projectRoot: root,
+          dockerfile: File(p.join(root.path, 'nowhere', 'Dockerfile')),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('web-cache-policy', () {
+    late Directory root;
+
+    setUp(() => root = Directory.systemTemp.createTempSync('dw_web_policy'));
+    tearDown(() => root.deleteSync(recursive: true));
+
+    final check = dwLocalDeployChecks.firstWhere(
+      (c) => c.id == 'web-cache-policy',
+    );
+
+    DwDeployContext contextIn(Directory root) => DwDeployContext(
+      projectRoot: root,
+      serverPackage: 'shop_server',
+      flutterPackage: 'shop_flutter',
+      target: DwDeployTarget(
+        environment: 'staging',
+        host: '203.0.113.10',
+        sshUser: 'root',
+        deployUser: 'deployer',
+        os: 'ubuntu',
+        repo: 'git@github.com:acme/shop.git',
+        branch: 'master',
+        sslEmail: 'ops@example.com',
+        webAppDomain: 'app.example.com',
+      ),
+      serverpod: DwServerpodConfig(
+        environment: 'staging',
+        relativePath: 'shop_server/config/staging.yaml',
+        apiServer: DwServerEndpoint(
+          name: 'apiServer',
+          port: 8080,
+          publicHost: 'api.example.com',
+          publicPort: 443,
+          publicScheme: 'https',
+        ),
+        insightsServer: null,
+        webServer: null,
+        databaseHost: 'postgres',
+        databasePort: 5432,
+        databaseName: 'shop',
+        databaseUser: 'shop',
+        redisEnabled: false,
+        redisHost: null,
+      ),
+    );
+
+    void writeWebImage(String configuration) {
+      File(p.join(root.path, 'shop_flutter', 'nginx.conf'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(configuration);
+      File(p.join(root.path, 'shop_flutter', 'Dockerfile')).writeAsStringSync(
+        'FROM nginx:alpine\n'
+        'COPY shop_flutter/nginx.conf /etc/nginx/conf.d/default.conf\n',
+      );
+    }
+
+    test('nothing to judge without a web Dockerfile', () async {
+      expect((await check.evaluate(contextIn(root))).skipped, isTrue);
+    });
+
+    test('accepts the configuration the template ships', () async {
+      writeWebImage(_shippedConfiguration);
+      final verdict = await check.evaluate(contextIn(root));
+      expect(verdict.passed, isTrue, reason: verdict.detail);
+    });
+
+    test('names the entry points an immutable rule would freeze', () async {
+      writeWebImage(_immutableAssetsConfiguration);
+      final verdict = await check.evaluate(contextIn(root));
+
+      expect(verdict.passed, isFalse);
+      expect(verdict.detail, contains('/main.dart.js'));
+      // The half a fix has to be accompanied by, or the finding is only half
+      // reported: the copies already out there.
+      expect(verdict.fix, contains('hard-reload'));
+    });
+
+    test('an image serving no configuration of its own is a finding', () async {
+      File(p.join(root.path, 'shop_flutter', 'Dockerfile'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync('FROM nginx:alpine\nEXPOSE 80\n');
+
+      final verdict = await check.evaluate(contextIn(root));
+      expect(verdict.passed, isFalse);
+      expect(verdict.detail, contains('no serving configuration'));
+    });
+
+    // Reading configuration text can miss things a running server would show —
+    // an include outside the build context, a header a front proxy adds — so
+    // this one warns and `web-cache-headers`, which observed the response,
+    // errors.
+    test('warns rather than blocking a deploy', () {
+      expect(check.severity, DwCheckSeverity.warning);
+      expect(
+        dwRemoteDeployChecks
+            .firstWhere((c) => c.id == 'web-cache-headers')
+            .severity,
+        DwCheckSeverity.error,
+      );
+    });
+
+    // The header check asks the site, not the server, so it needs no SSH — and
+    // must still run when the SSH checks have failed.
+    test('the deployed site is asked over HTTP, not over SSH', () {
+      expect(
+        dwRemoteDeployChecks
+            .firstWhere((c) => c.id == 'web-cache-headers')
+            .requiresSsh,
+        isFalse,
+      );
+    });
+  });
+
+  // Inside the monorepo the skeleton itself is the thing that must not rot: it
+  // is what `dartway create` hands to a project that will never read this file.
+  group('the configuration the template ships', () {
+    final shipped = File(
+      p.join(
+        Directory.current.path,
+        '..',
+        '..',
+        'template',
+        'dartway_starter_flutter',
+        'nginx.conf',
+      ),
+    );
+
+    test('revalidates every entry point a build overwrites', () {
+      final policies = dwEntryPointPolicies(shipped.readAsStringSync());
+      final notRevalidated = policies.entries
+          .where((entry) => entry.value != DwCacheReuse.revalidated)
+          .map((entry) => '${entry.key} -> ${entry.value.name}')
+          .toList();
+      expect(notRevalidated, isEmpty);
+    }, skip: shipped.existsSync() ? null : 'not running inside the monorepo');
+  });
+}

--- a/packages/dartway_push/dartway_push_server/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_server/CHANGELOG.md
@@ -1,6 +1,42 @@
 ## 0.3.0
 
-Web click-through no longer rests on the app's service worker alone.
+Web click-through no longer rests on the app's service worker alone, and a
+provider that was asked for and not finished now says so.
+
+**Breaking.** `DwFcmPushProviderConfig.fromPasswords` no longer takes
+`serviceAccountJsonKey`. The service account is read from a **file** —
+`DwFcmPushProviderConfig.defaultServiceAccountFile`, that is
+`config/fcm-service-account.json`, overridable with `serviceAccountFile:`. An
+app that kept the JSON in `passwords.yaml` moves it with
+`dartway deploy secret put-file` and names it under `requires.files` in
+`deploy/config.yaml`; nothing else in the wiring changes. The plain constructor
+still takes the JSON directly, for an app that obtains it some other way.
+
+- **A service-account JSON is not a password, and steering it into one was our
+  doing.** The comment that shipped with push described `fcmServiceAccountJson`
+  as "the whole service-account JSON … on one line", and `fromPasswords` was the
+  only factory the documentation showed — so a couple of thousand characters of
+  JSON went into the master copy of every environment's secrets, with a silent
+  failure attached: the value starts with `{`, so unquoted YAML parses it as a
+  flow mapping rather than as a string. Meanwhile the CLI already had
+  `deploy secret put-file`, whose own help names this case verbatim, and since
+  `dartway_cli` 0.8.0 a file named under `requires.files` is genuinely mounted
+  into the container. `config/<name>` is now the path, and it resolves to the
+  same file locally and in the image.
+
+- **A declared-but-incomplete provider fails at startup instead of going
+  quiet.** `isConfigured` returned `false` on any missing field, which is also
+  the answer for "this environment sends no push" — so a forgotten key and a
+  deliberate decision were indistinguishable from inside a running server, and
+  the difference surfaced weeks later as "why did that notification never
+  arrive?". The project id is now the **declaration**: once `fcmProjectId` or
+  `rustorePushProjectId` is present, everything else that provider needs has to
+  be there too, or the config constructor throws the new
+  `DwPushProviderConfigurationException` — naming what is missing and where it
+  was looked for. A service account that is not a JSON object is refused the
+  same way, so a truncated upload or a value that lost its YAML quotes is caught
+  at boot rather than at the first send. An environment that wants no push
+  declares nothing and is believed.
 
 - **`dwPushLinkDataKey` joins the wire keys.** The in-app path a payload carries
   under `link` is now named on the server as it already was on the app half.

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_fcm_push_provider.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_fcm_push_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart' as http;
@@ -14,6 +15,22 @@ const _fcmHost = 'fcm.googleapis.com';
 
 typedef DwFcmAccessTokenProvider = Future<String?> Function();
 
+/// Credentials for [DwFcmPushProvider], from a password key and a file.
+///
+/// The two halves of an FCM credential are not the same kind of thing, and
+/// keeping them in one place made a mess of both. The project id is a short
+/// identifier — a password, in the sense `passwords.yaml` means. The service
+/// account is a JSON document a couple of thousand characters long, and a
+/// document in a passwords file is a document in the master copy of every
+/// environment's secrets, with a trap attached: it starts with `{`, so
+/// unquoted YAML reads it as a flow mapping rather than a string and the value
+/// silently is not what was written.
+///
+/// So the document travels as a file — `dartway deploy secret put-file`, named
+/// under `requires.files` in `deploy/config.yaml`, mounted read-only into the
+/// container. [defaultServiceAccountFile] is a relative path on purpose: the
+/// server works from its own package directory locally and from `/app` in the
+/// image, and `config/<name>` is the same file in both.
 final class DwFcmPushProviderConfig {
   DwFcmPushProviderConfig({
     required String? projectId,
@@ -34,24 +51,56 @@ final class DwFcmPushProviderConfig {
         'Must be positive',
       );
     }
+    _assertWholeOrAbsent();
   }
 
+  /// Where the service-account document is read from by default.
+  ///
+  /// Relative, and that is the whole point: it resolves to the same file in a
+  /// local run and inside the container, where the deploy mounts every entry
+  /// of `requires.files` at `/app/config/<name>` beside `passwords.yaml`.
+  static const String defaultServiceAccountFile =
+      'config/fcm-service-account.json';
+
+  /// The shape an app writes: the project id out of `passwords.yaml`, the
+  /// service account out of a file.
+  ///
+  /// The project id doubles as the declaration. An environment that names it
+  /// wants push, and a missing credential is then a fault rather than a
+  /// preference — see [DwPushProviderConfigurationException].
   factory DwFcmPushProviderConfig.fromPasswords(
     Map<String, String> passwords, {
     String projectIdKey = 'fcmProjectId',
-    String serviceAccountJsonKey = 'fcmServiceAccountJson',
+    String serviceAccountFile = defaultServiceAccountFile,
     String? webpushIcon,
     String? androidIcon,
     String? androidColor,
     Duration requestTimeout = const Duration(seconds: 10),
-  }) => DwFcmPushProviderConfig(
-    projectId: passwords[projectIdKey],
-    serviceAccountJson: passwords[serviceAccountJsonKey],
-    webpushIcon: webpushIcon,
-    androidIcon: androidIcon,
-    androidColor: androidColor,
-    requestTimeout: requestTimeout,
-  );
+  }) {
+    final file = File(serviceAccountFile);
+    final projectId = _trimToNull(passwords[projectIdKey]);
+    if (projectId != null && !file.existsSync()) {
+      throw DwPushProviderConfigurationException(
+        'FCM',
+        'the service account was not found at "$serviceAccountFile" (the '
+            'project id came from the "$projectIdKey" password key). Send the '
+            'JSON to the server with "dartway deploy secret put-file", name it '
+            'under requires.files in deploy/config.yaml so the deploy mounts '
+            'it into the container, and keep it out of passwords.yaml — a '
+            'document there is a document in the master copy of every '
+            'environment, and unquoted YAML reads a leading "{" as a mapping '
+            'rather than as text',
+      );
+    }
+    return DwFcmPushProviderConfig(
+      projectId: projectId,
+      serviceAccountJson: file.existsSync() ? file.readAsStringSync() : null,
+      webpushIcon: webpushIcon,
+      androidIcon: androidIcon,
+      androidColor: androidColor,
+      requestTimeout: requestTimeout,
+    );
+  }
 
   final String? projectId;
   final String? serviceAccountJson;
@@ -60,7 +109,51 @@ final class DwFcmPushProviderConfig {
   final String? androidColor;
   final Duration requestTimeout;
 
+  /// Whether this provider has everything it needs.
+  ///
+  /// After construction there is no third state left: a config either has both
+  /// halves or neither, because anything between the two throws.
   bool get isConfigured => projectId != null && serviceAccountJson != null;
+
+  /// Nothing, or everything — never the half that fails at the first send.
+  void _assertWholeOrAbsent() {
+    if (projectId == null && serviceAccountJson == null) {
+      return;
+    }
+    if (projectId == null) {
+      throw const DwPushProviderConfigurationException(
+        'FCM',
+        'no project id was given. It is the key that declares an environment '
+            'wants FCM at all, so a service account without one configures '
+            'nothing',
+      );
+    }
+    if (serviceAccountJson == null) {
+      throw const DwPushProviderConfigurationException(
+        'FCM',
+        'no service account was given. Read it from a file — the default is '
+            '"$defaultServiceAccountFile", delivered by '
+            '"dartway deploy secret put-file"',
+      );
+    }
+    final Object? document;
+    try {
+      document = jsonDecode(serviceAccountJson!);
+    } on FormatException catch (error) {
+      throw DwPushProviderConfigurationException(
+        'FCM',
+        'the service account is not JSON (${error.message}). A truncated '
+            'upload and a YAML value that lost its quotes both look like this',
+      );
+    }
+    if (document is! Map) {
+      throw const DwPushProviderConfigurationException(
+        'FCM',
+        'the service account is valid JSON but not an object. Google issues '
+            'it as a file; send that file through unchanged',
+      );
+    }
+  }
 }
 
 /// A blank string is an absent one everywhere in this file: an empty icon, an

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_provider.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_provider.dart
@@ -350,3 +350,31 @@ final class DwPushProviderTransport implements DwPushTransport {
     );
   }
 }
+
+/// A provider that was asked for and not finished.
+///
+/// Missing credentials used to be indistinguishable from absent ones: every
+/// built-in config answered `isConfigured == false` on any missing field, the
+/// app skipped the provider, and push went quiet. "We do not send push here"
+/// and "the key never made it to this environment" then look the same from
+/// inside the running server — and the second one is only noticed when somebody
+/// asks why a notification never arrived, which can be weeks.
+///
+/// So a provider states its intent with one key — its project id — and once
+/// that key is present, everything else it needs has to be there too. What is
+/// missing is named, and the server does not start.
+final class DwPushProviderConfigurationException implements Exception {
+  const DwPushProviderConfigurationException(this.provider, this.problem);
+
+  /// Which provider is half-configured, in the words the app uses for it.
+  final String provider;
+
+  /// What is missing or wrong, and where it was looked for.
+  final String problem;
+
+  @override
+  String toString() =>
+      'DwPushProviderConfigurationException: $provider push is configured for '
+      'this environment, but $problem. Supply it, or remove the declaration '
+      'entirely so that push is deliberately off rather than quietly broken.';
+}

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_rustore_push_provider.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_rustore_push_provider.dart
@@ -9,6 +9,11 @@ import 'dw_push_provider_utils.dart';
 
 const _ruStoreHost = 'vkpns.rustore.ru';
 
+/// Credentials for [DwRuStorePushProvider].
+///
+/// Both halves are short values and both stay in `passwords.yaml` — a RuStore
+/// service token is a token, not a document, so nothing here needs the file
+/// route FCM's service account takes.
 final class DwRuStorePushProviderConfig {
   DwRuStorePushProviderConfig({
     required String? projectId,
@@ -27,8 +32,12 @@ final class DwRuStorePushProviderConfig {
         'Must be positive',
       );
     }
+    _assertWholeOrAbsent();
   }
 
+  /// The project id doubles as the declaration: an environment that names it
+  /// wants RuStore push, so a missing service token is a fault rather than a
+  /// preference — see [DwPushProviderConfigurationException].
   factory DwRuStorePushProviderConfig.fromPasswords(
     Map<String, String> passwords, {
     String projectIdKey = 'rustorePushProjectId',
@@ -50,7 +59,33 @@ final class DwRuStorePushProviderConfig {
   final String? androidColor;
   final Duration requestTimeout;
 
+  /// Whether this provider has everything it needs. After construction there
+  /// is no half state left — anything between the two throws.
   bool get isConfigured => projectId != null && serviceToken != null;
+
+  /// Nothing, or everything. "We do not send RuStore push" and "the token
+  /// never reached this environment" must not look the same from inside a
+  /// running server.
+  void _assertWholeOrAbsent() {
+    if (projectId == null && serviceToken == null) {
+      return;
+    }
+    if (projectId == null) {
+      throw const DwPushProviderConfigurationException(
+        'RuStore',
+        'no project id was given. It is the key that declares an environment '
+            'wants RuStore at all, so a service token without one configures '
+            'nothing',
+      );
+    }
+    if (serviceToken == null) {
+      throw const DwPushProviderConfigurationException(
+        'RuStore',
+        'no service token was given. It is a short value: keep it in '
+            'passwords.yaml and deliver it with "dartway deploy secret set"',
+      );
+    }
+  }
 
   static String? _trimToNull(String? value) {
     final normalized = value?.trim();

--- a/packages/dartway_push/dartway_push_server/test/push/dw_push_builtin_provider_configs_test.dart
+++ b/packages/dartway_push/dartway_push_server/test/push/dw_push_builtin_provider_configs_test.dart
@@ -1,20 +1,112 @@
+import 'dart:io';
+
 import 'package:dartway_push_server/dartway_push_server.dart';
 import 'package:test/test.dart';
 
+const _serviceAccount =
+    '{"type":"service_account","project_id":"demo-project",'
+    '"client_email":"push@demo-project.iam.gserviceaccount.com"}';
+
 void main() {
   group('Built-in push provider configs', () {
-    test('constructs FCM config from app passwords keys', () {
+    late Directory root;
+    late String previousCwd;
+
+    // `fromPasswords` reads the service account by a relative path, because
+    // that path has to mean the same thing here and inside the container. So a
+    // test for it is a test about the working directory.
+    setUp(() {
+      previousCwd = Directory.current.path;
+      root = Directory.systemTemp.createTempSync('dw_push_config_');
+      Directory('${root.path}/config').createSync();
+      Directory.current = root;
+    });
+
+    tearDown(() {
+      Directory.current = previousCwd;
+      root.deleteSync(recursive: true);
+    });
+
+    void writeServiceAccount([String contents = _serviceAccount]) => File(
+      '${root.path}/${DwFcmPushProviderConfig.defaultServiceAccountFile}',
+    ).writeAsStringSync(contents);
+
+    test('constructs FCM config from a password key and a mounted file', () {
+      writeServiceAccount();
+
       final config = DwFcmPushProviderConfig.fromPasswords({
         'fcmProjectId': 'demo-project',
-        'fcmServiceAccountJson':
-            '{"type":"service_account","project_id":"demo-project"}',
       });
 
       expect(config.projectId, 'demo-project');
+      expect(config.serviceAccountJson, _serviceAccount);
+      expect(config.isConfigured, isTrue);
+    });
+
+    test('an environment that declares no project id wants no push', () {
+      final config = DwFcmPushProviderConfig.fromPasswords(const {});
+
+      expect(config.isConfigured, isFalse);
+      expect(config.projectId, isNull);
+    });
+
+    // The finding this whole change is about: a declared provider with a
+    // missing credential used to answer `isConfigured == false`, which is the
+    // same answer as "we do not send push here". From inside a running server
+    // the two were indistinguishable.
+    test('a declared provider whose file never arrived fails loudly', () {
       expect(
-        config.serviceAccountJson,
-        '{"type":"service_account","project_id":"demo-project"}',
+        () => DwFcmPushProviderConfig.fromPasswords({
+          'fcmProjectId': 'demo-project',
+        }),
+        throwsA(
+          isA<DwPushProviderConfigurationException>().having(
+            (error) => error.toString(),
+            'message',
+            allOf(
+              contains(DwFcmPushProviderConfig.defaultServiceAccountFile),
+              contains('put-file'),
+            ),
+          ),
+        ),
       );
+    });
+
+    test('a service account without a project id configures nothing', () {
+      expect(
+        () => DwFcmPushProviderConfig(
+          projectId: null,
+          serviceAccountJson: _serviceAccount,
+        ),
+        throwsA(isA<DwPushProviderConfigurationException>()),
+      );
+    });
+
+    // A YAML value that lost its quotes, a truncated upload, the wrong file
+    // entirely — all of them reach the constructor as a string, and all of
+    // them used to reach the first send instead.
+    test('a service account that is not a JSON object is refused', () {
+      for (final broken in ['not json at all', '"a string"', '[1, 2]']) {
+        expect(
+          () => DwFcmPushProviderConfig(
+            projectId: 'demo-project',
+            serviceAccountJson: broken,
+          ),
+          throwsA(isA<DwPushProviderConfigurationException>()),
+          reason: broken,
+        );
+      }
+    });
+
+    test('a path of the app own choosing is honoured', () {
+      File('${root.path}/config/other.json').writeAsStringSync(_serviceAccount);
+
+      final config = DwFcmPushProviderConfig.fromPasswords(
+        {'fcmProjectId': 'demo-project'},
+        serviceAccountFile: 'config/other.json',
+      );
+
+      expect(config.serviceAccountJson, _serviceAccount);
     });
 
     test('constructs RuStore config from app passwords keys', () {
@@ -27,13 +119,34 @@ void main() {
       expect(config.serviceToken, 'rustore-service-token');
     });
 
+    test('RuStore is silent about an environment that declares it not', () {
+      expect(
+        DwRuStorePushProviderConfig.fromPasswords(const {}).isConfigured,
+        isFalse,
+      );
+    });
+
+    test('a declared RuStore provider missing its token fails loudly', () {
+      expect(
+        () => DwRuStorePushProviderConfig.fromPasswords({
+          'rustorePushProjectId': 'demo-project',
+        }),
+        throwsA(
+          isA<DwPushProviderConfigurationException>().having(
+            (error) => error.toString(),
+            'message',
+            contains('service token'),
+          ),
+        ),
+      );
+    });
+
     test(
       'allows explicit constructor values for built-in provider configs',
       () {
         final fcm = DwFcmPushProviderConfig(
           projectId: 'demo-project',
-          serviceAccountJson:
-              '{"type":"service_account","project_id":"demo-project"}',
+          serviceAccountJson: _serviceAccount,
           webpushIcon: '/icons/push.png',
           androidIcon: 'ic_notification',
           androidColor: '#102030',

--- a/template/dartway_starter_flutter/Dockerfile
+++ b/template/dartway_starter_flutter/Dockerfile
@@ -24,34 +24,11 @@ FROM nginx:alpine
 
 COPY --from=build /workspace/dartway_starter_flutter/build/web /usr/share/nginx/html
 
-# This server block serves the build inside the container; the deployment's own
-# Nginx sits in front of it and terminates TLS.
-COPY <<'EOF' /etc/nginx/conf.d/default.conf
-server {
-  listen 80;
-  root /usr/share/nginx/html;
-  index index.html;
-
-  # A Flutter route is not a file: everything unknown is answered by the app.
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
-
-  location ~* \.(png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-  }
-
-  # The build's own files change on every deploy and carry no hash in the name,
-  # so a cached copy is a stale app that nobody can refresh out of.
-  location ~* \.(js|css|json|wasm)$ {
-    add_header Cache-Control "no-cache";
-  }
-
-  location = /index.html {
-    add_header Cache-Control "no-cache";
-  }
-}
-EOF
+# How the build is served, and above all what a browser may keep. A file of its
+# own rather than a heredoc: the caching split is the part of a deployment that
+# fails silently — a stale entry point serves the previous build to a browser
+# that never asks again — so it has to be readable, diffable, and something
+# `dartway deploy check` can interrogate.
+COPY dartway_starter_flutter/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/template/dartway_starter_flutter/nginx.conf
+++ b/template/dartway_starter_flutter/nginx.conf
@@ -1,0 +1,54 @@
+# How the Flutter web build is served inside the `web` container. The
+# deployment's own Nginx sits in front of this one and terminates TLS; what is
+# decided here is what a browser is allowed to keep.
+#
+# **A Flutter web build hashes nothing.** `index.html`, `flutter_bootstrap.js`,
+# `flutter.js`, `main.dart.js`, `main.dart.wasm`, `flutter_service_worker.js`
+# and everything under `assets/` carry the same name in every build. The usual
+# "fingerprinted assets are immutable, cache them for a year" rule therefore
+# lands on exactly the files that change on every deploy: a browser that took
+# one under a long `max-age` does not ask again, so it keeps running the
+# previous build and no server-side change reaches it. Nothing in the deploy
+# reports this — the server serves the new bundle and the browser never
+# requests it.
+#
+# So the default here is revalidation, and the long-lived rule is narrowed to
+# paths that genuinely carry a content hash in the name.
+#
+# `dartway deploy check` reads this file and probes the deployed site for the
+# same property. Edit it deliberately.
+
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # What makes revalidation cheap: the browser asks, the server answers 304,
+  # and nothing is transferred. Without a validator, "no-cache" would mean a
+  # full download on every navigation.
+  etag on;
+
+  # A Flutter route is not a file: everything unknown is answered by the app.
+  #
+  # "no-cache" is not "no-store" — the copy is kept, it just may not be reused
+  # before the server has confirmed it. That is the correct policy for every
+  # file a Flutter build emits, because every one of them can change under the
+  # same name.
+  location / {
+    try_files $uri $uri/ /index.html;
+    add_header Cache-Control "no-cache";
+  }
+
+  # The one long-lived exception: a name that carries a content hash, which is
+  # only ever produced by a build step this project added — `app.9f2b1c4e.js`
+  # and the like. Such a URL changes when the bytes change, so the copy a
+  # browser holds can never be the wrong one.
+  #
+  # Quoted because the pattern contains braces, which Nginx would otherwise
+  # read as block delimiters. A project whose fingerprints look different
+  # (a dash, base32, a query parameter) edits the pattern here rather than
+  # widening the rule above.
+  location ~* "\.[0-9a-f]{8,}\.(js|css|wasm|json|png|jpe?g|gif|svg|webp|avif|ico|woff2?|otf|ttf)$" {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+}

--- a/template/deploy/README.md
+++ b/template/deploy/README.md
@@ -21,6 +21,7 @@ dartway deploy secret --help                # runtime secrets on the server
 | `../dartway_starter_server/config/<env>.yaml` | the **application**: domains, ports, database, Redis — read by the deploy, never written |
 | `../dartway_starter_server/Dockerfile` | the server image, built from the project root |
 | `../dartway_starter_flutter/Dockerfile` | the web image; the deploy passes it `DW_BACKEND_URL` |
+| `../dartway_starter_flutter/nginx.conf` | how that image serves the build, and above all **what a browser may keep** — see "Caching" |
 | `compose.override.yml` | anything this project adds to a standard deployment — create it when that happens. Read from the checkout on every deploy, so a committed change to it takes effect on the next `run` |
 | `nginx.d/{http,api,app}/*.conf` | extra Nginx directives, if any are ever needed |
 
@@ -36,6 +37,31 @@ every push turns a routine change into an infrastructure one. `compose.override.
 is the opposite: it is never copied to the server, only named on every Compose
 call, so the file the deploy merges is the committed one.
 
+## Caching — why a redeploy might not reach the browser
+
+**A Flutter web build hashes nothing.** `index.html`, `flutter_bootstrap.js`,
+`flutter.js`, `main.dart.js`, `main.dart.wasm` and every file under `assets/`
+carry the same name in every build. The familiar rule — "fingerprinted assets
+are immutable, cache them for a year" — is correct for a bundler that puts a
+content hash in the name, and here it lands on exactly the files that change on
+every deploy. A browser that took one under a long `max-age` will not ask again:
+it goes on running the previous build while the server serves the new one, and
+nothing anywhere reports it.
+
+So `../dartway_starter_flutter/nginx.conf` serves everything a build emits with
+`Cache-Control: no-cache` — the copy is kept, it just may not be reused before
+the server has confirmed it, which with an ETag costs a 304 rather than a
+download — and keeps the long-lived, immutable rule for names that genuinely
+carry a content hash. `dartway deploy check` reads that file and, separately,
+asks the deployed site what it actually answers.
+
+**Fixing the configuration does not un-poison the browsers already out there.**
+A response taken under `max-age=2592000` stays fresh in that browser for the
+rest of the thirty days, and it will not ask. Tell whoever you can reach to
+hard-reload (Ctrl+Shift+R) or clear site data; for the rest, either wait the
+window out or move the app to a URL that was never poisoned — a URL a browser
+has not seen is the only thing that gets through.
+
 ## Secrets
 
 `../dartway_starter_server/config/passwords.yaml` is **git-ignored** and holds
@@ -45,12 +71,20 @@ environment live on the server, outside the checkout, so the `git reset --hard`
 a deploy performs cannot touch them; `dartway deploy secret push/pull` moves
 them between the two.
 
-A credential that is a whole file — a service-account JSON, an `.env` for some
-integration — goes to the server with `dartway deploy secret put-file` and is
-named under `requires.files` in `config.yaml`. The deploy mounts each declared
-file read-only at `/app/config/<name>` in the server container, so the
-application reads it as `config/<name>`, and `dartway deploy check` asserts that
-the mount is really there rather than only that the file reached the machine.
+**The split is by shape.** A short value — a token, an identifier, a password —
+is a key in `passwords.yaml`. A credential that is a whole document — a
+service-account JSON, an `.env` for some integration — goes to the server with
+`dartway deploy secret put-file` and is named under `requires.files` in
+`config.yaml`. The deploy mounts each declared file read-only at
+`/app/config/<name>` in the server container, so the application reads it as
+`config/<name>` — the same path it reads locally — and `dartway deploy check`
+asserts that the mount is really there rather than only that the file reached
+the machine.
+
+A document does not belong in `passwords.yaml` even when it fits: that file is
+the master copy of every environment's secrets, and a value beginning with `{`
+is parsed by unquoted YAML as a mapping rather than as text, so what the
+application receives is not what was written.
 
 > `serviceSecret` is also the key other credentials are encrypted with, where a
 > project encrypts any. Rotating it makes them unreadable. Rotate deliberately.

--- a/template/deploy/config.yaml.example
+++ b/template/deploy/config.yaml.example
@@ -41,13 +41,21 @@ staging:
   # file. Listing them turns "the container starts and immediately dies" into a
   # pre-deploy error.
   #
+  # The split is by shape, not by importance. `secrets` are short values and
+  # live in passwords.yaml; `files` are whole documents — a service-account
+  # JSON, an .env for some integration — which do not belong in a passwords
+  # file at all: that file is the master copy of every environment's secrets,
+  # and an unquoted value starting with `{` is read by YAML as a mapping rather
+  # than as text.
+  #
   # `files` are delivered with `dartway deploy secret put-file` and mounted
   # read-only into the server container at /app/config/<name>, beside
-  # passwords.yaml — so the application reaches one as `config/<name>`. Each
-  # entry is a file name exactly as the store holds it: a pattern or a path
-  # cannot be mounted, and is refused rather than rendered.
+  # passwords.yaml — so the application reaches one as `config/<name>`, the
+  # same path it reads locally. Each entry is a file name exactly as the store
+  # holds it: a pattern or a path cannot be mounted, and is refused rather than
+  # rendered.
   # requires:
   #   secrets:
-  #     - firebaseServiceAccountKey
+  #     - fcmProjectId
   #   files:
-  #     - integrations.env
+  #     - fcm-service-account.json

--- a/toolkit/skills/dartway-push-delivery/SKILL.md
+++ b/toolkit/skills/dartway-push-delivery/SKILL.md
@@ -80,12 +80,58 @@ void initDartwayCore({required Map<String, String> passwords}) {
 }
 ```
 
-Default password keys are `fcmProjectId`, `fcmServiceAccountJson`,
-`rustorePushProjectId`, `rustorePushServiceToken`; override them in
-`fromPasswords`. Secrets stay in the app and never reach the queue or logs.
-Include only providers whose `isConfigured == true`; if none are, keep `dwPush`
-null. Icons and colours are the app's choice — pass optional `webpushIcon`,
-`androidIcon`, `androidColor` explicitly.
+### Credentials come from two places, and which one is not a preference
+
+**Short values go in `passwords.yaml`; a credential that is a whole document
+goes in as a file.** Default password keys are `fcmProjectId`,
+`rustorePushProjectId`, `rustorePushServiceToken` — two identifiers and a token,
+each a line long. FCM's service account is a couple of thousand characters of
+JSON and is **not** a password key: it is delivered with
+`dartway deploy secret put-file`, named under `requires.files` in
+`deploy/config.yaml`, and read from `config/fcm-service-account.json` — a
+relative path that resolves to the same file locally and inside the container,
+where the deploy mounts every declared file at `/app/config/<name>` beside
+`passwords.yaml`. `fromPasswords` reads it from there by default;
+`serviceAccountFile:` names a different path.
+
+A document in `passwords.yaml` is a document in the master copy of **every**
+environment's secrets, and it carries a silent failure: the value starts with
+`{`, so unquoted YAML parses it as a flow mapping rather than as a string.
+
+So `passwords.yaml.example` documents the project id and nothing else:
+
+```yaml
+staging:
+  # Push. Naming this key is what declares that this environment sends push —
+  # the server refuses to start when it is set and the credential is missing.
+  # The service account is not a password but a file: deliver it with
+  # `dartway deploy secret put-file fcm-service-account.json`, list it under
+  # requires.files in deploy/config.yaml, and it is read as
+  # config/fcm-service-account.json.
+  fcmProjectId:
+```
+
+### Half-configuration fails at startup, by design
+
+A provider's project id is its **declaration**. Once it is present, everything
+else that provider needs has to be there too, or the config constructor throws
+`DwPushProviderConfigurationException` and the server does not start — naming
+what is missing and where it was looked for. A service account that is not a
+JSON object (a truncated upload, a YAML value that lost its quotes) is refused
+the same way.
+
+Deliberate, because `isConfigured == false` used to be the answer both to "we do
+not send push here" and to "the key never reached this environment": a forgotten
+credential looked exactly like a decision, and was noticed weeks later by
+somebody asking why a notification never arrived.
+
+An environment that genuinely wants no push declares nothing — no project id, no
+file — and `isConfigured` is false without anyone being lied to.
+
+Secrets stay in the app and never reach the queue or logs. Include only
+providers whose `isConfigured == true`; if none are, keep `dwPush` null. Icons
+and colours are the app's choice — pass optional `webpushIcon`, `androidIcon`,
+`androidColor` explicitly.
 
 `DwPushConfig` is deliberately small: `recipientResolver` and `transport` are the
 whole surface most apps write. Every tuning knob lives on an optional
@@ -342,6 +388,8 @@ user. The module deliberately keeps no "who is admin" concept.
   endpoint of the app's own, and never takes the recipient from the request;
 - the app half passes no `recipientIdProvider`, and the `plugins:` list mentions
   `dw` nowhere;
+- the FCM service account is a file under `requires.files`, never a key in
+  `passwords.yaml`; the project id is a password key and declares the intent;
 - raw token/credentials/provider body never logged;
 - deduplication key stable and unique; `expiresAt` always set;
 - worker scheduled via `DwRecurringFutureCall`; several instances safe;


### PR DESCRIPTION
**A Flutter web build hashes nothing.** `index.html`, `flutter_bootstrap.js`,
`flutter.js`, `main.dart.js`, `main.dart.wasm` and everything under `assets/`
carry the same names in every build — so the ordinary rule "hashed assets are
immutable, cache them for a year" lands on precisely the files that change on
every deploy. The templates shipped no serving configuration at all, each
project invented one, and what it invented gave `expires 1y; immutable` to every
image and font. A freshly deployed app then keeps answering from the previous
build: in the reported case the server served a newer bridge protocol while the
browser went on running the older one, and every check said the right thing.

The configuration is shipped now, as a file the image copies rather than a
heredoc nobody can diff, and its default is inverted from the usual — everything
is `no-cache`, meaning kept but revalidated, with `etag on;` so revalidation
costs a 304 rather than a download. The one long-lived rule matches names a
project's own build step fingerprinted.

Two checks guard it, and they are deliberately unequal. `web-cache-policy` reads
the configuration text and **warns**, because text can hide an `include` from
outside the build context or a header a front proxy adds later, and a deploy
must not be blocked on a guess. `web-cache-headers` asks the running site — six
HEAD requests — and **fails**, because a header the server actually handed back
leaves nothing to interpret. It accepts a bad certificate on purpose: refusing
would make it skip in silence on a server still carrying the one-day self-signed
certificate `setup` installs, which is exactly the deployment most likely to be
serving a configuration nobody has looked at.

**Fixing the configuration does not un-poison a browser that already holds a
copy**, and that is written in four places rather than left to be rediscovered:
a response taken under `max-age=2592000` stays fresh for the rest of the window
and the browser does not ask. Reachable people hard-reload; for the rest the
only thing that gets through is a URL they have never seen.

**And the scaffold stops steering a service-account JSON into `passwords.yaml`.**
The generated comment described the whole document "on one line" while the CLI
already had `put-file`, and the value starts with `{`, so unquoted YAML parses it
as a flow mapping rather than a string. It travels as a file now, mounted where
`requires.files` puts it — the same relative path locally and in the container.
The split is by shape, not by importance: a short value is a password, a
document is a file.

**A provider that was asked for and not finished now refuses to start.**
`isConfigured` returning `false` on a missing field made "we don't need push"
and "we forgot the key" indistinguishable from inside, so push went quietly
absent in production. The project id is the declaration: name it and everything
else must be there, or the constructor throws and says what is missing and where
it looked. An environment that wants no push declares nothing and is believed.

Two operational notes for whoever upgrades an existing project. The serving
configuration is now a required build input, so a project that updates its
Dockerfile without copying `nginx.conf` fails `docker build` loudly — the check
still reads the old heredoc shape, so an unmigrated project is judged rather
than ignored. And a deployment that has been running without push because a key
was missing will now fail to start until the key is supplied or the project id
removed, which is the whole point.

Closes #68
Closes #74

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
