### PR TITLE
fix(offline): make integer bounds web-compatible

### DIFF
--- a/packages/dartway_offline/dartway_offline_flutter/CHANGELOG.md
+++ b/packages/dartway_offline/dartway_offline_flutter/CHANGELOG.md
@@ -14,3 +14,6 @@
   `DwRepoLocalReads` conformance suites.
 - Manifest v2 accepts an application-calculated `leaseValidUntilUtc`. The framework verifies the
   signed boundary but carries no application-specific access categories or duration rules.
+- Web compilation no longer encounters JavaScript-inexact 64-bit integer literals: unbounded
+  leases use a far-future web-safe timestamp, while download size validation keeps the exact
+  SQLite integer boundary through `BigInt`.

--- a/packages/dartway_offline/dartway_offline_flutter/lib/src/access/dw_offline_access_store.dart
+++ b/packages/dartway_offline/dartway_offline_flutter/lib/src/access/dw_offline_access_store.dart
@@ -24,6 +24,7 @@ final class DwOfflineAccessStore implements DwOfflineRepositoryReadPolicy {
   }
 
   static const int _recordSchemaVersion = 1;
+  static const int _unboundedExpiryEpochMs = 253402300799999;
 
   final DwOfflineDatabase _database;
   final DwOfflineManifestVerifier _manifestVerifier;
@@ -74,7 +75,7 @@ final class DwOfflineAccessStore implements DwOfflineRepositoryReadPolicy {
             trustedAtEpochMs: nowEpochMs,
             expiresAtEpochMs:
                 lease.validUntilUtc?.millisecondsSinceEpoch ??
-                0x7fffffffffffffff,
+                _unboundedExpiryEpochMs,
           ),
         );
   }

--- a/packages/dartway_offline/dartway_offline_flutter/lib/src/download/dw_download_plan.dart
+++ b/packages/dartway_offline/dartway_offline_flutter/lib/src/download/dw_download_plan.dart
@@ -30,6 +30,10 @@ final class DwDownloadAssetPlan {
 }
 
 final class DwDownloadPackagePlan {
+  static final BigInt _maximumSqliteInteger = BigInt.parse(
+    '9223372036854775807',
+  );
+
   DwDownloadPackagePlan({
     required this.userScopeId,
     required this.packageId,
@@ -53,7 +57,7 @@ final class DwDownloadPackagePlan {
         throw ArgumentError('Download plan contains a duplicate asset.');
       }
     }
-    if (packageTotalBytes > 0x7fffffffffffffff) {
+    if (BigInt.from(packageTotalBytes) > _maximumSqliteInteger) {
       throw ArgumentError('Download package exceeds SQLite integer range.');
     }
   }

--- a/packages/dartway_offline/dartway_offline_flutter/test/access/dw_offline_access_store_test.dart
+++ b/packages/dartway_offline/dartway_offline_flutter/test/access/dw_offline_access_store_test.dart
@@ -95,6 +95,23 @@ void main() {
     );
   });
 
+  test(
+    'persists an unbounded lease with a web-safe far-future expiry',
+    () async {
+      final manifest = await manifestFixture.verify(
+        assets: const [],
+        unboundedLease: true,
+      );
+
+      await accessStore.persistVerifiedManifestLease(manifest);
+
+      final storedLease = await database
+          .select(database.dwOfflineLeases)
+          .getSingle();
+      expect(storedLease.expiresAtEpochMs, 253402300799999);
+    },
+  );
+
   test('lease lookup treats SQL wildcard characters as literal text', () async {
     final candidate = await manifestFixture.verify(
       assets: const [],
@@ -114,7 +131,7 @@ void main() {
               'signedManifestEnvelopeJson': candidate.canonicalEnvelopeJson,
             }),
             trustedAtEpochMs: 0,
-            expiresAtEpochMs: 0x7fffffffffffffff,
+            expiresAtEpochMs: 253402300799999,
           ),
         );
 

--- a/packages/dartway_offline/dartway_offline_flutter/test/support/dw_download_plan_web_fixture.dart
+++ b/packages/dartway_offline/dartway_offline_flutter/test/support/dw_download_plan_web_fixture.dart
@@ -1,0 +1,21 @@
+import 'package:dartway_offline_flutter/src/download/dw_download_plan.dart';
+
+void main() {
+  final downloadPlan = DwDownloadPackagePlan(
+    userScopeId: 'scope-a',
+    packageId: 'package-a',
+    manifestRevision: 'manifest-a',
+    manifestDigest: 'digest-a',
+    priority: 0,
+    assets: [
+      DwDownloadAssetPlan(
+        assetId: 'asset-a',
+        assetRevision: 'revision-a',
+        expectedSizeBytes: 1,
+      ),
+    ],
+  );
+  if (!downloadPlan.jobId.startsWith('dw_')) {
+    throw StateError('Download plan did not create a stable job id.');
+  }
+}

--- a/packages/dartway_offline/dartway_offline_flutter/test/web/dw_offline_web_compile_test.dart
+++ b/packages/dartway_offline/dartway_offline_flutter/test/web/dw_offline_web_compile_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('download plan compiles to JavaScript', () async {
+    final outputDirectory = await Directory.systemTemp.createTemp(
+      'dw_offline_web_compile_',
+    );
+    addTearDown(() => outputDirectory.delete(recursive: true));
+
+    final compileResult = await Process.run(
+      'dart',
+      [
+        'compile',
+        'js',
+        'test/support/dw_download_plan_web_fixture.dart',
+        '-o',
+        '${outputDirectory.path}/fixture.js',
+      ],
+      workingDirectory: Directory.current.path,
+      runInShell: Platform.isWindows,
+    );
+
+    expect(
+      compileResult.exitCode,
+      0,
+      reason: '${compileResult.stdout}\n${compileResult.stderr}',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- replace the JavaScript-inexact unbounded lease sentinel with a web-safe far-future timestamp
- preserve exact SQLite integer range validation through BigInt
- add a dart2js compile regression for the offline download plan

## Testing
- flutter test --no-pub (232 passed)
- dart analyze lib test
- Flutter Web smoke build with dartway_offline_flutter imported