### PR TITLE
feat(testing): the repository speaks to a port, and every project gets the tests that use it

### DIFF
--- a/docs/3-flutter/data-layer.md
+++ b/docs/3-flutter/data-layer.md
@@ -357,16 +357,20 @@ core sends everything through**. A test hands `DwCore` its own instead of a Serv
 ```dart
 import 'package:dartway_serverpod_core_flutter/testing.dart';
 
-final transport = DwRecordingServerTransport(classNames: {Lesson: 'Lesson'});
+// Your own generated Protocol — the same object the real client carries, and
+// the only thing that names your models correctly. A generated model is an
+// abstract class with a private implementation, so its `runtimeType` reads
+// `_LessonImpl`. Import it prefixed: the DartWay core declares a `Protocol` too.
+final transport = DwRecordingServerTransport(
+  serializationManager: app.Protocol(),
+);
 
-setUpAll(() {
-  dw = DwCore<Client, UserProfile>(
-    config: const DwConfig(defaultModelGetter: dwGetDefault),
-    transport: transport,          // instead of client:, not beside it
-    dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
-    getUserId: (profile) => profile?.id,
-  );
-});
+// Booted through the app's own initializer — the real bootstrap with one thing
+// swapped — so a test never stands a second, subtly different core beside the
+// one the app ships. Give the initializer an optional `transport` and build no
+// Serverpod client when it is set: a client brings a connectivity monitor and an
+// auth key manager, both of which reach for platform channels.
+setUpAll(() => initAppDwCore(transport: transport));
 
 testWidgets('the button saves the lesson', (tester) async {
   transport.answerGetAll = (_) async => lessonsResponse([draft]);
@@ -380,6 +384,10 @@ testWidgets('the button saves the lesson', (tester) async {
   expect((transport.saves.single.model as Lesson).isPublished, isTrue);
 });
 ```
+
+The worked version of all of this is
+[`example/dartway_example_flutter/test/`](https://github.com/dartway/dartway/tree/master/example/dartway_example_flutter/test) —
+the news feature, its read states and its write, with the shared harness in `test/support/`.
 
 Reads must be prepared; writes need not be. A read nobody answered throws `DwUnpreparedServerCall`
 naming the call and the field that would answer it — a test that does not know what its subject
@@ -398,6 +406,19 @@ Two things to know before writing the test at all:
   transport first; `dw.repo.localWrites` is reached only after the connection refuses it. Reaching
   for it to watch a save would force every save to declare itself queued, which is a lie about
   intent.
+
+And two things that surprise every test that meets them, both of which are about time rather than
+about the transport:
+
+- **`pumpAndSettle` does not drain a notification.** A successful
+  `dw.action(onSuccessNotification: ...)` inserts a toast that removes itself on a `Future.delayed`,
+  and settling waits for frames, not for timers. The test then fails on "A Timer is still pending
+  even after the widget tree was disposed" — an error about the toast, in a test about a save. Pump
+  `DwUiNotification.defaultDuration` after the tap, once, in a shared helper.
+- **A failed read is retried.** Riverpod retries a failed provider on its own with a growing
+  backoff, so a read you made fail is attempted many times while the test settles. Assert the shape
+  of what was asked (`transport.reads.map((r) => r.operation)`), not the count — a count pins
+  somebody else's default.
 
 What this covers is "the button reached `saveModel` with this model". What covers the **rule** —
 who may save what — is an integration test over the CRUD config on the server, where the rule lives.

--- a/docs/3-flutter/data-layer.md
+++ b/docs/3-flutter/data-layer.md
@@ -345,6 +345,63 @@ scroll position and renders the same skeletons.
 equal config share one state; a config rebuilt with a fresh closure (`customUpdatesListener`,
 `updatesSortingMethod`) does not, and silently gets its own. Keep such configs out of `build`.
 
+## Testing a feature that reads and writes for itself
+
+A feature built the way this page describes hands nothing out: it watches its own provider and calls
+`dw.repo.saveModel` in its own action. There is no callback for a test to assert on, and **you should
+not keep one alive as a test seam** — that buys a weaker screen for a weaker test.
+
+The seam is one level down, and it is the same one the framework uses on itself: **the transport the
+core sends everything through**. A test hands `DwCore` its own instead of a Serverpod client:
+
+```dart
+import 'package:dartway_serverpod_core_flutter/testing.dart';
+
+final transport = DwRecordingServerTransport(classNames: {Lesson: 'Lesson'});
+
+setUpAll(() {
+  dw = DwCore<Client, UserProfile>(
+    config: const DwConfig(defaultModelGetter: dwGetDefault),
+    transport: transport,          // instead of client:, not beside it
+    dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
+    getUserId: (profile) => profile?.id,
+  );
+});
+
+testWidgets('the button saves the lesson', (tester) async {
+  transport.answerGetAll = (_) async => lessonsResponse([draft]);
+
+  await tester.pumpWidget(const App());
+  await tester.pumpAndSettle();
+  await tester.tap(find.byIcon(Icons.check));
+  await tester.pumpAndSettle();
+
+  expect(transport.saves, hasLength(1));
+  expect((transport.saves.single.model as Lesson).isPublished, isTrue);
+});
+```
+
+Reads must be prepared; writes need not be. A read nobody answered throws `DwUnpreparedServerCall`
+naming the call and the field that would answer it — a test that does not know what its subject
+fetches is the thing being caught. A save answers by echoing the model back, because the assertion
+is about what *left*; set `answerSave` when the response itself matters, such as the id assigned on
+insert.
+
+Two things to know before writing the test at all:
+
+- **The core has to be up for the widget to render**, not only for the tap. `dw.action(...)` is
+  constructed in `build`, so a feature reaches `dw` while building — without a core the subtree does
+  not build and the test fails later at a finder ("found 0 widgets"), with the real cause in a
+  separate exception block above. Boot it from `setUpAll` through the app's own initializer, and keep
+  that initializer idempotent so no test file has to know whether another one got there first.
+- **The offline store is not this seam**, and is documented not to be. A write always leaves by the
+  transport first; `dw.repo.localWrites` is reached only after the connection refuses it. Reaching
+  for it to watch a save would force every save to declare itself queued, which is a lie about
+  intent.
+
+What this covers is "the button reached `saveModel` with this model". What covers the **rule** —
+who may save what — is an integration test over the CRUD config on the server, where the rule lives.
+
 ## Escape hatches
 
 Reach for these only when a provider genuinely does not fit — an imperative flow that owns its own

--- a/docs/5-tooling/agent-toolkit.md
+++ b/docs/5-tooling/agent-toolkit.md
@@ -31,7 +31,7 @@ worse than a missing one — the agent writes non-working code with full confide
 ```
 .claude/
   CLAUDE.md                    # the methodology, always in the agent's context
-  skills/dartway-*/SKILL.md    # 12 skills, loaded by relevance to the task
+  skills/dartway-*/SKILL.md    # 13 skills, loaded by relevance to the task
   commands/commit.md
   commands/dartway-checkup.md
 ```
@@ -158,6 +158,13 @@ raw styles inside features.
 **`dartway-push-delivery`** — server-side push through the optional `dartway_push_server` module:
 the engine, recipient resolution, FCM/RuStore transports, idempotent enqueue, retries, campaign
 progress. Opt-in — an app that does not depend on it has no push tables.
+
+**`dartway-testing`** — where a test goes and how to write it: a rule from a `DwCrudConfig` is an
+integration test on the server against a live database, plain logic is a unit test, and a feature is
+a widget test with the core booted and the server standing in as a recording transport. A DartWay
+feature saves for itself and hands no callback out, so the technique is not guessable — and the
+skeleton ships a worked example of each layer in its `test/` folder. Also what is deliberately not
+tested, and why there are no coverage thresholds.
 
 **`dartway-finish`** — the definition of done before a commit or PR: audits the diff against the
 contract, checks the feature's description for drift and the test coverage, then shows suggestions

--- a/docs/5-tooling/conventions-checker.md
+++ b/docs/5-tooling/conventions-checker.md
@@ -126,6 +126,9 @@ commit over a 210-line file is a check people disable.
 | `fileLong` | info | Over 200 lines |
 | `fileTooLong` | warning | Over 350 lines |
 | `generatedCodeUnformatted` | warning | The server's `lib/src/generated/` or the client's `lib/src/protocol/` differs from `dart format` |
+| `crudConfigMissing` | warning | A model with a table and no `DwCrudConfig` — the app cannot reach it |
+| `crudConfigUnregistered` | error | A config that exists and is not in `crudConfigurations` |
+| `crudRuleUntested` | warning | A config carrying save or delete logic that no server test names |
 
 "Raw styles" means `Color(`, `TextStyle(`, `BorderRadius`, `Theme.of(context)`, `context.theme`,
 `context.textTheme`, `context.colorScheme`. The long spelling is in the list on purpose: the rule
@@ -224,6 +227,40 @@ the check exists at all — `app/admin/` is a perfectly ordinary group as far as
 concerned, which is how the admin panel spent a release outside the checks that were written for
 it. The pass covers the server package too (`lib/src/`), and `--dir` skips it, the same way it
 skips `ui_kit/`.
+
+## The three server checks: what fails closed, nobody sees fail
+
+The Flutter checks above catch code that is wrong in a way you can point at. The server ones catch
+something else — a project that is missing a piece, where every symptom is an absence.
+
+Generic CRUD is **secure by default**: a model nobody configured refuses every read and write with
+`notConfigured`. That is the right default, and it is silent. The table migrates, the server starts,
+the app compiles, and a list is empty forever. `crudConfigMissing` names the model, and it is a
+warning rather than an error because the absence has a second, legitimate reading — a table the
+server owns alone and no client should ever see. The check cannot tell the two apart; you can, and
+saying which it is costs one doc comment.
+
+`crudConfigUnregistered` is the same failure with no second reading, and it is the one worth the
+error. The config was written. It sits in `lib/src/crud/`, it reviews as finished, it has the access
+rules and the validation in it — and it was never added to the `crudConfigurations` list, so the API
+answers exactly as if the file did not exist. Nothing else in the toolchain has any opinion about
+this: it compiles, and the config is a value nobody is required to use.
+
+`crudRuleUntested` is the one that came out of writing the [testing skill](agent-toolkit.md). A CRUD
+config that only declares a shape — an `accessFilter`, an `include` — has no rule to hold and is not
+asked for anything. One that carries hand-written save or delete logic does, and that logic runs
+inside a request and reads the database to decide: no widget test can reach it, and a widget test
+proving the admin-only button is hidden proves only that the button is hidden. So the check looks
+for the model's name anywhere under the server's `test/`, and says so when it finds nothing. A
+mention is a loose signal on purpose — it is enough to raise the question and not enough to fail a
+build on, which is why this one is a warning too.
+
+**None of the three counts anything.** There is no percentage here and no threshold: each finding
+names one model and one thing to do about it. That is also why two things the checker could have
+guessed at are deliberately absent. A Flutter feature's tests are not countable without becoming the
+coverage number this exists instead of. And an *Event model* — a change written on top of a base — is
+a domain reading with no marker in the YAML: a rule keying off an `*Event` suffix would miss the one
+called `BalanceEntry` and fire on the one that is a plain lookup table.
 
 ## Why `generatedCodeUnformatted` is a warning that names a command
 

--- a/example/dartway_example_flutter/lib/core/dev/test_error_button.dart
+++ b/example/dartway_example_flutter/lib/core/dev/test_error_button.dart
@@ -29,8 +29,10 @@ class TestErrorButton extends ConsumerWidget {
             )(context);
           case 'call':
             // A server call that fails on the backend → onFailedCall path
-            // with `endpoint.method` attached.
-            dw.endpointCaller.dwCrud.getOne(
+            // with `endpoint.method` attached. Straight down the transport,
+            // deliberately: dw.repo would be the way to actually read
+            // something, and there is nothing here to read.
+            dw.serverTransport.getOne(
               className: 'NoSuchModel',
               filter: const DwBackendFilter<int>.value(
                 type: DwBackendFilterType.equals,

--- a/example/dartway_example_flutter/lib/core/dw_core.dart
+++ b/example/dartway_example_flutter/lib/core/dw_core.dart
@@ -20,28 +20,39 @@ String exampleAppVersion = 'local';
 /// backend URL can be supplied as a runtime development parameter.
 late final DwCore<Client, UserProfile> dw;
 
-/// Builds the global [dw] core using the development [backendUrl]. Called once
-/// from `DartwayExampleApp.run` before any widget reads `dw`.
-void initExampleDwCore({required String backendUrl}) {
+bool _coreInitialized = false;
+
+/// Builds the global [dw] core using the development [backendUrl]. Called from
+/// `DartwayExampleApp.run` before any widget reads `dw`.
+///
+/// Calling it again does nothing, and that is what makes it usable from a
+/// widget test's `setUpAll`. Tests need it more often than it looks: anything
+/// reached through `dw.` — `dw.userProfileProvider` among them — needs the core
+/// to exist merely to be *named*, so a test that pumps a subtree touching the
+/// router needs a booted core even when it knows nothing about the session.
+/// Without the guard, the second test file in a run would meet a
+/// `LateInitializationError` on an already-initialized field.
+///
+/// The app passes [backendUrl]; a widget test passes [transport] instead and no
+/// Serverpod client is built at all — see `test/support/example_test_core.dart`.
+/// That is not an optimisation: a client brings a connectivity monitor and an
+/// auth key manager with it, both of which reach for platform channels a widget
+/// test has no business answering. Without a key manager there is no session
+/// either, so `dw.initDwCore` is safe to call from `setUpAll` and a test that
+/// needs a signed-in profile overrides `dw.requireUserProfileProvider` in its
+/// own `ProviderScope`.
+void initExampleDwCore({String? backendUrl, DwServerTransport? transport}) {
+  if (_coreInitialized) return;
+  _coreInitialized = true;
+
   dw = DwCore<Client, UserProfile>(
     config: DwConfig(
       defaultModelGetter: dwGetDefault,
       // Shown in error reports next to the platform and user.
       appVersion: exampleAppVersion,
     ),
-    client:
-        Client(
-            backendUrl,
-            // Connection-level failures (timeout/offline) → a toast, not an alert;
-            // everything else enters the dw error pipeline with `endpoint.method`
-            // attached and is alerted out of the box with the app context.
-            onFailedCall: dwReportingOnFailedCall(
-              onConnectionError: (_, _) =>
-                  dw.notify.error(appL10n.networkErrorTryAgain),
-            ),
-          )
-          ..connectivityMonitor = FlutterConnectivityMonitor()
-          ..authKeyProvider = DwAuthenticationKeyManager(),
+    client: backendUrl == null ? null : _buildClient(backendUrl),
+    transport: transport,
     // No telegram config here: locally the alerts degrade to logging. To see
     // the full formatted alert in the console use
     // `DwAlerts.init(logErrors: true, logFunction: debugPrint)`.
@@ -51,3 +62,17 @@ void initExampleDwCore({required String backendUrl}) {
         debugPrint('[example] realtime status → $status'),
   );
 }
+
+Client _buildClient(String backendUrl) =>
+    Client(
+        backendUrl,
+        // Connection-level failures (timeout/offline) → a toast, not an alert;
+        // everything else enters the dw error pipeline with `endpoint.method`
+        // attached and is alerted out of the box with the app context.
+        onFailedCall: dwReportingOnFailedCall(
+          onConnectionError: (_, _) =>
+              dw.notify.error(appL10n.networkErrorTryAgain),
+        ),
+      )
+      ..connectivityMonitor = FlutterConnectivityMonitor()
+      ..authKeyProvider = DwAuthenticationKeyManager();

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -298,7 +298,7 @@ packages:
       path: "../../packages/dartway_router"
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.2"
   dartway_serverpod_core_client:
     dependency: "direct overridden"
     description:

--- a/example/dartway_example_flutter/test/app/news/create_news_post_sheet_test.dart
+++ b/example/dartway_example_flutter/test/app/news/create_news_post_sheet_test.dart
@@ -1,0 +1,91 @@
+import 'package:dartway_example_client/dartway_example_client.dart';
+import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:dartway_example_flutter/app/news/widgets/create_news_post_sheet.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../support/example_test_core.dart';
+
+/// The write half of the news feature: it renders, you fill it in, you tap
+/// publish, and what leaves for the server is exactly what you typed.
+///
+/// The sheet takes no callback and returns no value — it saves for itself, the
+/// way `dartway-data-layer` says a feature should. So there is nothing to spy
+/// on above it, and the assertion lives one level below: on the transport the
+/// core sends every write through.
+void main() {
+  setUpAll(bootExampleTestCore);
+  setUp(resetExampleTestCore);
+
+  final author = staffProfile(id: 7, firstName: 'Sam');
+
+  testWidgets('publishes what was typed, under the signed-in author', (
+    tester,
+  ) async {
+    await tester.pumpFeature(const CreateNewsPostSheet(), signedInAs: author);
+
+    await tester.enterText(
+      find.byType(TextField).first,
+      '  Pool closed on Monday  ',
+    );
+    await tester.enterText(find.byType(TextField).last, '  Maintenance day.  ');
+    // Settle, not pump: `AppTextFormField` delivers `onChanged` from a
+    // post-frame callback, so the form's own state — and with it whether the
+    // button is enabled — is one frame behind the keystroke.
+    await tester.pumpAndSettle();
+
+    expect(exampleTransport.saves, isEmpty, reason: 'nothing saves on typing');
+
+    await tester.tapAndSettle(find.text('Publish'));
+
+    expect(exampleTransport.saves, hasLength(1));
+    final saved = exampleTransport.saves.single;
+    expect(saved.wrappedModel.className, 'NewsPost');
+    expect(saved.apiGroup, isNull);
+
+    final post = saved.model as NewsPost;
+    // Trimmed, which is the sheet's own rule and the reason the input above has
+    // padding around it.
+    expect(post.title, 'Pool closed on Monday');
+    expect(post.text, 'Maintenance day.');
+    // The author is the signed-in user, not anything the form offered.
+    expect(post.authorProfileId, author.id);
+    // A create, not an update: the id is the server's to assign.
+    expect(post.id, isNull);
+  });
+
+  testWidgets('refuses to publish until both fields are filled', (
+    tester,
+  ) async {
+    await tester.pumpFeature(const CreateNewsPostSheet(), signedInAs: author);
+
+    await tester.tapAndSettle(find.text('Publish'));
+    expect(exampleTransport.saves, isEmpty);
+
+    // A title alone is not enough, and neither is whitespace in the body.
+    await tester.enterText(find.byType(TextField).first, 'Pool closed');
+    await tester.enterText(find.byType(TextField).last, '   ');
+    await tester.pumpAndSettle();
+    await tester.tapAndSettle(find.text('Publish'));
+    expect(exampleTransport.saves, isEmpty);
+  });
+
+  testWidgets('tells the user when the server refuses the post', (
+    tester,
+  ) async {
+    exampleTransport.answerSave = (_) async =>
+        const DwApiResponse<DwModelWrapper>.forbidden();
+
+    await tester.pumpFeature(const CreateNewsPostSheet(), signedInAs: author);
+    await tester.enterText(find.byType(TextField).first, 'Pool closed');
+    await tester.enterText(find.byType(TextField).last, 'Maintenance day.');
+    await tester.pumpAndSettle();
+
+    await tester.tapAndSettle(find.text('Publish'));
+
+    // The write still left — the rule lives on the server, and this is the
+    // client finding out. What matters is that the refusal is not swallowed.
+    expect(exampleTransport.saves, hasLength(1));
+    expect(find.text('Post published!'), findsNothing);
+  });
+}

--- a/example/dartway_example_flutter/test/app/news/news_post_list_test.dart
+++ b/example/dartway_example_flutter/test/app/news/news_post_list_test.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+
+import 'package:dartway_example_flutter/app/news/widgets/news_post_card.dart';
+import 'package:dartway_example_flutter/app/news/widgets/news_post_list.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../support/example_test_core.dart';
+
+/// The read half of the news feature, in the three states that actually break:
+/// still loading, nothing to show, and the server saying no.
+///
+/// The list asks for nothing and is handed nothing — it watches
+/// `dw.repo.modelList<NewsPost>()` and draws whatever comes back. So the only
+/// place to stand is the transport, which is what the core was handed instead
+/// of a Serverpod client.
+void main() {
+  setUpAll(bootExampleTestCore);
+  setUp(resetExampleTestCore);
+
+  testWidgets('draws a skeleton while the server has not answered', (
+    tester,
+  ) async {
+    final answer = Completer<void>();
+    exampleTransport.answerGetAll = (_) async {
+      await answer.future;
+      return newsPostsResponse(const []);
+    };
+
+    await tester.pumpFeature(const NewsPostList());
+    await tester.pump();
+
+    // The skeleton is built from the registered default model, so it has the
+    // shape of a real card rather than a spinner.
+    expect(find.byType(NewsPostCard), findsWidgets);
+    expect(find.text('Pool closed on Monday'), findsNothing);
+
+    answer.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('draws every post the server answered with', (tester) async {
+    exampleTransport.answerGetAll = (_) async => newsPostsResponse([
+      newsPost(id: 1, title: 'Pool closed on Monday'),
+      newsPost(id: 2, title: 'New yoga coach'),
+    ]);
+
+    await tester.pumpFeature(const NewsPostList());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pool closed on Monday'), findsOneWidget);
+    expect(find.text('New yoga coach'), findsOneWidget);
+    expect(find.byType(NewsPostCard), findsNWidgets(2));
+
+    // The list is unfiltered on purpose — news is readable by everyone signed
+    // in — and this is where that stops being a claim in a doc comment. The
+    // request still carries a filter object: the list always sends one, and an
+    // empty `and` is how it says "narrow nothing".
+    final read = exampleTransport.reads.single;
+    expect(read.operation, 'getAll');
+    expect(read.className, 'NewsPost');
+    expect(read.apiGroup, isNull);
+    expect(read.filter!.children, isEmpty);
+  });
+
+  testWidgets('says there is no news rather than showing an empty page', (
+    tester,
+  ) async {
+    exampleTransport.answerGetAll = (_) async => newsPostsResponse(const []);
+
+    await tester.pumpFeature(const NewsPostList());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NewsPostCard), findsNothing);
+    expect(find.text('No news yet — stay tuned!'), findsOneWidget);
+  });
+
+  testWidgets('does not claim there is no news when the read failed', (
+    tester,
+  ) async {
+    exampleTransport.answerGetAll = (_) async =>
+        throw TimeoutException('the backend is unreachable');
+
+    await tester.pumpFeature(const NewsPostList());
+    await tester.pumpAndSettle();
+
+    // The distinction that matters to a member: "nothing was published" and
+    // "we could not ask" must not look the same. `dwBuildListAsync` renders its
+    // `errorWidget` — nothing, here — and routes the error into the dw pipeline
+    // (alerting), which is the framework's business rather than this test's.
+    // A failed read is retried: Riverpod 3 retries a failed provider on its
+    // own, with a growing backoff, so `pumpAndSettle` drains a whole run of
+    // attempts rather than the one this test asked for. Assert the shape, not
+    // the count — pinning the count here would pin somebody else's default.
+    expect(exampleTransport.reads, isNotEmpty);
+    expect(exampleTransport.reads.map((read) => read.operation).toSet(), {
+      'getAll',
+    });
+    expect(find.byType(NewsPostCard), findsNothing);
+    expect(find.text('No news yet — stay tuned!'), findsNothing);
+  });
+}

--- a/example/dartway_example_flutter/test/support/example_test_core.dart
+++ b/example/dartway_example_flutter/test/support/example_test_core.dart
@@ -1,0 +1,132 @@
+import 'package:dartway_example_client/dartway_example_client.dart';
+// Prefixed because both this project's generated client and the DartWay core's
+// declare a `Protocol`, and the core's arrives through the framework barrel.
+import 'package:dartway_example_client/dartway_example_client.dart' as app;
+import 'package:dartway_example_flutter/core/app_l10n.dart';
+import 'package:dartway_example_flutter/core/default_models.dart';
+import 'package:dartway_example_flutter/core/dw_core.dart';
+import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+export 'package:dartway_serverpod_core_flutter/testing.dart'
+    show DwRecordingServerTransport, DwUnpreparedServerCall;
+
+/// The server, as far as any widget test in this project is concerned.
+///
+/// One instance for the whole run: the core keeps the transport it was built
+/// with for its lifetime, and there is one core per process. Each test calls
+/// [resetExampleTestCore] to start from nothing recorded and nothing prepared.
+///
+/// It is handed this project's own generated `Protocol()` — the same object the
+/// real Serverpod client carries — so every model is named on the wire exactly
+/// as the server knows it. Nothing else can do that job: a generated model is
+/// an abstract class with a private implementation, and its `runtimeType` reads
+/// `_NewsPostImpl`.
+final exampleTransport = DwRecordingServerTransport(
+  serializationManager: app.Protocol(),
+);
+
+/// Boots the app's own core, once, through the app's own initializer.
+///
+/// Call it from `setUpAll`. It is the app's real bootstrap with one thing
+/// swapped — the server — so a test never rebuilds a second, subtly different
+/// core beside the one the app ships. The initializer is idempotent, so no test
+/// file has to know whether another one got there first.
+///
+/// The core is *required* to render, not only to interact: a feature builds its
+/// `dw.action(...)` inside `build`, so `dw` is touched before anything is
+/// tapped. A test that forgets this fails at a finder ("found 0 widgets") with
+/// the real cause in a separate exception block above it.
+void bootExampleTestCore() {
+  initExampleDwCore(transport: exampleTransport);
+  // What `dw.initDwCore` would do for the repository, without the session and
+  // socket startup that a test has no server to do it against. This is the part
+  // list skeletons need: `dwBuildListAsync` builds its placeholder from the
+  // registered default model.
+  DefaultModels.initRepository();
+}
+
+/// Forgets everything the transport recorded and every answer prepared for it.
+/// Call from `setUp`.
+void resetExampleTestCore() => exampleTransport.reset();
+
+/// A signed-in staff member, for the features that are only shown to one.
+UserProfile staffProfile({int id = 7, String firstName = 'Sam'}) => UserProfile(
+  id: id,
+  userIdentifier: '7900000000$id',
+  firstName: firstName,
+  phone: '7900000000$id',
+  role: UserRole.staff,
+  agreedForMarketingCommunications: false,
+  conditionsAcceptedAt: DateTime.utc(2026),
+);
+
+/// Pumps [child] inside everything a page of this app is drawn inside, minus
+/// the router: localizations, the theme, the notification listener, and a
+/// Riverpod scope.
+///
+/// [signedInAs] overrides the framework's profile providers. Overriding them in
+/// the test's own `ProviderScope` is the sanctioned way to stand a user up —
+/// there is no session here to sign into, and inventing one would test the
+/// framework's session rather than this feature.
+extension ExampleFeaturePump on WidgetTester {
+  /// Taps [finder] and lets everything the tap set off finish.
+  ///
+  /// `pumpAndSettle` alone is not enough after an action that notifies: a
+  /// successful `dw.action(onSuccessNotification: ...)` inserts a toast which
+  /// removes itself on a `Future.delayed`, and settling waits for frames, not
+  /// for timers. A test that stops early ends on "A Timer is still pending even
+  /// after the widget tree was disposed" — an error about the toast, in a test
+  /// about a save.
+  Future<void> tapAndSettle(Finder finder) async {
+    await tap(finder);
+    await pumpAndSettle();
+    await pump(DwUiNotification.defaultDuration);
+  }
+
+  Future<void> pumpFeature(Widget child, {UserProfile? signedInAs}) async {
+    await pumpWidget(
+      ProviderScope(
+        overrides: [
+          if (signedInAs != null) ...[
+            dw.userProfileProvider.overrideWithValue(signedInAs),
+            dw.requireUserProfileProvider.overrideWithValue(signedInAs),
+          ],
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DwNotificationsListener(
+            handlers: {DwUiNotification: DwUiNotificationHandler()},
+            child: Scaffold(body: child),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Wraps [posts] the way the server would answer a `getAll` with them.
+DwApiResponse<List<DwModelWrapper>> newsPostsResponse(List<NewsPost> posts) =>
+    DwApiResponse<List<DwModelWrapper>>(
+      isOk: true,
+      value: posts
+          .map((post) => DwModelWrapper.wrap(model: post))
+          .toList(growable: false),
+    );
+
+/// A post as the server would hand it back — anything a list needs to draw.
+NewsPost newsPost({
+  int id = 1,
+  String title = 'Pool closed on Monday',
+  String text = 'Maintenance day.',
+}) => NewsPost(
+  id: id,
+  authorProfileId: 7,
+  title: title,
+  text: text,
+  createdAt: DateTime.utc(2026, 8, 19),
+);

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## 0.8.0
 
+- **`dartway check` reads the server now, and names three things a project is missing.** Every one
+  of them fails *closed*: the code compiles, the server starts, the migration applies, and the app
+  quietly cannot do something.
+
+  `crudConfigMissing` (warning) — a model with a table and no `DwCrudConfig`. Generic CRUD is secure
+  by default, so an unconfigured model answers `notConfigured` to every read and write; the list is
+  simply empty forever. A warning and not an error because the absence has a second, legitimate
+  reading — a table the server owns alone — which the check cannot tell apart and you can.
+
+  `crudConfigUnregistered` (error) — a config that exists and is not in the `crudConfigurations`
+  list. The same failure with no second reading, and the one that hides best: the file is there, it
+  has the access rules in it, it reviews as finished, and the API answers exactly as if it had never
+  been written. Nothing else in the toolchain has an opinion — it compiles, and a config is a value
+  nobody is obliged to use.
+
+  `crudRuleUntested` (warning) — a config carrying hand-written save or delete logic that no test in
+  the server package names. The rule runs inside a request and reads the database to decide, so no
+  widget test can reach it; one proving the admin-only button is hidden proves only that.
+
+  **None of the three counts anything** — each finding names one model and one thing to do. Two
+  things the checker could have guessed at are deliberately absent for that reason: a Flutter
+  feature's tests are not countable without becoming a coverage percentage, and an *Event model* is a
+  domain reading with no marker in the YAML (a rule keyed off an `*Event` suffix would miss the one
+  called `BalanceEntry` and fire on a lookup table).
+
 - **The deploy templates now ship the configuration that serves a Flutter web build, and it caches
   by what is actually hashed.** Nothing was shipped before, so every project wrote its own, and what
   they wrote applied the rule everybody knows — "fingerprinted assets are immutable, cache them for

--- a/packages/dartway_cli/lib/src/checker/dw_check_type.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_check_type.dart
@@ -113,7 +113,34 @@ enum DwCheckType {
   /// commit of the framework. Nothing else says so: `ref: master` is written
   /// once per package and reads as "from master", while the lock pins each one
   /// at whatever master was when *that* package was added.
-  frameworkRefsDiverged;
+  frameworkRefsDiverged,
+
+  /// A model with a table and no `DwCrudConfig`. Generic CRUD is secure by
+  /// default, so an unconfigured model answers `notConfigured` to every read
+  /// and write: it migrates, it exists, and the app cannot reach it.
+  ///
+  /// A **warning**, because the absence has a second, legitimate reading — a
+  /// table the server owns alone and no client should see. The check does not
+  /// know which of the two it is looking at; the person reading it does, and
+  /// answering costs one doc comment.
+  crudConfigMissing,
+
+  /// A `DwCrudConfig` that exists and is not in the `crudConfigurations` list
+  /// passed to `DwCore.init`.
+  ///
+  /// The one of this family with no second reading, and the one that hides
+  /// best: the file is there, it reviews as finished, and the API answers
+  /// exactly as if it had never been written.
+  crudConfigUnregistered,
+
+  /// A `DwCrudConfig` carrying hand-written save or delete logic that no test
+  /// in the server package names.
+  ///
+  /// The rule runs inside a request and touches the database, so nothing below
+  /// the server can hold it — a widget test proving the button is hidden proves
+  /// nothing about who may save. A **warning**: a mention of the model is a
+  /// good enough signal to raise the question, not to fail a build on.
+  crudRuleUntested;
 
   DwCheckSeverity get severity => switch (this) {
     DwCheckType.fileLong => DwCheckSeverity.info,
@@ -123,6 +150,8 @@ enum DwCheckType {
     DwCheckType.unusedFeatureFile ||
     DwCheckType.generatedCodeUnformatted ||
     DwCheckType.frameworkRefsDiverged ||
+    DwCheckType.crudConfigMissing ||
+    DwCheckType.crudRuleUntested ||
     DwCheckType.fileTooLong => DwCheckSeverity.warning,
     _ => DwCheckSeverity.error,
   };

--- a/packages/dartway_cli/lib/src/checker/dw_crud_coverage.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_crud_coverage.dart
@@ -1,0 +1,285 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'dw_check_type.dart';
+
+/// One finding, kept as a value so the tests can assert what the rule *said*
+/// rather than what it printed.
+class DwCrudCoverageFinding {
+  const DwCrudCoverageFinding(this.type, this.message);
+
+  final DwCheckType type;
+  final String message;
+
+  @override
+  String toString() => '${type.name}: $message';
+}
+
+/// Finds the things a project is **missing** on the server, by name.
+///
+/// Not a coverage percentage: each finding names one model and one thing to do
+/// about it. The three it looks for are the ones nothing else catches, because
+/// every one of them fails *closed* — the code compiles, the server starts, the
+/// migration applies, and the app quietly cannot do something.
+///
+/// - [DwCheckType.crudConfigMissing] — a table nobody configured. Generic CRUD
+///   is secure by default, so an unconfigured model answers `notConfigured` to
+///   every read and write. That is the right default and a silent one.
+/// - [DwCheckType.crudConfigUnregistered] — a config that was written and never
+///   put in `crudConfigurations`. The worst of the three: the file exists, it
+///   reviews as done, and the API answers exactly as if it did not.
+/// - [DwCheckType.crudRuleUntested] — a config carrying hand-written save or
+///   delete logic that no server test names. The rule lives on the server, so
+///   only a server test can hold it; a widget test proving the button is hidden
+///   proves nothing about who may save.
+///
+/// **What it deliberately does not do.** It says nothing about Flutter features
+/// or about Event models. A feature's tests are not countable without turning
+/// into the percentage this check exists instead of, and *Event model* is a
+/// domain reading — a change written on top of a base — with no marker in the
+/// YAML to detect it by. A rule that guessed from a `*Event` suffix would miss
+/// the one spelled `BalanceEntry` and fire on the one that is a plain lookup.
+class DwCrudCoverageInspector {
+  DwCrudCoverageInspector({
+    required this.serverPackageDir,
+    DwCheckType? filterType,
+    DwCheckSeverity? filterSeverity,
+  }) : _filterType = filterType,
+       _filterSeverity = filterSeverity;
+
+  final Directory? serverPackageDir;
+
+  final DwCheckType? _filterType;
+  final DwCheckSeverity? _filterSeverity;
+  final _findings = <DwCrudCoverageFinding>[];
+
+  /// The findings, in the order they were made.
+  List<DwCrudCoverageFinding> get findings => List.unmodifiable(_findings);
+
+  static const _checks = {
+    DwCheckType.crudConfigMissing,
+    DwCheckType.crudConfigUnregistered,
+    DwCheckType.crudRuleUntested,
+  };
+
+  /// The save/delete hooks that make a config carry a rule rather than declare
+  /// a shape. `accessFilter` and `include` are deliberately absent: they are
+  /// the declaration, and a config that only declares needs no test.
+  static const _ruleHooks = {
+    'allowSave',
+    'validateSave',
+    'beforeSaveTransaction',
+    'afterSaveTransaction',
+    'afterSaveTransform',
+    'afterSaveSideEffects',
+    'allowDelete',
+    'beforeDelete',
+    'afterDelete',
+  };
+
+  bool _runs(DwCheckType type) =>
+      (_filterType == null || _filterType == type) &&
+      (_filterSeverity == null || _filterSeverity == type.severity);
+
+  /// Runs the checks and prints the section. Returns the number of
+  /// error-severity findings.
+  int run() {
+    final serverDir = serverPackageDir;
+    if (serverDir == null) return 0;
+    if (!_checks.any(_runs)) return 0;
+
+    final srcDir = Directory(p.join(serverDir.path, 'lib', 'src'));
+    if (!srcDir.existsSync()) return 0;
+
+    final models = _declaredTableModels(
+      Directory(p.join(srcDir.path, 'models')),
+    );
+    if (models.isEmpty) return 0;
+
+    final configs = _declaredConfigs(srcDir);
+    final registered = _registeredConfigNames(srcDir);
+    final testedModels = _modelsNamedInTests(serverDir);
+
+    for (final model in models) {
+      final config = configs[model];
+
+      if (config == null) {
+        if (_runs(DwCheckType.crudConfigMissing)) {
+          _findings.add(
+            DwCrudCoverageFinding(
+              DwCheckType.crudConfigMissing,
+              '$model has a table and no DwCrudConfig, so every read and write '
+              'of it answers notConfigured — the app cannot reach it at all. '
+              'Add a config in lib/src/crud/, or, if this table is the '
+              "server's own and no client should see it, that is what the "
+              'absence already means and this line is the reminder to say so '
+              'in a doc comment on the model.',
+            ),
+          );
+        }
+        continue;
+      }
+
+      if (!registered.contains(config.variableName) &&
+          _runs(DwCheckType.crudConfigUnregistered)) {
+        _findings.add(
+          DwCrudCoverageFinding(
+            DwCheckType.crudConfigUnregistered,
+            '${config.variableName} (${config.relativePath}) is not in the '
+            'crudConfigurations list passed to DwCore.init, so $model answers '
+            'notConfigured exactly as if the config had never been written.',
+          ),
+        );
+      }
+
+      if (config.ruleHooks.isNotEmpty &&
+          !testedModels.contains(model) &&
+          _runs(DwCheckType.crudRuleUntested)) {
+        _findings.add(
+          DwCrudCoverageFinding(
+            DwCheckType.crudRuleUntested,
+            '$model carries a rule (${config.ruleHooks.join(', ')}) that no '
+            'test under test/ names. The rule runs inside a request and touches '
+            'the database, so only an integration test can hold it — see the '
+            'dartway-testing skill. A widget test showing the button is hidden '
+            'says nothing about who may save.',
+          ),
+        );
+      }
+    }
+
+    if (_findings.isEmpty) return 0;
+
+    print('\n🗄️ Server CRUD coverage:\n');
+    for (final finding in _findings) {
+      print('  ${finding.type.reportLabel}: ${finding.message}');
+    }
+
+    return _findings
+        .where((f) => f.type.severity == DwCheckSeverity.error)
+        .length;
+  }
+
+  /// Every model this project declares with a table, by class name.
+  ///
+  /// Only the ones with a `table:` — an enum, and a class used purely as a DTO,
+  /// have no rows and nothing to configure access to.
+  Set<String> _declaredTableModels(Directory modelsDir) {
+    if (!modelsDir.existsSync()) return const {};
+
+    final models = <String>{};
+    for (final file in modelsDir.listSync(recursive: true).whereType<File>()) {
+      if (!file.path.endsWith('.yaml') && !file.path.endsWith('.yml')) continue;
+
+      final source = file.readAsStringSync();
+      final className = RegExp(
+        r'^class:\s*(\w+)',
+        multiLine: true,
+      ).firstMatch(source)?.group(1);
+      if (className == null) continue;
+      if (!RegExp(r'^table:\s*\S', multiLine: true).hasMatch(source)) continue;
+
+      models.add(className);
+    }
+    return models;
+  }
+
+  /// Every `DwCrudConfig<Model>` the server declares, by the model it is for.
+  Map<String, _DeclaredConfig> _declaredConfigs(Directory srcDir) {
+    final configs = <String, _DeclaredConfig>{};
+    final declaration = RegExp(
+      r'(?:final|const)\s+(\w+)\s*=\s*DwCrudConfig<(\w+)>\s*\(',
+    );
+
+    for (final file in _dartFilesOf(srcDir)) {
+      final source = file.readAsStringSync();
+      for (final match in declaration.allMatches(source)) {
+        final variableName = match.group(1)!;
+        final model = match.group(2)!;
+        configs[model] = _DeclaredConfig(
+          variableName: variableName,
+          relativePath: p
+              .relative(file.path, from: srcDir.parent.parent.path)
+              .replaceAll(r'\', '/'),
+          ruleHooks: _ruleHooks.where((hook) {
+            return RegExp('\\b$hook\\s*:').hasMatch(source);
+          }).toList(),
+        );
+      }
+    }
+    return configs;
+  }
+
+  /// The identifiers listed in the `crudConfigurations:` argument.
+  ///
+  /// Read as text rather than parsed: the list is one argument in one call, and
+  /// an analyzer pass would cost seconds on every run to learn the same names.
+  Set<String> _registeredConfigNames(Directory srcDir) {
+    final names = <String>{};
+    for (final file in _dartFilesOf(srcDir)) {
+      final source = file.readAsStringSync();
+      final start = source.indexOf('crudConfigurations:');
+      if (start < 0) continue;
+
+      final open = source.indexOf('[', start);
+      final close = open < 0 ? -1 : source.indexOf(']', open);
+      if (open < 0 || close < 0) continue;
+
+      for (final identifier in RegExp(
+        r'\b[a-z]\w*\b',
+      ).allMatches(source.substring(open, close))) {
+        names.add(identifier.group(0)!);
+      }
+    }
+    return names;
+  }
+
+  /// The model class names any server test mentions.
+  ///
+  /// A Serverpod integration test names the model to build a row with it, so a
+  /// mention is a reliable enough signal — and the failure mode of being wrong
+  /// is a rule silently counted as covered, which is why this check is a
+  /// warning and not an error.
+  Set<String> _modelsNamedInTests(Directory serverDir) {
+    final testDir = Directory(p.join(serverDir.path, 'test'));
+    if (!testDir.existsSync()) return const {};
+
+    final mentioned = <String>{};
+    for (final file in _dartFilesOf(testDir)) {
+      // The generated test tools name every model of the project, so counting
+      // them would mark the whole schema as tested.
+      if (p.basename(file.path) == 'serverpod_test_tools.dart') continue;
+
+      for (final word in RegExp(
+        r'\b[A-Z]\w*\b',
+      ).allMatches(file.readAsStringSync())) {
+        mentioned.add(word.group(0)!);
+      }
+    }
+    return mentioned;
+  }
+
+  Iterable<File> _dartFilesOf(Directory dir) sync* {
+    if (!dir.existsSync()) return;
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final relative = p.relative(entity.path, from: dir.path);
+      // Generated code declares no configs and tests nothing.
+      if (relative.split(p.separator).contains('generated')) continue;
+      yield entity;
+    }
+  }
+}
+
+class _DeclaredConfig {
+  const _DeclaredConfig({
+    required this.variableName,
+    required this.relativePath,
+    required this.ruleHooks,
+  });
+
+  final String variableName;
+  final String relativePath;
+  final List<String> ruleHooks;
+}

--- a/packages/dartway_cli/lib/src/commands/check_command.dart
+++ b/packages/dartway_cli/lib/src/commands/check_command.dart
@@ -4,6 +4,7 @@ import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 
 import '../checker/dw_check_type.dart';
+import '../checker/dw_crud_coverage.dart';
 import '../checker/dw_flutter_inspector.dart';
 import '../checker/dw_framework_lock.dart';
 import '../checker/dw_generated_format.dart';
@@ -95,6 +96,14 @@ class CheckCommand extends Command<int> {
       // `--dir` for the same reason the layout check is.
       errorCount += DwFrameworkLockInspector(
         projectRoot: layout?.root ?? flutterPackageDir,
+        filterType: filterType,
+        filterSeverity: filterSeverity,
+      ).run();
+
+      // Reads the server's models, configs and tests together — which is the
+      // only way to see what is missing between them.
+      errorCount += DwCrudCoverageInspector(
+        serverPackageDir: layout?.serverPackageDir,
         filterType: filterType,
         filterSeverity: filterSeverity,
       ).run();

--- a/packages/dartway_cli/test/crud_coverage_test.dart
+++ b/packages/dartway_cli/test/crud_coverage_test.dart
@@ -1,0 +1,244 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/checker/dw_check_type.dart';
+import 'package:dartway_cli/src/checker/dw_crud_coverage.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// The three gaps on the server that fail *closed*: the code compiles, the
+/// server starts, the migration applies, and the app quietly cannot do
+/// something. Nothing else in the toolchain says a word about any of them —
+/// which is the whole reason they are worth a check rather than a convention.
+void main() {
+  late Directory sandbox;
+
+  setUp(() {
+    sandbox = Directory.systemTemp.createTempSync('dw_crud_coverage');
+  });
+
+  tearDown(() {
+    sandbox.deleteSync(recursive: true);
+  });
+
+  /// Writes a server package and returns what the rule said.
+  ///
+  /// [models] maps a class name to whether it has a table; [configs] maps a
+  /// model to the source of the config file declaring it; [registered] is what
+  /// the `crudConfigurations` list names; [tests] is the source of the files
+  /// under `test/`.
+  List<DwCrudCoverageFinding> findingsFor({
+    required Map<String, bool> models,
+    Map<String, String> configs = const {},
+    List<String> registered = const [],
+    Map<String, String> tests = const {},
+  }) {
+    final serverDir = Directory(p.join(sandbox.path, 'my_server'))
+      ..createSync(recursive: true);
+    final srcDir = Directory(p.join(serverDir.path, 'lib', 'src'));
+
+    models.forEach((className, hasTable) {
+      File(p.join(srcDir.path, 'models', '$className.spy.yaml'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(
+          'class: $className\n'
+          '${hasTable ? 'table: ${className.toLowerCase()}\n' : ''}'
+          'fields:\n  title: String\n',
+        );
+    });
+
+    configs.forEach((model, source) {
+      File(p.join(srcDir.path, 'crud', '${model.toLowerCase()}_config.dart'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(source);
+    });
+
+    File(p.join(srcDir.path, 'dartway', 'dartway_core.dart'))
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(
+        'void initDartwayCore() {\n'
+        '  dw = DwCore.init<UserProfile>(\n'
+        '    crudConfigurations: [${registered.join(', ')}],\n'
+        '  );\n'
+        '}\n',
+      );
+
+    tests.forEach((name, source) {
+      File(p.join(serverDir.path, 'test', 'integration', '$name.dart'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(source);
+    });
+
+    final inspector = DwCrudCoverageInspector(serverPackageDir: serverDir);
+    inspector.run();
+    return inspector.findings;
+  }
+
+  String configSource(String model, {String hooks = ''}) =>
+      'final ${model.toLowerCase()}CrudConfig = DwCrudConfig<$model>(\n'
+      '  table: $model.t,\n'
+      '  getListConfig: DwGetModelListConfig(accessFilter: (s) async => null),\n'
+      '$hooks'
+      ');\n';
+
+  test('a table nobody configured is reported by name', () {
+    final findings = findingsFor(models: const {'Invoice': true});
+
+    expect(findings, hasLength(1));
+    expect(findings.single.type, DwCheckType.crudConfigMissing);
+    expect(findings.single.message, contains('Invoice'));
+    expect(findings.single.message, contains('notConfigured'));
+  });
+
+  test('an enum and a table-less model are not asked for a config', () {
+    // The two shapes that legitimately have no rows: `UserRole` is an enum
+    // (no `class:` at all) and `SearchQuery` is a DTO. Demanding access
+    // configuration for either would be noise, and noise is how a check gets
+    // switched off.
+    final findings = findingsFor(models: const {'SearchQuery': false});
+
+    expect(findings, isEmpty);
+  });
+
+  test('a configured and registered model says nothing', () {
+    final findings = findingsFor(
+      models: const {'Invoice': true},
+      configs: {'Invoice': configSource('Invoice')},
+      registered: const ['invoiceCrudConfig'],
+    );
+
+    expect(findings, isEmpty);
+  });
+
+  test('a config that was written and never registered is an error', () {
+    // The one with no second reading: the file exists, it reviews as finished,
+    // and the API answers exactly as if it had never been written.
+    final findings = findingsFor(
+      models: const {'Invoice': true},
+      configs: {'Invoice': configSource('Invoice')},
+      registered: const [],
+    );
+
+    expect(findings, hasLength(1));
+    expect(findings.single.type, DwCheckType.crudConfigUnregistered);
+    expect(findings.single.type.severity, DwCheckSeverity.error);
+    expect(findings.single.message, contains('invoiceCrudConfig'));
+  });
+
+  test('a config that only declares a shape is not asked for a test', () {
+    // `accessFilter` and `include` are the declaration. A config that carries
+    // no hand-written save logic has no rule to hold, and asking it for a test
+    // would be counting coverage rather than naming a gap.
+    final findings = findingsFor(
+      models: const {'Invoice': true},
+      configs: {'Invoice': configSource('Invoice')},
+      registered: const ['invoiceCrudConfig'],
+      tests: const {},
+    );
+
+    expect(findings, isEmpty);
+  });
+
+  test('a save rule no server test names is reported, with the hooks', () {
+    final findings = findingsFor(
+      models: const {'Invoice': true},
+      configs: {
+        'Invoice': configSource(
+          'Invoice',
+          hooks:
+              '  saveConfig: DwSaveConfig<Invoice>(\n'
+              '    allowSave: (session, ctx) async => session.isAdmin,\n'
+              '  ),\n',
+        ),
+      },
+      registered: const ['invoiceCrudConfig'],
+    );
+
+    expect(findings, hasLength(1));
+    expect(findings.single.type, DwCheckType.crudRuleUntested);
+    expect(findings.single.type.severity, DwCheckSeverity.warning);
+    expect(findings.single.message, contains('allowSave'));
+  });
+
+  test('a rule a test names is covered', () {
+    final findings = findingsFor(
+      models: const {'Invoice': true},
+      configs: {
+        'Invoice': configSource(
+          'Invoice',
+          hooks:
+              '  saveConfig: DwSaveConfig<Invoice>(\n'
+              '    allowSave: (session, ctx) async => session.isAdmin,\n'
+              '  ),\n',
+        ),
+      },
+      registered: const ['invoiceCrudConfig'],
+      tests: const {
+        'invoice_access_test': "void main() { Invoice(title: 'x'); }\n",
+      },
+    );
+
+    expect(findings, isEmpty);
+  });
+
+  test('the generated test tools do not count as covering anything', () {
+    // They name every model of the project, so counting them would mark the
+    // whole schema as tested and the check would never fire again.
+    final serverDir = Directory(p.join(sandbox.path, 'tools_server'))
+      ..createSync(recursive: true);
+    File(p.join(serverDir.path, 'lib', 'src', 'models', 'Invoice.spy.yaml'))
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync('class: Invoice\ntable: invoice\n');
+    File(p.join(serverDir.path, 'lib', 'src', 'crud', 'invoice.dart'))
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(
+        configSource(
+          'Invoice',
+          hooks:
+              '  saveConfig: DwSaveConfig<Invoice>(allowSave: (s, c) => x),\n',
+        ),
+      );
+    File(p.join(serverDir.path, 'lib', 'src', 'dartway', 'dartway_core.dart'))
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync('crudConfigurations: [invoiceCrudConfig],');
+    File(
+        p.join(
+          serverDir.path,
+          'test',
+          'integration',
+          'test_tools',
+          'serverpod_test_tools.dart',
+        ),
+      )
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync('// Invoice is named here by the generator.\n');
+
+    final inspector = DwCrudCoverageInspector(serverPackageDir: serverDir);
+    inspector.run();
+
+    expect(inspector.findings, hasLength(1));
+    expect(inspector.findings.single.type, DwCheckType.crudRuleUntested);
+  });
+
+  test('--type narrows the run to one of the three', () {
+    final serverDir = Directory(p.join(sandbox.path, 'narrow_server'))
+      ..createSync(recursive: true);
+    File(p.join(serverDir.path, 'lib', 'src', 'models', 'Invoice.spy.yaml'))
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync('class: Invoice\ntable: invoice\n');
+
+    final inspector = DwCrudCoverageInspector(
+      serverPackageDir: serverDir,
+      filterType: DwCheckType.crudConfigUnregistered,
+    );
+    inspector.run();
+
+    expect(inspector.findings, isEmpty);
+  });
+
+  test('a project with no server package is passed over', () {
+    final inspector = DwCrudCoverageInspector(serverPackageDir: null);
+
+    expect(inspector.run(), 0);
+    expect(inspector.findings, isEmpty);
+  });
+}

--- a/packages/dartway_flutter/CHANGELOG.md
+++ b/packages/dartway_flutter/CHANGELOG.md
@@ -11,6 +11,13 @@ and deciding something the app did not.
 Added for the data layer, which now asks this way whether the app declared a local store for
 `dw.repo` — see `dartway_serverpod_core_flutter` 0.10.0.
 
+**The ambient-core errors say what is missing.** `Dw is not initialized` now names the core the app
+failed to build and adds the part that costs people an afternoon: a widget test needs one too,
+because a feature reaches `dw` while *building* — `dw.action(...)` is constructed in `build` — so
+the subtree does not render without it, and the failure surfaces later as a finder that found
+nothing. `Dw already initialized` says why an app's core initializer has to be idempotent: one core
+per process, so a second test file booting it must be a no-op rather than an error.
+
 ## 0.5.1
 
 **`dwBuildListAsync` builds its skeleton only when it is showing one.** The placeholder list — and

--- a/packages/dartway_flutter/lib/src/private/dw_singleton.dart
+++ b/packages/dartway_flutter/lib/src/private/dw_singleton.dart
@@ -4,7 +4,13 @@ DwFlutter? _instance;
 
 DwFlutter get dw {
   if (_instance == null) {
-    throw StateError('Dw is not initialized');
+    throw StateError(
+      'Dw is not initialized.\n'
+      'Make sure the app built its core — DwFlutter(config: ...), or the '
+      'DwCore of a Serverpod app — before anything reached dw. A widget test '
+      'has to boot one too: a feature reaches dw while building, not on the '
+      'tap, so the subtree does not render without it.',
+    );
   }
   return _instance!;
 }
@@ -15,7 +21,12 @@ DwFlutter? get dwOrNull => _instance;
 
 void setDwInstance(DwFlutter instance) {
   if (_instance != null) {
-    throw StateError('Dw already initialized');
+    throw StateError(
+      'Dw is already initialized.\n'
+      'One core per process, and it cannot be replaced. A test file that '
+      'boots the core must do so through an initializer that is idempotent, '
+      'so a second call is a no-op rather than this error.',
+    );
   }
   _instance = instance;
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## 0.10.0
 
+**Everything `dw.repo` sends to the server now goes through one narrow port, `DwServerTransport`,
+and a test can hand the core its own.** Eight operations — `getOne`, `getAll`, `getCount`,
+`saveModel`, `delete`, `subscribeOnUpdates`, `getUploadDescription`, `verifyUpload` — are the whole
+dependency the client-side repository has on the generated Serverpod client, and they are now stated
+as a type instead of being reached for through `dw.endpointCaller`.
+
+Two things this buys, in the order they matter:
+
+- **A widget test can watch a feature write.** `package:dartway_serverpod_core_flutter/testing.dart`
+  ships `DwRecordingServerTransport`: it answers reads from what the test prepared, keeps every save
+  and delete that left, and throws `DwUnpreparedServerCall` — naming the call and the field that
+  would answer it — for a read nobody prepared. What it replaces is a subclass of
+  `ServerpodClientShared` implementing `callServerEndpoint(endpoint, method, args)` against
+  string-keyed wire arguments; the four such props inside this package came to ~150 lines and are
+  gone. A save that needs no particular answer needs no setup at all — the default echoes the model
+  back, because the assertion is about what *left*.
+- **Serverpod is replaceable.** `DwServerpodTransport` is now the only place in the Flutter half that
+  knows a generated `Caller` exists.
+
+The local store is still not this seam and is still documented as not being one: a write always
+leaves by the transport first, and `dw.repo.localWrites` is reached only after the connection
+refuses it.
+
+**Breaking: `dw.endpointCaller` is gone; the replacement is `dw.serverTransport`.** An app that
+called DartWay's own CRUD endpoints directly — in practice, only a dev stand deliberately failing a
+call — renames `dw.endpointCaller.dwCrud.getOne(...)` to `dw.serverTransport.getOne(...)` and
+`dw.endpointCaller.dwUpload.verifyUpload(...)` to `dw.serverTransport.verifyUpload(...)`. Everything
+reached through `dw.repo`, `dw.client` and `DwFileUploadHandler` is unchanged.
+
+**`DwCore`'s `client` is now optional, and `transport:` takes its place.** An application passes
+`client:` exactly as before and nothing about it changes — `dw.client` is still non-nullable, so no
+call site grows a `!`. A test passes `transport:` *instead*, and then nothing in the process stands
+up a Serverpod client merely so a widget can render. A core built with neither is refused with an
+`ArgumentError` naming both options, and refused before the ambient `dw` is claimed, so a
+misconfigured core cannot be left registered as the one and only. Reaching `dw.client` on a
+transport-only core throws and says how the core was built.
+
+**The two "not initialized" errors now name the missing step.** `DwCore is not initialized` and
+`Dw is not initialized` used to be bare; they now point at the core the app failed to build, and say
+that a widget test needs one too — a feature reaches `dw` while *building*, not on the tap. Their
+"already initialized" counterparts say why an app's initializer has to be idempotent.
+
 **`dw.repo` can keep a local copy of its reads and writes, and the contract for doing so is new
 public API.** Two optional boundaries — `DwRepoLocalReads` and `DwRepoLocalWrites` — let a store
 outside the core keep repository responses and queue mutations that failed on the connection.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -17,7 +17,10 @@ Two things this buys, in the order they matter:
   `ServerpodClientShared` implementing `callServerEndpoint(endpoint, method, args)` against
   string-keyed wire arguments; the four such props inside this package came to ~150 lines and are
   gone. A save that needs no particular answer needs no setup at all — the default echoes the model
-  back, because the assertion is about what *left*.
+  back, because the assertion is about what *left*. **An application hands it its own generated
+  `Protocol()`** as `serializationManager`; a model it cannot name is refused rather than sent under
+  a name no server knows, because falling back to `runtimeType` would be silently wrong for every
+  generated model (they are abstract classes, so it reads `_NewsPostImpl`).
 - **Serverpod is replaceable.** `DwServerpodTransport` is now the only place in the Flutter half that
   knows a generated `Caller` exists.
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/dartway_serverpod_core_flutter.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/dartway_serverpod_core_flutter.dart
@@ -10,6 +10,8 @@ export 'src/app/socket/domain/dw_socket_status.dart';
 export 'src/app/socket/dw_channel_subscription_widget.dart';
 export 'src/app/socket/service/streaming_error_classifier.dart';
 export 'src/core/dw_core.dart';
+export 'src/transport/dw_server_transport.dart';
+export 'src/transport/dw_serverpod_transport.dart';
 export 'src/utils/connection_error_handling.dart';
 export 'src/repository/domain/dw_backend_filters_mixin.dart';
 export 'src/repository/domain/dw_cursor_pagination.dart';

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/core/dw_core.dart
@@ -1,8 +1,5 @@
 import 'dart:async';
 
-import 'package:collection/collection.dart';
-import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart'
-    as dartway;
 import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -20,7 +17,27 @@ class DwCore<
   UserProfileClass extends SerializableModel
 >
     extends DwFlutter {
-  final ServerpodClientClass client;
+  final ServerpodClientClass? _client;
+
+  /// This app's own generated Serverpod client — for the endpoints the app
+  /// declared itself. DartWay's own CRUD does not travel through it; that is
+  /// [serverTransport].
+  ///
+  /// Throws when the core was built without one, which only happens in a test
+  /// that passed a `transport` instead. An application always has a client, so
+  /// this stays non-nullable and `dw.client` needs no `!`.
+  ServerpodClientClass get client {
+    final client = _client;
+    if (client == null) {
+      throw StateError(
+        'DwCore was built without a Serverpod client.\n'
+        'Only a test does that (it passed transport: instead). Application '
+        'code reaching dw.client means the core was built the wrong way.',
+      );
+    }
+    return client;
+  }
+
   final DwAlerts dwAlerts;
   late final DwSessionService<UserProfileClass>? sessionService;
   late final DwSocketService? socketService;
@@ -68,7 +85,15 @@ class DwCore<
   Provider<int?> get signedInUserIdProvider =>
       _userProfileProviders.signedInUserId;
 
-  late final dartway.Caller endpointCaller;
+  /// The wire `dw.repo` speaks — the single path every CRUD call, realtime
+  /// subscription and upload takes to the server.
+  ///
+  /// An app reads and writes through `dw.repo` and never needs this. Reach for
+  /// it in the two cases the repository cannot cover: a test substitutes it
+  /// (`DwRecordingServerTransport` from
+  /// `package:dartway_serverpod_core_flutter/testing.dart`), and a dev stand
+  /// exercises a DartWay endpoint deliberately.
+  final DwServerTransport serverTransport;
 
   final int? Function(UserProfileClass? user) getUserId;
 
@@ -78,32 +103,46 @@ class DwCore<
   /// never reach the global error handler.
   final void Function(DwSocketStatus status)? onSocketStatusChanged;
 
+  static ServerpodClientShared _requireClient(ServerpodClientShared? client) {
+    if (client == null) {
+      throw ArgumentError(
+        'DwCore has no way to reach the server.\n'
+        'Pass client: <your generated Client>, or — from a test — '
+        'transport: DwRecordingServerTransport(...).',
+      );
+    }
+    return client;
+  }
+
+  /// Builds the core.
+  ///
+  /// [client] is this app's generated Serverpod client, and is what an
+  /// application always passes: the DartWay CRUD transport is derived from it.
+  /// [transport] replaces that derivation — pass it *instead of* [client] in a
+  /// test, so nothing has to stand up a Serverpod client to see a widget draw
+  /// or a save leave. Exactly one of the two is required; when both are given
+  /// [transport] wins and [client] stays reachable as `dw.client`.
   DwCore({
     required super.config,
-    required this.client,
+    ServerpodClientClass? client,
+    DwServerTransport? transport,
     required this.dwAlerts,
     required this.getUserId,
     super.plugins,
     this.onSocketStatusChanged,
-  }) {
+  }) : _client = client,
+       // In the initializer list, so a core with neither is refused *before*
+       // the superclass claims the ambient `dw` — a half-built core registered
+       // as the one and only is worse than the error that produced it.
+       serverTransport =
+           transport ?? DwServerpodTransport(_requireClient(client)) {
     setDwInstance(this);
 
-    DwCoreServerpodClient.protocol = client.serializationManager;
+    DwCoreServerpodClient.protocol = serverTransport.serializationManager;
 
-    final dartwayCaller = client.moduleLookup.values.firstWhereOrNull(
-      (e) => e is dartway.Caller,
-    );
-
-    if (dartwayCaller == null) {
-      throw Exception(
-        'DartWay Core module not found. '
-        'Add dartway_serverpod_core module to the client.',
-      );
-    }
-    endpointCaller = dartwayCaller as dartway.Caller;
     socketService = DwSocketService(
       openChannelStream: (channel) =>
-          endpointCaller.dwCrud.subscribeOnUpdates(channel: channel),
+          serverTransport.subscribeOnUpdates(channel: channel),
       reportError: handleError,
       onStatusChanged: onSocketStatusChanged,
       // The server ended this app's subscriptions because the account is no
@@ -114,7 +153,7 @@ class DwCore<
           unawaited(sessionService?.invalidateSession() ?? Future.value()),
     );
 
-    final keyProvider = client.authKeyProvider;
+    final keyProvider = _client?.authKeyProvider;
 
     if (keyProvider is DwAuthenticationKeyManager) {
       int? socketUserId;
@@ -129,7 +168,7 @@ class DwCore<
         // filters by the authenticated user, so an empty answer means the
         // stored key no longer identifies this user — see [DwSessionService].
         fetchUserProfile: (userId) async {
-          final response = await endpointCaller.dwCrud.getOne(
+          final response = await serverTransport.getOne(
             className: DwRepository.typeName<UserProfileClass>(),
             filter: DwBackendFilter<int>.value(
               type: DwBackendFilterType.equals,
@@ -146,7 +185,7 @@ class DwCore<
           return wrapper?.model as UserProfileClass?;
         },
         deleteAuthKey: (authKeyId) async {
-          await endpointCaller.dwCrud.delete(
+          await serverTransport.delete(
             className: 'DwAuthKey',
             modelId: authKeyId,
             apiGroup: DwCoreConst.dartwayInternalApi,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/private/dw_singleton.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/private/dw_singleton.dart
@@ -4,11 +4,26 @@ DwCore? _instance;
 
 DwCore get dw {
   final v = _instance;
-  if (v == null) throw StateError('DwCore is not initialized');
+  if (v == null) {
+    throw StateError(
+      'DwCore is not initialized.\n'
+      'Make sure the app built its core — DwCore(config: ..., client: ...) — '
+      'before anything reached dw. In a test, boot it from setUpAll through '
+      "the app's own initializer, and pass transport: "
+      'DwRecordingServerTransport(...) instead of a client.',
+    );
+  }
   return v;
 }
 
 void setDwInstance(DwCore instance) {
-  if (_instance != null) throw StateError('DwCore already initialized');
+  if (_instance != null) {
+    throw StateError(
+      'DwCore is already initialized.\n'
+      'One core per process, and it cannot be replaced. A test file that '
+      'boots the core must do so through an initializer that is idempotent, '
+      'so a second call is a no-op rather than this error.',
+    );
+  }
   _instance = instance;
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repository.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repository.dart
@@ -242,7 +242,7 @@ class DwRepository {
   }) => _executeWrite<DwModelWrapper, Model>(
     capturePreparedWrite: () =>
         _capturePreparedSaveWrite(model: model, apiGroup: apiGroupOverride),
-    onlineRequest: () => dw.endpointCaller.dwCrud.saveModel(
+    onlineRequest: () => dw.serverTransport.saveModel(
       wrappedModel: DwModelWrapper.wrap(model: model),
       apiGroup: apiGroupOverride,
     ),
@@ -257,7 +257,7 @@ class DwRepository {
   }) => _executeWrite<DwModelWrapper, DwApiResponse<DwModelWrapper>>(
     capturePreparedWrite: () =>
         _capturePreparedSaveWrite(model: model, apiGroup: apiGroupOverride),
-    onlineRequest: () => dw.endpointCaller.dwCrud.saveModel(
+    onlineRequest: () => dw.serverTransport.saveModel(
       wrappedModel: DwModelWrapper.wrap(model: model),
       apiGroup: apiGroupOverride,
     ),
@@ -282,7 +282,7 @@ class DwRepository {
         modelId: modelId,
         apiGroup: apiGroupOverride,
       ),
-      onlineRequest: () => dw.endpointCaller.dwCrud.delete(
+      onlineRequest: () => dw.serverTransport.delete(
         className: DwModelWrapper.getClassNameForObject(model),
         modelId: modelId,
         apiGroup: apiGroupOverride,
@@ -394,7 +394,7 @@ class DwRepository {
         },
       ),
       readStrategy: readStrategy,
-      onlineRequest: () => dw.endpointCaller.dwCrud.getAll(
+      onlineRequest: () => dw.serverTransport.getAll(
         className: className,
         filter: filter,
         orderByList: orderByList,
@@ -805,7 +805,7 @@ class DwRepository {
     DwBackendFilter? filter,
     String? apiGroupOverride,
   }) async {
-    final response = await dw.endpointCaller.dwCrud.getCount(
+    final response = await dw.serverTransport.getCount(
       className: typeName<Model>(),
       filter: filter,
       apiGroup: apiGroupOverride,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/states/dw_model_list_state.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/states/dw_model_list_state.dart
@@ -105,7 +105,7 @@ class DwModelListState<Model extends SerializableModel>
         await DwRepository.executeRead<Model, List<DwModelWrapper>>(
           queryKey: config.queryKeyFor(params, requestFilter: filter),
           readStrategy: config.readStrategy,
-          onlineRequest: () => dw.endpointCaller.dwCrud.getAll(
+          onlineRequest: () => dw.serverTransport.getAll(
             className: className,
             filter: filter,
             orderByList: config.orderByList,
@@ -122,7 +122,7 @@ class DwModelListState<Model extends SerializableModel>
 
     return data;
 
-    // final result = await dw.endpointCaller.dwCrud
+    // final result = await dw.serverTransport
     //     .getAll(
     //       className: DwRepository.typeName<Model>(),
     //       filter: arg.backendFilter,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/states/dw_single_model_state.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/states/dw_single_model_state.dart
@@ -34,7 +34,7 @@ class DwSingleModelState<Model extends SerializableModel>
         : await DwRepository.executeRead<Model, DwModelWrapper>(
             queryKey: config.queryKey,
             readStrategy: config.readStrategy,
-            onlineRequest: () => dw.endpointCaller.dwCrud.getOne(
+            onlineRequest: () => dw.serverTransport.getOne(
               className: DwRepository.typeName<Model>(),
               filter: config.backendFilter,
               apiGroup: config.apiGroupOverride,
@@ -68,7 +68,7 @@ class DwSingleModelState<Model extends SerializableModel>
     final readResult = await DwRepository.executeRead<Model, DwModelWrapper>(
       queryKey: config.queryKey,
       readStrategy: config.readStrategy,
-      onlineRequest: () => dw.endpointCaller.dwCrud.getOne(
+      onlineRequest: () => dw.serverTransport.getOne(
         className: DwRepository.typeName<Model>(),
         filter: config.backendFilter,
         apiGroup: config.apiGroupOverride,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/testing/dw_recording_server_transport.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/testing/dw_recording_server_transport.dart
@@ -1,0 +1,385 @@
+import 'dart:async';
+
+import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart';
+
+import '../transport/dw_server_transport.dart';
+
+/// One save that left through the transport.
+class DwRecordedSave {
+  const DwRecordedSave({required this.wrappedModel, required this.apiGroup});
+
+  /// The model as the repository wrapped it for the wire.
+  final DwModelWrapper wrappedModel;
+
+  /// The model itself, unwrapped — what an assertion usually wants.
+  SerializableModel get model => wrappedModel.model;
+
+  final String? apiGroup;
+
+  @override
+  String toString() =>
+      'DwRecordedSave(${wrappedModel.className}, apiGroup: $apiGroup)';
+}
+
+/// One delete that left through the transport.
+class DwRecordedDelete {
+  const DwRecordedDelete({
+    required this.className,
+    required this.modelId,
+    required this.apiGroup,
+  });
+
+  final String className;
+  final int modelId;
+  final String? apiGroup;
+
+  @override
+  String toString() =>
+      'DwRecordedDelete($className#$modelId, apiGroup: $apiGroup)';
+}
+
+/// One read that left through the transport.
+///
+/// [limit], [offset] and [orderByList] are `null` for a `getOne` and a
+/// `getCount`, which have no such arguments.
+class DwRecordedRead {
+  const DwRecordedRead({
+    required this.operation,
+    required this.className,
+    required this.filter,
+    this.orderByList,
+    this.limit,
+    this.offset,
+    required this.apiGroup,
+  });
+
+  /// `getOne`, `getAll` or `getCount`.
+  final String operation;
+  final String className;
+  final DwBackendFilter? filter;
+  final List<DwOrderBy>? orderByList;
+  final int? limit;
+  final int? offset;
+  final String? apiGroup;
+
+  @override
+  String toString() =>
+      'DwRecordedRead($operation $className, apiGroup: $apiGroup)';
+}
+
+/// Thrown when the code under test performed a server operation the test never
+/// prepared an answer for.
+///
+/// It is a failure and not an empty answer on purpose: a read nobody prepared
+/// is a test that does not know what its subject fetches, and an empty list
+/// would hide that behind an empty-state widget that looks deliberate.
+class DwUnpreparedServerCall extends Error {
+  DwUnpreparedServerCall(this.operation, this.responder, this.details);
+
+  /// The transport method that was called.
+  final String operation;
+
+  /// The field on [DwRecordingServerTransport] that would answer it.
+  final String responder;
+
+  /// What was asked for, so the message names the call and not just the method.
+  final String details;
+
+  @override
+  String toString() =>
+      'DwUnpreparedServerCall: the code under test called '
+      '$operation($details), and the transport had no answer ready.\n'
+      'Prepare one by setting `$responder` on the transport before the code '
+      'runs — a read is never answered by default, because a test that does '
+      'not know what its subject fetches is the thing being caught here.';
+}
+
+/// A [DwServerTransport] that answers reads from what the test prepared and
+/// keeps every write that left, for a test to assert on afterwards.
+///
+/// Hand it to `DwCore` **instead of** a `client`, and nothing has to stand up a
+/// Serverpod client to render a widget or watch it save:
+///
+/// ```dart
+/// final transport = DwRecordingServerTransport(
+///   classNames: {Task: 'Task'},
+/// );
+///
+/// setUpAll(() {
+///   DwCore<ServerpodClientShared, Task>(
+///     config: const DwConfig(),
+///     transport: transport,
+///     dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
+///     getUserId: (_) => null,
+///   );
+/// });
+///
+/// testWidgets('the button saves the task', (tester) async {
+///   await tester.pumpWidget(/* the feature */);
+///   await tester.tap(find.byIcon(Icons.check));
+///   await tester.pumpAndSettle();
+///
+///   expect(transport.saves, hasLength(1));
+///   expect((transport.saves.single.model as Task).isDone, isTrue);
+/// });
+/// ```
+///
+/// **Reads must be prepared, writes need not be.** A read nobody answered
+/// throws [DwUnpreparedServerCall], because the test does not know what its
+/// subject fetches. A save answers by echoing the model back and a delete by
+/// succeeding, because there the assertion is about what *left*, and forcing a
+/// canned response for it would be ceremony with nothing behind it. Override
+/// either with [answerSave] / [answerDelete] when the response matters — an id
+/// assigned on insert, a rejected write.
+///
+/// One instance per core, and [reset] between tests: the core keeps the
+/// transport it was built with for its whole life, and `DwCore` can be built
+/// only once per process.
+class DwRecordingServerTransport implements DwServerTransport {
+  /// [classNames] maps the models this test uses to the class names they travel
+  /// under — the same names the server's CRUD config knows them by. Without an
+  /// entry a model falls back to its `runtimeType`, which is right often enough
+  /// for a test and wrong for a private class whose Dart name is not the wire
+  /// name.
+  ///
+  /// [serializationManager] replaces that shorthand outright, for the tests
+  /// that need models read *back* off the wire and not only named on the way
+  /// out — reading a local snapshot is the case, since it rebuilds the response
+  /// from stored JSON. Pass one or the other, not both.
+  DwRecordingServerTransport({
+    Map<Type, String> classNames = const {},
+    SerializationManager? serializationManager,
+  }) : assert(
+         serializationManager == null || classNames.isEmpty,
+         'classNames is the shorthand for building a serializationManager; '
+         'passing both means one of them is silently ignored.',
+       ),
+       serializationManager =
+           serializationManager ?? _RecordingSerializationManager(classNames);
+
+  @override
+  final SerializationManager serializationManager;
+
+  /// Every save that left, oldest first.
+  final saves = <DwRecordedSave>[];
+
+  /// Every delete that left, oldest first.
+  final deletes = <DwRecordedDelete>[];
+
+  /// Every read that left, oldest first — including the ones that then threw
+  /// [DwUnpreparedServerCall], so a failing test can be told what was asked.
+  final reads = <DwRecordedRead>[];
+
+  /// Answers `getOne`. Unset means every `getOne` throws.
+  Future<DwApiResponse<DwModelWrapper>> Function(DwRecordedRead read)?
+  answerGetOne;
+
+  /// Answers `getAll`. Unset means every `getAll` throws.
+  Future<DwApiResponse<List<DwModelWrapper>>> Function(DwRecordedRead read)?
+  answerGetAll;
+
+  /// Answers `getCount`. Unset means every `getCount` throws.
+  Future<DwApiResponse<int>> Function(DwRecordedRead read)? answerGetCount;
+
+  /// Answers `saveModel`. Unset echoes the saved model back, as a server that
+  /// accepted it unchanged would.
+  Future<DwApiResponse<DwModelWrapper>> Function(DwRecordedSave save)?
+  answerSave;
+
+  /// Answers `delete`. Unset reports success.
+  Future<DwApiResponse<bool>> Function(DwRecordedDelete delete)? answerDelete;
+
+  /// Answers `subscribeOnUpdates`. Unset opens a stream that never emits and
+  /// never ends.
+  ///
+  /// Silence rather than a throw, unlike the reads: a channel is opened by the
+  /// framework when a subscribing widget mounts, not by the test, so failing
+  /// here would break tests about something else entirely with a message about
+  /// an operation their author never wrote. It never *ends* either — a closed
+  /// channel reads as the server having dropped it, and the framework would
+  /// leave a reconnect timer pending for the test to trip over.
+  Stream<SerializableModel> Function(String channel)? answerSubscribe;
+
+  /// Answers `getUploadDescription`. Unset means it throws.
+  Future<String?> Function(String path)? answerUploadDescription;
+
+  /// Answers `verifyUpload`. Unset means it throws.
+  Future<DwCloudFile?> Function(String path)? answerVerifyUpload;
+
+  /// Forgets everything recorded and every prepared answer.
+  void reset() {
+    saves.clear();
+    deletes.clear();
+    reads.clear();
+    answerGetOne = null;
+    answerGetAll = null;
+    answerGetCount = null;
+    answerSave = null;
+    answerDelete = null;
+    answerSubscribe = null;
+    answerUploadDescription = null;
+    answerVerifyUpload = null;
+  }
+
+  @override
+  Future<DwApiResponse<DwModelWrapper>> getOne({
+    required String className,
+    required DwBackendFilter filter,
+    String? apiGroup,
+  }) {
+    final read = DwRecordedRead(
+      operation: 'getOne',
+      className: className,
+      filter: filter,
+      apiGroup: apiGroup,
+    );
+    reads.add(read);
+    final answer = answerGetOne;
+    if (answer == null) {
+      throw DwUnpreparedServerCall(
+        'getOne',
+        'answerGetOne',
+        'className: $className',
+      );
+    }
+    return answer(read);
+  }
+
+  @override
+  Future<DwApiResponse<List<DwModelWrapper>>> getAll({
+    required String className,
+    DwBackendFilter? filter,
+    List<DwOrderBy>? orderByList,
+    int? limit,
+    int? offset,
+    String? apiGroup,
+  }) {
+    final read = DwRecordedRead(
+      operation: 'getAll',
+      className: className,
+      filter: filter,
+      orderByList: orderByList,
+      limit: limit,
+      offset: offset,
+      apiGroup: apiGroup,
+    );
+    reads.add(read);
+    final answer = answerGetAll;
+    if (answer == null) {
+      throw DwUnpreparedServerCall(
+        'getAll',
+        'answerGetAll',
+        'className: $className',
+      );
+    }
+    return answer(read);
+  }
+
+  @override
+  Future<DwApiResponse<int>> getCount({
+    required String className,
+    DwBackendFilter? filter,
+    String? apiGroup,
+  }) {
+    final read = DwRecordedRead(
+      operation: 'getCount',
+      className: className,
+      filter: filter,
+      apiGroup: apiGroup,
+    );
+    reads.add(read);
+    final answer = answerGetCount;
+    if (answer == null) {
+      throw DwUnpreparedServerCall(
+        'getCount',
+        'answerGetCount',
+        'className: $className',
+      );
+    }
+    return answer(read);
+  }
+
+  @override
+  Future<DwApiResponse<DwModelWrapper>> saveModel({
+    required DwModelWrapper wrappedModel,
+    String? apiGroup,
+  }) {
+    final save = DwRecordedSave(wrappedModel: wrappedModel, apiGroup: apiGroup);
+    saves.add(save);
+    final answer = answerSave;
+    if (answer != null) return answer(save);
+    return Future.value(
+      DwApiResponse<DwModelWrapper>(
+        isOk: true,
+        value: wrappedModel,
+        updatedModels: <DwModelWrapper>[wrappedModel],
+      ),
+    );
+  }
+
+  @override
+  Future<DwApiResponse<bool>> delete({
+    required String className,
+    required int modelId,
+    String? apiGroup,
+  }) {
+    final delete = DwRecordedDelete(
+      className: className,
+      modelId: modelId,
+      apiGroup: apiGroup,
+    );
+    deletes.add(delete);
+    final answer = answerDelete;
+    if (answer != null) return answer(delete);
+    return Future.value(const DwApiResponse<bool>(isOk: true, value: true));
+  }
+
+  @override
+  Stream<SerializableModel> subscribeOnUpdates({required String channel}) =>
+      answerSubscribe?.call(channel) ??
+      Stream<SerializableModel>.fromFuture(
+        Completer<SerializableModel>().future,
+      );
+
+  @override
+  Future<String?> getUploadDescription({required String path}) {
+    final answer = answerUploadDescription;
+    if (answer == null) {
+      throw DwUnpreparedServerCall(
+        'getUploadDescription',
+        'answerUploadDescription',
+        'path: $path',
+      );
+    }
+    return answer(path);
+  }
+
+  @override
+  Future<DwCloudFile?> verifyUpload({required String path}) {
+    final answer = answerVerifyUpload;
+    if (answer == null) {
+      throw DwUnpreparedServerCall(
+        'verifyUpload',
+        'answerVerifyUpload',
+        'path: $path',
+      );
+    }
+    return answer(path);
+  }
+}
+
+/// Names models the way the test declared, and defers to Serverpod's own
+/// defaults for everything else.
+class _RecordingSerializationManager extends SerializationManager {
+  _RecordingSerializationManager(this._classNames);
+
+  final Map<Type, String> _classNames;
+
+  @override
+  String? getClassNameForObject(Object? value) {
+    if (value == null) return null;
+    return _classNames[value.runtimeType] ??
+        super.getClassNameForObject(value) ??
+        (value is SerializableModel ? '${value.runtimeType}' : null);
+  }
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/testing/dw_recording_server_transport.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/testing/dw_recording_server_transport.dart
@@ -136,16 +136,19 @@ class DwUnpreparedServerCall extends Error {
 /// transport it was built with for its whole life, and `DwCore` can be built
 /// only once per process.
 class DwRecordingServerTransport implements DwServerTransport {
-  /// [classNames] maps the models this test uses to the class names they travel
-  /// under — the same names the server's CRUD config knows them by. Without an
-  /// entry a model falls back to its `runtimeType`, which is right often enough
-  /// for a test and wrong for a private class whose Dart name is not the wire
-  /// name.
+  /// **An application passes [serializationManager], and passes its own
+  /// generated `Protocol()`** — the same object its Serverpod client carries.
+  /// It already names every model of the project correctly, and it is the only
+  /// thing that can: a generated model is an abstract class with a private
+  /// implementation, so its `runtimeType` is `_NewsPostImpl` and never the name
+  /// the wire uses. It is also what a test needs to read a model *back* — a
+  /// local snapshot rebuilds its response from stored JSON.
   ///
-  /// [serializationManager] replaces that shorthand outright, for the tests
-  /// that need models read *back* off the wire and not only named on the way
-  /// out — reading a local snapshot is the case, since it rebuilds the response
-  /// from stored JSON. Pass one or the other, not both.
+  /// [classNames] is the shorthand for the other case, a test over models it
+  /// invented itself, which the framework's own tests are full of: it maps each
+  /// one to the name it travels under. Pass one or the other, not both. A model
+  /// covered by neither is refused when it is first named, rather than sent
+  /// under a name no server knows.
   DwRecordingServerTransport({
     Map<Type, String> classNames = const {},
     SerializationManager? serializationManager,
@@ -378,8 +381,19 @@ class _RecordingSerializationManager extends SerializationManager {
   @override
   String? getClassNameForObject(Object? value) {
     if (value == null) return null;
-    return _classNames[value.runtimeType] ??
-        super.getClassNameForObject(value) ??
-        (value is SerializableModel ? '${value.runtimeType}' : null);
+    final declared =
+        _classNames[value.runtimeType] ?? super.getClassNameForObject(value);
+    if (declared != null) return declared;
+    // Falling back to the Dart type name would be silently wrong exactly where
+    // it matters most: a generated Serverpod model is an abstract class with a
+    // private implementation, so `runtimeType` reads `_NewsPostImpl` and the
+    // save would leave under a name no server knows.
+    throw StateError(
+      'DwRecordingServerTransport does not know what ${value.runtimeType} is '
+      'called on the wire.\n'
+      'An app passes its own generated Protocol() as serializationManager — it '
+      'names every model of the project. A test over an invented model adds it '
+      'to classNames: {${value.runtimeType}: \'<TheWireName>\'}.',
+    );
   }
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/transport/dw_server_transport.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/transport/dw_server_transport.dart
@@ -1,0 +1,98 @@
+import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart';
+
+/// Every server operation `dw.repo` performs, and nothing else.
+///
+/// This is the whole dependency the client-side repository has on the server:
+/// five CRUD calls, one realtime subscription, and the two-step upload
+/// handshake. Everything an app reaches — the read providers, `saveModel`,
+/// `deleteModel`, `DwFileUploadHandler` — ends here, so replacing this
+/// replaces the wire without touching a line of feature code.
+///
+/// Two things follow from that, and both are the reason it exists as a type:
+///
+/// * **A test can observe a write.** The repository does not name the generated
+///   Serverpod client any more, so a test hands `DwCore` a transport of its own
+///   instead of subclassing `ServerpodClientShared` and decoding string-keyed
+///   endpoint arguments. The core ships one for that —
+///   `DwRecordingServerTransport` in
+///   `package:dartway_serverpod_core_flutter/testing.dart`.
+/// * **Serverpod is replaceable.** The default implementation,
+///   `DwServerpodTransport`, is the only place in the Flutter half that knows
+///   what a generated `Caller` is.
+///
+/// The local store is *not* an alternative to this. `dw.repo.localWrites` keeps
+/// a write that failed on the connection; a write still always leaves by this
+/// path first. See `DwRepoLocalWrites`.
+///
+/// Implementations are expected to be cheap to construct and to hold no state
+/// the core owns — `DwCore` builds or receives exactly one and keeps it for its
+/// lifetime.
+abstract interface class DwServerTransport {
+  /// How models are named and rebuilt on the wire this transport speaks.
+  ///
+  /// It belongs here because encoding *is* part of speaking to a server: the
+  /// class name that travels with every wrapped model comes from this, and the
+  /// core installs it globally ([DwCoreServerpodClient.protocol]) the moment
+  /// the transport is known. A transport that answers calls but cannot name a
+  /// model would let `DwModelWrapper.wrap` fail long after construction, on the
+  /// first save.
+  SerializationManager get serializationManager;
+
+  // --- CRUD ------------------------------------------------------------------
+
+  /// Reads the single [className] row matching [filter].
+  Future<DwApiResponse<DwModelWrapper>> getOne({
+    required String className,
+    required DwBackendFilter filter,
+    String? apiGroup,
+  });
+
+  /// Reads the [className] rows matching [filter], ordered and paginated.
+  Future<DwApiResponse<List<DwModelWrapper>>> getAll({
+    required String className,
+    DwBackendFilter? filter,
+    List<DwOrderBy>? orderByList,
+    int? limit,
+    int? offset,
+    String? apiGroup,
+  });
+
+  /// Counts the [className] rows matching [filter], server-side.
+  Future<DwApiResponse<int>> getCount({
+    required String className,
+    DwBackendFilter? filter,
+    String? apiGroup,
+  });
+
+  /// Creates or updates [wrappedModel]; answers with the persisted model.
+  Future<DwApiResponse<DwModelWrapper>> saveModel({
+    required DwModelWrapper wrappedModel,
+    String? apiGroup,
+  });
+
+  /// Deletes row [modelId] of [className].
+  Future<DwApiResponse<bool>> delete({
+    required String className,
+    required int modelId,
+    String? apiGroup,
+  });
+
+  // --- Realtime --------------------------------------------------------------
+
+  /// Opens the server-side update stream for [channel].
+  ///
+  /// One stream per channel; the connection is the streams, so subscribing is
+  /// connecting and the last cancellation disconnects. Called by
+  /// `DwSocketService`, never by an app directly.
+  Stream<SerializableModel> subscribeOnUpdates({required String channel});
+
+  // --- Uploads ---------------------------------------------------------------
+
+  /// Asks the server for a one-shot upload description for [path], or `null`
+  /// when it refuses the path.
+  Future<String?> getUploadDescription({required String path});
+
+  /// Confirms with the server that the bytes at [path] arrived, and answers
+  /// with the stored file — `null` when the upload cannot be verified.
+  Future<DwCloudFile?> verifyUpload({required String path});
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/transport/dw_serverpod_transport.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/transport/dw_serverpod_transport.dart
@@ -1,0 +1,108 @@
+import 'package:collection/collection.dart';
+import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart';
+
+import 'dw_server_transport.dart';
+
+/// [DwServerTransport] over the generated Serverpod client — the default, and
+/// what every application runs.
+///
+/// It is the only place in the Flutter half that knows the generated `Caller`
+/// exists. `DwCore` builds one from the `client` it is given, so an app writes
+/// nothing here; a test that wants to watch a write reaches for
+/// `DwRecordingServerTransport` instead of standing this one up on a fake
+/// client.
+final class DwServerpodTransport implements DwServerTransport {
+  /// Wraps [client], resolving the DartWay core module registered on it.
+  ///
+  /// Throws when the module is absent — the client was generated without
+  /// `dartway_serverpod_core` in its `modules`, and no CRUD call could ever
+  /// have worked.
+  DwServerpodTransport(this._client) : _caller = _resolveCaller(_client);
+
+  final ServerpodClientShared _client;
+  final Caller _caller;
+
+  static Caller _resolveCaller(ServerpodClientShared client) {
+    final caller = client.moduleLookup.values.whereType<Caller>().firstOrNull;
+    if (caller == null) {
+      throw StateError(
+        'DartWay core module not found on the Serverpod client.\n'
+        'Add dartway_serverpod_core to the modules of your client project '
+        'and re-run `serverpod generate`.',
+      );
+    }
+    return caller;
+  }
+
+  @override
+  SerializationManager get serializationManager => _client.serializationManager;
+
+  @override
+  Future<DwApiResponse<DwModelWrapper>> getOne({
+    required String className,
+    required DwBackendFilter filter,
+    String? apiGroup,
+  }) => _caller.dwCrud.getOne(
+    className: className,
+    filter: filter,
+    apiGroup: apiGroup,
+  );
+
+  @override
+  Future<DwApiResponse<List<DwModelWrapper>>> getAll({
+    required String className,
+    DwBackendFilter? filter,
+    List<DwOrderBy>? orderByList,
+    int? limit,
+    int? offset,
+    String? apiGroup,
+  }) => _caller.dwCrud.getAll(
+    className: className,
+    filter: filter,
+    orderByList: orderByList,
+    limit: limit,
+    offset: offset,
+    apiGroup: apiGroup,
+  );
+
+  @override
+  Future<DwApiResponse<int>> getCount({
+    required String className,
+    DwBackendFilter? filter,
+    String? apiGroup,
+  }) => _caller.dwCrud.getCount(
+    className: className,
+    filter: filter,
+    apiGroup: apiGroup,
+  );
+
+  @override
+  Future<DwApiResponse<DwModelWrapper>> saveModel({
+    required DwModelWrapper wrappedModel,
+    String? apiGroup,
+  }) =>
+      _caller.dwCrud.saveModel(wrappedModel: wrappedModel, apiGroup: apiGroup);
+
+  @override
+  Future<DwApiResponse<bool>> delete({
+    required String className,
+    required int modelId,
+    String? apiGroup,
+  }) => _caller.dwCrud.delete(
+    className: className,
+    modelId: modelId,
+    apiGroup: apiGroup,
+  );
+
+  @override
+  Stream<SerializableModel> subscribeOnUpdates({required String channel}) =>
+      _caller.dwCrud.subscribeOnUpdates(channel: channel);
+
+  @override
+  Future<String?> getUploadDescription({required String path}) =>
+      _caller.dwUpload.getUploadDescription(path: path);
+
+  @override
+  Future<DwCloudFile?> verifyUpload({required String path}) =>
+      _caller.dwUpload.verifyUpload(path: path);
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_file_upload_handler.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_file_upload_handler.dart
@@ -128,8 +128,9 @@ class DwFileUploadHandler {
   }) async {
     final byteData = ByteData.view(bytes.buffer);
 
-    var uploadDescription = await dw.endpointCaller.dwUpload
-        .getUploadDescription(path: path);
+    var uploadDescription = await dw.serverTransport.getUploadDescription(
+      path: path,
+    );
 
     if (uploadDescription == null) {
       throw Exception("Failed to get upload description for path: $path");
@@ -140,7 +141,7 @@ class DwFileUploadHandler {
 
     await uploader.uploadByteData(byteData);
 
-    var dwMedia = await dw.endpointCaller.dwUpload.verifyUpload(path: path);
+    var dwMedia = await dw.serverTransport.verifyUpload(path: path);
 
     if (dwMedia == null) {
       throw Exception("Failed to verify uploaded file with path: $path");

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/testing.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/testing.dart
@@ -1,4 +1,4 @@
-/// Test suites the core ships for the contracts it defines.
+/// What the core ships for the tests written against it.
 ///
 /// Import this from a test, never from application code:
 ///
@@ -6,10 +6,19 @@
 /// import 'package:dartway_serverpod_core_flutter/testing.dart';
 /// ```
 ///
-/// A contract whose dangerous half cannot be held by the shape of its API is
-/// held by a suite instead — the implementation runs the core's own tests and
-/// either passes them or does not.
+/// Two kinds of thing live here, and nothing else:
+///
+/// * **Conformance suites.** A contract whose dangerous half cannot be held by
+///   the shape of its API is held by a suite instead — the implementation runs
+///   the core's own tests and either passes them or does not.
+/// * **Test doubles for the core's own seams.** `DwRecordingServerTransport`
+///   stands in for the server, so a widget test can watch a feature save
+///   without a Serverpod client anywhere in the process.
+///
+/// They ship from here rather than from the main barrel so that nothing an
+/// application imports can reach them by accident.
 library;
 
+export 'src/testing/dw_recording_server_transport.dart';
 export 'src/testing/dw_repo_local_reads_conformance.dart';
 export 'src/testing/dw_repo_local_writes_conformance.dart';

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_ambient_feature_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_ambient_feature_test.dart
@@ -1,0 +1,220 @@
+import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The path an application actually takes, end to end: a feature that reads
+/// and writes for itself, rendered against a core booted the way an app boots
+/// one, with the server standing in as a [DwRecordingServerTransport].
+///
+/// Every other test in this package calls the repository directly or holds the
+/// core in a local variable. This one deliberately does neither — the core is a
+/// library-level `dw`, exactly as an app declares it, and the widget reaches it
+/// ambiently. That is the difference between testing the framework and testing
+/// the way the framework is used.
+void main() {
+  final transport = DwRecordingServerTransport(
+    classNames: <Type, String>{_Task: 'Task'},
+  );
+
+  setUpAll(() => _bootTestCore(transport));
+
+  setUp(() {
+    transport.reset();
+    // The feature reads a list on every build, so this is the baseline every
+    // test starts from; the tests that care about the read replace it.
+    transport.answerGetAll = (_) async => _tasksResponse(const <_Task>[]);
+  });
+
+  testWidgets('a feature draws what the transport answered', (tester) async {
+    transport.answerGetAll = (_) async => _tasksResponse(const <_Task>[
+      _Task(id: 1, title: 'Buy milk'),
+      _Task(id: 2, title: 'Call the dentist'),
+    ]);
+
+    await tester.pumpWidget(const _App());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Buy milk'), findsOneWidget);
+    expect(find.text('Call the dentist'), findsOneWidget);
+    expect(transport.reads.single.className, 'Task');
+  });
+
+  testWidgets('the tap leaves as a save, carrying what the feature built', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const _App());
+    await tester.pumpAndSettle();
+
+    expect(transport.saves, isEmpty, reason: 'nothing saves on render alone');
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    expect(transport.saves, hasLength(1));
+    final saved = transport.saves.single;
+    expect(saved.wrappedModel.className, 'Task');
+    expect((saved.model as _Task).title, 'A new task');
+    expect(saved.apiGroup, isNull);
+  });
+
+  testWidgets('the saved model comes back and the list shows it', (
+    tester,
+  ) async {
+    // The server assigns the id, as a real one does on insert.
+    transport.answerSave = (save) async {
+      final task = save.model as _Task;
+      final stored = _Task(id: 42, title: task.title);
+      return DwApiResponse<DwModelWrapper>(
+        isOk: true,
+        value: DwModelWrapper.wrap(model: stored),
+        updatedModels: <DwModelWrapper>[DwModelWrapper.wrap(model: stored)],
+      );
+    };
+
+    await tester.pumpWidget(const _App());
+    await tester.pumpAndSettle();
+    expect(find.text('A new task'), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    // Not re-fetched: the save's `updatedModels` reached the open list through
+    // the repository's own update dispatch.
+    expect(transport.reads, hasLength(1));
+    expect(find.text('A new task'), findsOneWidget);
+  });
+
+  testWidgets(
+    'a read nobody prepared names itself and the field that answers',
+    (tester) async {
+      transport.answerGetAll = null;
+
+      await tester.pumpWidget(const _App());
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('DwUnpreparedServerCall'), findsOneWidget);
+      expect(find.textContaining('answerGetAll'), findsOneWidget);
+      expect(
+        transport.reads.single.operation,
+        'getAll',
+        reason: 'the attempt is recorded even though it had no answer',
+      );
+    },
+  );
+
+  test('a core with neither a client nor a transport says so', () {
+    expect(
+      () => DwCore<ServerpodClientShared, _Task>(
+        config: const DwConfig(),
+        dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
+        getUserId: (_) => null,
+      ),
+      throwsA(
+        isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('client:'), contains('transport:')),
+        ),
+      ),
+    );
+  });
+
+  test('dw.client on a transport-only core says how the core was built', () {
+    expect(
+      () => dw.client,
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('without a Serverpod client'),
+        ),
+      ),
+    );
+  });
+}
+
+// --- The app half ------------------------------------------------------------
+//
+// Written the way `template/dartway_starter_flutter/lib/core/dw_core.dart` is,
+// down to the idempotency guard: a test file must be able to boot the core from
+// `setUpAll` without knowing whether another one got there first.
+
+late final DwCore<ServerpodClientShared, _Task> dw;
+
+bool _coreInitialized = false;
+
+void _bootTestCore(DwServerTransport transport) {
+  if (_coreInitialized) return;
+  _coreInitialized = true;
+
+  dw = DwCore<ServerpodClientShared, _Task>(
+    config: const DwConfig(defaultModelGetter: dwGetDefault),
+    // Instead of a client, not beside one: nothing here stands up Serverpod.
+    transport: transport,
+    dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
+    getUserId: (task) => task?.id,
+  );
+
+  dw.repo.setupRepository(defaultModel: const _Task(id: 0, title: ''));
+}
+
+/// A feature that reads and writes for itself — no callbacks handed in, so the
+/// only thing a test can observe is what left for the server.
+class _TaskFeature extends ConsumerWidget {
+  const _TaskFeature();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Built here rather than inside the callback, which is what makes a booted
+    // core a prerequisite for *rendering* and not only for tapping.
+    final addTask = dw.action<_Task>(
+      (_) => dw.repo.saveModel(const _Task(title: 'A new task')),
+      label: 'addTask',
+      onSuccessNotification: 'Task added',
+    );
+
+    final tasks = ref.watch(dw.repo.modelList<_Task>());
+
+    return Scaffold(
+      body: switch (tasks) {
+        AsyncData(:final value) => ListView(
+          children: <Widget>[for (final task in value) Text(task.title)],
+        ),
+        AsyncError(:final error) => Text('$error'),
+        _ => const Center(child: CircularProgressIndicator()),
+      },
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => addTask(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class _App extends StatelessWidget {
+  const _App();
+
+  @override
+  Widget build(BuildContext context) =>
+      const ProviderScope(child: MaterialApp(home: _TaskFeature()));
+}
+
+class _Task implements SerializableModel {
+  const _Task({this.id, required this.title});
+
+  final int? id;
+  final String title;
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{'id': id, 'title': title};
+}
+
+DwApiResponse<List<DwModelWrapper>> _tasksResponse(List<_Task> tasks) =>
+    DwApiResponse<List<DwModelWrapper>>(
+      isOk: true,
+      value: tasks
+          .map((task) => DwModelWrapper.wrap(model: task))
+          .toList(growable: false),
+    );

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repo_local_reads_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repo_local_reads_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
 import 'package:dartway_serverpod_core_flutter/src/repository/dw_repository.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
 import 'package:dartway_serverpod_core_client/src/protocol/protocol.dart'
     as generated;
 import 'package:flutter_test/flutter_test.dart';
@@ -21,9 +22,14 @@ void main() {
 
   setUpAll(() {
     store = _TestLocalStore();
-    DwCore<_ReadsClient, DwAuthKey>(
+    DwCore<ServerpodClientShared, DwAuthKey>(
       config: const DwConfig(),
-      client: _ReadsClient(),
+      // The reads here supply their own online request, so the transport is
+      // never asked anything — it exists so the core is constructible, and
+      // that no longer costs a Serverpod client.
+      transport: DwRecordingServerTransport(
+        serializationManager: generated.Protocol(),
+      ),
       dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
       getUserId: (_) => null,
       plugins: [store],
@@ -55,10 +61,7 @@ void main() {
       expect(result.value, 42);
       expect(result.origin, DwRepoReadOrigin.network);
       expect(localReads.storedSnapshots, hasLength(1));
-      expect(
-        localReads.storedSnapshots.single.scope,
-        localReads.currentScope,
-      );
+      expect(localReads.storedSnapshots.single.scope, localReads.currentScope);
       expect(
         localReads.storedSnapshots.single.schemaVersion,
         DwRepoReadSnapshot.currentSchemaVersion,
@@ -557,36 +560,33 @@ void main() {
     },
   );
 
-  test(
-    'does not commit an online snapshot after its store changes',
-    () async {
-      final storeReached = Completer<void>();
-      final allowStoreCommit = Completer<void>();
-      final originalDelegate = localReads;
-      final replacementReads = _RecordingLocalReads();
-      localReads.storeReached = storeReached;
-      localReads.allowStoreCommit = allowStoreCommit;
+  test('does not commit an online snapshot after its store changes', () async {
+    final storeReached = Completer<void>();
+    final allowStoreCommit = Completer<void>();
+    final originalDelegate = localReads;
+    final replacementReads = _RecordingLocalReads();
+    localReads.storeReached = storeReached;
+    localReads.allowStoreCommit = allowStoreCommit;
 
-      final read = DwRepository.executeRead<Object, int>(
-        queryKey: queryKey,
-        readStrategy: DwRepoReadStrategy.networkFirstWithSnapshot,
-        onlineRequest: () async =>
-            const DwApiResponse<int>(isOk: true, value: 42),
-      );
-      await storeReached.future;
-      store.reads = replacementReads;
-      allowStoreCommit.complete();
+    final read = DwRepository.executeRead<Object, int>(
+      queryKey: queryKey,
+      readStrategy: DwRepoReadStrategy.networkFirstWithSnapshot,
+      onlineRequest: () async =>
+          const DwApiResponse<int>(isOk: true, value: 42),
+    );
+    await storeReached.future;
+    store.reads = replacementReads;
+    allowStoreCommit.complete();
 
-      await expectLater(read, throwsA(isA<StateError>()));
-      // The core refuses the response and never hands the value to the caller.
-      // Whether the outgoing store physically wrote the row is the store's own
-      // commit-time condition to hold, not something the core can undo from
-      // here — the store's own transaction exists for exactly that, and the
-      // conformance suite is where an implementation is held to it.
-      expect(replacementReads.storedSnapshots, isEmpty);
-      expect(originalDelegate.loadedQueryKeys, isEmpty);
-    },
-  );
+    await expectLater(read, throwsA(isA<StateError>()));
+    // The core refuses the response and never hands the value to the caller.
+    // Whether the outgoing store physically wrote the row is the store's own
+    // commit-time condition to hold, not something the core can undo from
+    // here — the store's own transaction exists for exactly that, and the
+    // conformance suite is where an implementation is held to it.
+    expect(replacementReads.storedSnapshots, isEmpty);
+    expect(originalDelegate.loadedQueryKeys, isEmpty);
+  });
 
   test(
     'does not commit an online snapshot after same-scope logout-login ABA in store',
@@ -715,9 +715,7 @@ void main() {
 
 class _RecordingLocalReads implements DwRepoLocalReads {
   DwRepoScope _currentScope = DwRepoScope('first-user');
-  late DwRepoBinding _currentBinding = DwRepoBinding(
-    scope: _currentScope,
-  );
+  late DwRepoBinding _currentBinding = DwRepoBinding(scope: _currentScope);
   final storedSnapshots = <DwRepoReadSnapshot>[];
   final loadedQueryKeys = <DwRepoQueryKey<Object>>[];
   DwRepoReadSnapshot? availableSnapshot;
@@ -785,7 +783,8 @@ class _RecordingReadTx implements DwRepoLocalReadTx {
     required DwRepoQueryKey<Model> queryKey,
     required DwRepoReadSnapshot snapshot,
   }) async {
-    if (_store.storeResult != DwRepoReadSnapshotStoreResult.stored) return false;
+    if (_store.storeResult != DwRepoReadSnapshotStoreResult.stored)
+      return false;
     staged.add(snapshot);
     return true;
   }
@@ -849,35 +848,4 @@ class _TestLocalStore extends DwRepoLocalStorePlugin {
 
   @override
   Future<void> init(DwFlutter core) async {}
-}
-
-/// The reads here supply their own online request, so the client only has to
-/// exist for the core to be constructible.
-class _ReadsClient extends ServerpodClientShared {
-  _ReadsClient()
-    : super(
-        'http://localhost:8080',
-        generated.Protocol(),
-        streamingConnectionTimeout: null,
-        connectionTimeout: null,
-      ) {
-    _caller = Caller(this);
-  }
-
-  late final Caller _caller;
-
-  @override
-  Map<String, ModuleEndpointCaller> get moduleLookup =>
-      <String, ModuleEndpointCaller>{'dartway_serverpod_core': _caller};
-
-  @override
-  Map<String, EndpointRef> get endpointRefLookup => <String, EndpointRef>{};
-
-  @override
-  Future<T> callServerEndpoint<T>(
-    String endpoint,
-    String method,
-    Map<String, dynamic> args, {
-    bool authenticated = true,
-  }) async => throw StateError('No test here reaches the network.');
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repo_query_key_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repo_query_key_test.dart
@@ -1,5 +1,6 @@
 import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
 import 'package:dartway_serverpod_core_flutter/src/repository/dw_repository.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
 import 'package:dartway_serverpod_core_flutter/src/repository/domain/dw_pagination_strategy.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,9 +16,9 @@ void main() {
 
   setUpAll(() {
     store = _TestLocalStore();
-    _queryKeyCore = DwCore<_EndpointCapturingClient, _QueryLesson>(
+    DwCore<ServerpodClientShared, _QueryLesson>(
       config: const DwConfig(),
-      client: _EndpointCapturingClient(),
+      transport: _transport,
       dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
       getUserId: (_) => null,
       plugins: [store],
@@ -464,7 +465,7 @@ void main() {
   test(
     'modelList sends the key API group to the actual endpoint request',
     () async {
-      final endpointClient = _queryKeyCore.client..reset();
+      _transport.reads.clear();
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final config = DwModelListStateConfig<_QueryLesson>(
@@ -477,7 +478,7 @@ void main() {
       );
 
       expect(localReads.queryKeys.single.apiGroup, 'learning');
-      expect(endpointClient.getAllApiGroup, 'learning');
+      expect(_transport.reads.single.apiGroup, 'learning');
     },
   );
 
@@ -596,54 +597,23 @@ class _QueryKeyProtocol extends SerializationManager {
   };
 }
 
-late final DwCore<_EndpointCapturingClient, _QueryLesson> _queryKeyCore;
+/// Answers the reads these tests trigger, and keeps what was asked for — the
+/// api group a key carries has to be shown reaching the request, not only the
+/// key.
+final _transport =
+    DwRecordingServerTransport(serializationManager: _QueryKeyProtocol())
+      ..answerGetAll = _emptyList
+      ..answerGetOne = _absentModel;
 
-class _EndpointCapturingClient extends ServerpodClientShared {
-  _EndpointCapturingClient()
-    : super(
-        'http://localhost:8080',
-        _QueryKeyProtocol(),
-        streamingConnectionTimeout: null,
-        connectionTimeout: null,
-      ) {
-    _dartwayCaller = Caller(this);
-  }
+Future<DwApiResponse<List<DwModelWrapper>>> _emptyList(
+  DwRecordedRead read,
+) async => const DwApiResponse<List<DwModelWrapper>>(
+  isOk: true,
+  value: <DwModelWrapper>[],
+);
 
-  late final Caller _dartwayCaller;
-  String? getAllApiGroup;
-
-  void reset() {
-    getAllApiGroup = null;
-  }
-
-  @override
-  Map<String, ModuleEndpointCaller> get moduleLookup =>
-      <String, ModuleEndpointCaller>{'dartway_serverpod_core': _dartwayCaller};
-
-  @override
-  Map<String, EndpointRef> get endpointRefLookup => <String, EndpointRef>{};
-
-  @override
-  Future<T> callServerEndpoint<T>(
-    String endpoint,
-    String method,
-    Map<String, dynamic> args, {
-    bool authenticated = true,
-  }) async {
-    if (endpoint == 'dartway_serverpod_core.dwCrud' && method == 'getAll') {
-      getAllApiGroup = args['apiGroup'] as String?;
-      return const DwApiResponse<List<DwModelWrapper>>(
-            isOk: true,
-            value: <DwModelWrapper>[],
-          )
-          as T;
-    }
-    if (endpoint == 'dartway_serverpod_core.dwCrud' && method == 'getOne') {
-      return const DwApiResponse<DwModelWrapper>(isOk: true, value: null) as T;
-    }
-    throw StateError('Unexpected endpoint request: $endpoint.$method');
-  }
-}
+Future<DwApiResponse<DwModelWrapper>> _absentModel(DwRecordedRead read) async =>
+    const DwApiResponse<DwModelWrapper>(isOk: true, value: null);
 
 class _FixedPagination implements DwPaginationStrategy {
   @override

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repository_offline_read_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repository_offline_read_test.dart
@@ -2,20 +2,26 @@ import 'dart:async';
 
 import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
 import 'package:dartway_serverpod_core_flutter/src/repository/dw_repository.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  late _OfflineReadClient client;
+  late DwRecordingServerTransport transport;
   late _TestLocalStore store;
   late _OfflineLocalReads localReads;
 
   setUpAll(() {
-    client = _OfflineReadClient();
+    // Its own manager rather than the `classNames` shorthand: these tests read
+    // snapshots back out of local storage, which rebuilds a response from
+    // stored JSON and so needs real deserialization, not only naming.
+    transport = DwRecordingServerTransport(
+      serializationManager: _OfflineReadProtocol(),
+    );
     store = _TestLocalStore();
-    DwCore<_OfflineReadClient, _OfflineReadModel>(
+    DwCore<ServerpodClientShared, _OfflineReadModel>(
       config: const DwConfig(),
-      client: client,
+      transport: transport,
       dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
       getUserId: (_) => null,
       plugins: [store],
@@ -24,7 +30,11 @@ void main() {
   });
 
   setUp(() {
-    client.listResponse = null;
+    // A connection that is simply down, which is what most cases here need;
+    // the one test about a served list replaces it.
+    transport.reset();
+    transport.answerGetAll = (_) async => throw TimeoutException('offline');
+    transport.answerGetOne = (_) async => throw TimeoutException('offline');
     localReads = _OfflineLocalReads();
     store.reads = localReads;
   });
@@ -106,7 +116,7 @@ void main() {
   test('imperative list reads do not publish updated models', () async {
     final receivedUpdates = <List<DwModelWrapper>>[];
     final update = DwModelWrapper.wrap(model: _OfflineReadModel());
-    client.listResponse = DwApiResponse<List<DwModelWrapper>>(
+    transport.answerGetAll = (_) async => DwApiResponse<List<DwModelWrapper>>(
       isOk: true,
       value: const <DwModelWrapper>[],
       updatedModels: <DwModelWrapper>[update],
@@ -128,43 +138,9 @@ class _OfflineReadModel implements SerializableModel {
   Map<String, dynamic> toJson() => <String, dynamic>{};
 }
 
-class _OfflineReadClient extends ServerpodClientShared {
-  _OfflineReadClient()
-    : super(
-        'http://localhost:8080',
-        _OfflineReadProtocol(),
-        streamingConnectionTimeout: null,
-        connectionTimeout: null,
-      ) {
-    _caller = Caller(this);
-  }
-
-  late final Caller _caller;
-
-  @override
-  Map<String, ModuleEndpointCaller> get moduleLookup =>
-      <String, ModuleEndpointCaller>{'dartway_serverpod_core': _caller};
-
-  @override
-  Map<String, EndpointRef> get endpointRefLookup => <String, EndpointRef>{};
-
-  /// What the backend answers a list read with. `null` — the default — is a
-  /// connection that is simply down, which is what most cases here need.
-  DwApiResponse<List<DwModelWrapper>>? listResponse;
-
-  @override
-  Future<T> callServerEndpoint<T>(
-    String endpoint,
-    String method,
-    Map<String, dynamic> args, {
-    bool authenticated = true,
-  }) async {
-    final response = listResponse;
-    if (response != null && method == 'getAll') return response as T;
-    throw TimeoutException('offline');
-  }
-}
-
+/// Deserializes what the local snapshot stored, and names the test model on the
+/// way out. The naming half is what `classNames` would have given; the
+/// deserializing half is why this test spells it out.
 class _OfflineReadProtocol extends SerializationManager {
   @override
   T deserialize<T>(dynamic value, [Type? type]) {

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repository_offline_write_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_repository_offline_write_test.dart
@@ -2,10 +2,11 @@ import 'dart:async';
 
 import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
 import 'package:dartway_serverpod_core_flutter/src/repository/dw_repository.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  late _OfflineWriteClient client;
+  late DwRecordingServerTransport transport;
   late _TestLocalStore store;
   late _RecordingLocalWrites localWrites;
 
@@ -13,11 +14,16 @@ void main() {
   // no setter to swap it with, which is the point of declaring it here. Each
   // test gets a fresh recorder inside the same plugin instead.
   setUpAll(() {
-    client = _OfflineWriteClient();
+    transport = DwRecordingServerTransport(
+      classNames: <Type, String>{
+        _OfflineWriteModel: 'OfflineWriteModel',
+        _OtherWriteModel: 'OtherWriteModel',
+      },
+    );
     store = _TestLocalStore();
-    DwCore<_OfflineWriteClient, _OfflineWriteModel>(
+    DwCore<ServerpodClientShared, _OfflineWriteModel>(
       config: const DwConfig(),
-      client: client,
+      transport: transport,
       dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
       getUserId: (_) => null,
       plugins: [store],
@@ -28,7 +34,7 @@ void main() {
   });
 
   setUp(() {
-    client.reset();
+    transport.reset();
     localWrites = _RecordingLocalWrites();
     store.writes = localWrites;
   });
@@ -48,7 +54,7 @@ void main() {
       localWrites.optInSaves = false;
       final savedModel = const _OfflineWriteModel(id: 91, title: 'server');
       final savedWrapper = DwModelWrapper.wrap(model: savedModel);
-      client.saveHandler = (_) async => DwApiResponse<DwModelWrapper>(
+      transport.answerSave = (_) async => DwApiResponse<DwModelWrapper>(
         isOk: true,
         value: savedWrapper,
         updatedModels: <DwModelWrapper>[savedWrapper],
@@ -69,7 +75,7 @@ void main() {
       expect(result.title, 'server');
       expect(localWrites.enqueuedMutations, isEmpty);
       expect(receivedUpdates, hasLength(1));
-      expect(client.saveApiGroups, ['learning']);
+      expect(transport.saves.map((save) => save.apiGroup), ['learning']);
     },
   );
 
@@ -84,7 +90,7 @@ void main() {
       final relatedWrapper = DwModelWrapper.wrap(
         model: const _OfflineWriteModel(id: 93, title: 'related response'),
       );
-      client.saveHandler = (_) async => DwApiResponse<DwModelWrapper>(
+      transport.answerSave = (_) async => DwApiResponse<DwModelWrapper>(
         isOk: true,
         value: savedWrapper,
         updatedModels: <DwModelWrapper>[relatedWrapper],
@@ -106,13 +112,13 @@ void main() {
       expect(receivedUpdates, [
         <DwModelWrapper>[relatedWrapper],
       ]);
-      expect(client.saveApiGroups, ['learning']);
+      expect(transport.saves.map((save) => save.apiGroup), ['learning']);
     },
   );
 
   test('online delete success returns true and does not enqueue', () async {
     localWrites.optInDeletes = false;
-    client.deleteHandler = (_) async =>
+    transport.answerDelete = (_) async =>
         const DwApiResponse<bool>(isOk: true, value: true);
 
     final result = await const DwRepo().deleteModel(
@@ -122,8 +128,8 @@ void main() {
 
     expect(result, isTrue);
     expect(localWrites.enqueuedMutations, isEmpty);
-    expect(client.deletedModelIds, [17]);
-    expect(client.deleteApiGroups, ['learning']);
+    expect(transport.deletes.map((d) => d.modelId), [17]);
+    expect(transport.deletes.map((d) => d.apiGroup), ['learning']);
   });
 
   test(
@@ -150,7 +156,7 @@ void main() {
       ];
 
       for (final failingResponse in failingResponses) {
-        client.saveHandler = (_) => failingResponse;
+        transport.answerSave = (_) => failingResponse;
 
         await expectLater(
           const DwRepo().saveModel(const _OfflineWriteModel(title: 'draft')),
@@ -167,7 +173,7 @@ void main() {
       final failure = TimeoutException('offline');
       final originalStackTrace = StackTrace.current;
       localWrites.optInSaves = false;
-      client.saveHandler = (_) => Future<DwApiResponse<DwModelWrapper>>.error(
+      transport.answerSave = (_) => Future<DwApiResponse<DwModelWrapper>>.error(
         failure,
         originalStackTrace,
       );
@@ -191,7 +197,7 @@ void main() {
     () async {
       final failure = TimeoutException('offline');
       store.writes = null;
-      client.deleteHandler = (_) async => throw failure;
+      transport.answerDelete = (_) async => throw failure;
 
       await expectLater(
         const DwRepo().deleteModel(const _OfflineWriteModel(id: 31)),
@@ -204,8 +210,7 @@ void main() {
     'connection failure queues an opted-in save once and returns the optimistic model',
     () async {
       localWrites.saveMetadata = <String, dynamic>{'source': 'draft'};
-      client.saveHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerSave = (_) async => throw TimeoutException('offline');
       localWrites.optimisticSaveResponse = DwApiResponse<DwModelWrapper>(
         isOk: true,
         value: DwModelWrapper.wrap(
@@ -232,7 +237,8 @@ void main() {
           model: const _OfflineWriteModel(id: 801, title: 'offline'),
         ),
       );
-      client.saveHandler = (_) async => throw TimeoutException('lost response');
+      transport.answerSave = (_) async =>
+          throw TimeoutException('lost response');
 
       final result = await const DwRepo().saveModel(
         const _OfflineWriteModel(title: 'draft'),
@@ -240,7 +246,7 @@ void main() {
 
       expect(result.id, 801);
       expect(
-        client.saveCallCount,
+        transport.saves.length,
         1,
         reason:
             'Opting a write into local storage must not reroute how it is '
@@ -250,33 +256,29 @@ void main() {
     },
   );
 
-  test(
-    'an opted-in save that succeeds online is never queued',
-    () async {
-      client.saveHandler = (_) async => DwApiResponse<DwModelWrapper>(
-        isOk: true,
-        value: DwModelWrapper.wrap(
-          model: const _OfflineWriteModel(id: 802, title: 'server'),
-        ),
-      );
+  test('an opted-in save that succeeds online is never queued', () async {
+    transport.answerSave = (_) async => DwApiResponse<DwModelWrapper>(
+      isOk: true,
+      value: DwModelWrapper.wrap(
+        model: const _OfflineWriteModel(id: 802, title: 'server'),
+      ),
+    );
 
-      final result = await const DwRepo().saveModel(
-        const _OfflineWriteModel(title: 'draft'),
-      );
+    final result = await const DwRepo().saveModel(
+      const _OfflineWriteModel(title: 'draft'),
+    );
 
-      expect(result.id, 802);
-      expect(result.title, 'server');
-      expect(client.saveCallCount, 1);
-      expect(localWrites.enqueuedMutations, isEmpty);
-    },
-  );
+    expect(result.id, 802);
+    expect(result.title, 'server');
+    expect(transport.saves.length, 1);
+    expect(localWrites.enqueuedMutations, isEmpty);
+  });
 
   test(
     'connection failure queues an opted-in delete once and returns true',
     () async {
       localWrites.deleteMetadata = <String, dynamic>{'reason': 'archive'};
-      client.deleteHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerDelete = (_) async => throw TimeoutException('offline');
 
       final result = await const DwRepo().deleteModel(
         const _OfflineWriteModel(id: 33, title: 'server'),
@@ -297,8 +299,7 @@ void main() {
       'reason': 'offline-sync',
       'nested': <String, dynamic>{'attempt': 1},
     };
-    client.saveHandler = (_) async =>
-        throw TimeoutException('offline');
+    transport.answerSave = (_) async => throw TimeoutException('offline');
     localWrites.optimisticSaveResponse = DwApiResponse<DwModelWrapper>(
       isOk: true,
       value: DwModelWrapper.wrap(
@@ -338,7 +339,7 @@ void main() {
     );
 
     expect(result, isTrue);
-    expect(client.deletedModelIds, isEmpty);
+    expect(transport.deletes.map((d) => d.modelId), isEmpty);
     expect(localWrites.enqueuedMutations, isEmpty);
   });
 
@@ -347,7 +348,7 @@ void main() {
     () async {
       final receivedUpdates = <List<DwModelWrapper>>[];
       final requestStarted = Completer<void>();
-      client.saveHandler = (_) async {
+      transport.answerSave = (_) async {
         requestStarted.complete();
         throw TimeoutException('offline');
       };
@@ -378,8 +379,7 @@ void main() {
       final allowEnqueue = Completer<void>();
       localWrites.enqueueReached = enqueueReached;
       localWrites.allowEnqueue = allowEnqueue;
-      client.saveHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerSave = (_) async => throw TimeoutException('offline');
       DwRepository.addUpdatesListener<_OfflineWriteModel>(receivedUpdates.add);
       addTearDown(
         () => DwRepository.removeUpdatesListener<_OfflineWriteModel>(
@@ -404,8 +404,7 @@ void main() {
     'surfaces enqueue failure instead of reporting offline success',
     () async {
       localWrites.enqueueFailure = StateError('disk full');
-      client.saveHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerSave = (_) async => throw TimeoutException('offline');
 
       await expectLater(
         const DwRepo().saveModel(const _OfflineWriteModel(title: 'draft')),
@@ -423,13 +422,12 @@ void main() {
   test(
     'healthy online success ignores a malformed fallback save plan',
     () async {
-      client.saveHandler = (_) async =>
-          DwApiResponse<DwModelWrapper>(
-            isOk: true,
-            value: DwModelWrapper.wrap(
-              model: const _OfflineWriteModel(id: 902, title: 'server'),
-            ),
-          );
+      transport.answerSave = (_) async => DwApiResponse<DwModelWrapper>(
+        isOk: true,
+        value: DwModelWrapper.wrap(
+          model: const _OfflineWriteModel(id: 902, title: 'server'),
+        ),
+      );
       localWrites.optimisticSaveResponse = DwApiResponse<DwModelWrapper>(
         isOk: true,
         value: DwModelWrapper.wrap(
@@ -447,7 +445,7 @@ void main() {
 
       expect(result.id, 902);
       expect(localWrites.enqueuedMutations, isEmpty);
-      expect(client.saveCallCount, 1);
+      expect(transport.saves.length, 1);
     },
   );
 
@@ -455,8 +453,7 @@ void main() {
     'rejects a malformed fallback save plan after transport failure and before enqueue',
     () async {
       final receivedUpdates = <List<DwModelWrapper>>[];
-      client.saveHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerSave = (_) async => throw TimeoutException('offline');
       localWrites.optimisticSaveResponse = DwApiResponse<DwModelWrapper>(
         isOk: true,
         value: DwModelWrapper.wrap(
@@ -482,20 +479,20 @@ void main() {
 
       expect(receivedUpdates, isEmpty);
       expect(localWrites.enqueuedMutations, isEmpty);
-      expect(client.saveCallCount, 1);
+      expect(transport.saves.length, 1);
     },
   );
 
   test(
     'rejects malformed optimistic save and delete result shapes before enqueue',
     () async {
-      client.saveHandler = (_) async =>
-          throw TimeoutException('offline');
-      client.deleteHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerSave = (_) async => throw TimeoutException('offline');
+      transport.answerDelete = (_) async => throw TimeoutException('offline');
 
-      localWrites.optimisticSaveResponse =
-          const DwApiResponse<DwModelWrapper>(isOk: true, value: null);
+      localWrites.optimisticSaveResponse = const DwApiResponse<DwModelWrapper>(
+        isOk: true,
+        value: null,
+      );
       await expectLater(
         const DwRepo().saveModel(const _OfflineWriteModel(title: 'draft')),
         throwsA(isA<StateError>()),
@@ -866,8 +863,7 @@ void main() {
   test(
     'generated mutation ids are 128-bit hex tokens and stay unique across many writes',
     () async {
-      client.saveHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerSave = (_) async => throw TimeoutException('offline');
       final mutationIds = <String>{};
 
       for (var index = 0; index < 40; index++) {
@@ -895,8 +891,7 @@ void main() {
     'rejects listener-unsafe optimistic updatedModels instead of publishing them',
     () async {
       final receivedUpdates = <List<DwModelWrapper>>[];
-      client.saveHandler = (_) async =>
-          throw TimeoutException('offline');
+      transport.answerSave = (_) async => throw TimeoutException('offline');
       localWrites.optimisticSaveResponse = DwApiResponse<DwModelWrapper>(
         isOk: true,
         value: DwModelWrapper.wrap(
@@ -922,8 +917,8 @@ void main() {
 
       expect(receivedUpdates, isEmpty);
       expect(localWrites.enqueuedMutations, isEmpty);
-      expect(client.saveApiGroups, [null]);
-      expect(client.saveCallCount, 1);
+      expect(transport.saves.map((save) => save.apiGroup), [null]);
+      expect(transport.saves.length, 1);
     },
   );
 }
@@ -947,90 +942,9 @@ class _OtherWriteModel implements SerializableModel {
   Map<String, dynamic> toJson() => <String, dynamic>{'id': id};
 }
 
-class _OfflineWriteProtocol extends SerializationManager {
-  @override
-  String? getClassNameForObject(Object? value) => switch (value) {
-    _OfflineWriteModel() => 'OfflineWriteModel',
-    _OtherWriteModel() => 'OtherWriteModel',
-    _ => super.getClassNameForObject(value),
-  };
-}
-
-class _OfflineWriteClient extends ServerpodClientShared {
-  _OfflineWriteClient()
-    : super(
-        'http://localhost:8080',
-        _OfflineWriteProtocol(),
-        streamingConnectionTimeout: null,
-        connectionTimeout: null,
-      ) {
-    _caller = Caller(this);
-  }
-
-  late final Caller _caller;
-  Future<Object?> Function(Map<String, dynamic> args)? saveHandler;
-  Future<Object?> Function(Map<String, dynamic> args)? deleteHandler;
-  final saveApiGroups = <String?>[];
-  final deleteApiGroups = <String?>[];
-  final deletedModelIds = <int>[];
-  var saveCallCount = 0;
-  var deleteCallCount = 0;
-
-  void reset() {
-    saveHandler = null;
-    deleteHandler = null;
-    saveApiGroups.clear();
-    deleteApiGroups.clear();
-    deletedModelIds.clear();
-    saveCallCount = 0;
-    deleteCallCount = 0;
-  }
-
-  @override
-  Map<String, ModuleEndpointCaller> get moduleLookup =>
-      <String, ModuleEndpointCaller>{'dartway_serverpod_core': _caller};
-
-  @override
-  Map<String, EndpointRef> get endpointRefLookup => <String, EndpointRef>{};
-
-  @override
-  Future<T> callServerEndpoint<T>(
-    String endpoint,
-    String method,
-    Map<String, dynamic> args, {
-    bool authenticated = true,
-  }) async {
-    if (endpoint != 'dartway_serverpod_core.dwCrud') {
-      throw StateError('Unexpected endpoint request: $endpoint.$method');
-    }
-    if (method == 'saveModel') {
-      saveCallCount++;
-      saveApiGroups.add(args['apiGroup'] as String?);
-      return await (saveHandler?.call(args) ??
-              Future<Object?>.error(
-                StateError('Missing save test handler for $method'),
-              ))
-          as T;
-    }
-    if (method == 'delete') {
-      deleteCallCount++;
-      deleteApiGroups.add(args['apiGroup'] as String?);
-      deletedModelIds.add(args['modelId'] as int);
-      return await (deleteHandler?.call(args) ??
-              Future<Object?>.error(
-                StateError('Missing delete test handler for $method'),
-              ))
-          as T;
-    }
-    throw StateError('Unexpected endpoint request: $endpoint.$method');
-  }
-}
-
 class _RecordingLocalWrites implements DwRepoLocalWrites {
   DwRepoScope _currentScope = DwRepoScope('first-user');
-  late DwRepoBinding _currentBinding = DwRepoBinding(
-    scope: _currentScope,
-  );
+  late DwRepoBinding _currentBinding = DwRepoBinding(scope: _currentScope);
 
   final enqueuedMutations = <DwRepoMutation>[];
   bool optInSaves = true;

--- a/template/dartway_starter_flutter/lib/core/dev/test_error_button.dart
+++ b/template/dartway_starter_flutter/lib/core/dev/test_error_button.dart
@@ -29,8 +29,10 @@ class TestErrorButton extends ConsumerWidget {
             )(context);
           case 'call':
             // A server call that fails on the backend → onFailedCall path
-            // with `endpoint.method` attached.
-            dw.endpointCaller.dwCrud.getOne(
+            // with `endpoint.method` attached. Straight down the transport,
+            // deliberately: dw.repo would be the way to actually read
+            // something, and there is nothing here to read.
+            dw.serverTransport.getOne(
               className: 'NoSuchModel',
               filter: const DwBackendFilter<int>.value(
                 type: DwBackendFilterType.equals,

--- a/template/dartway_starter_flutter/lib/core/dw_core.dart
+++ b/template/dartway_starter_flutter/lib/core/dw_core.dart
@@ -32,7 +32,14 @@ bool _coreInitialized = false;
 /// router needs a booted core even when it knows nothing about the session.
 /// Without the guard, the second test file in a run would meet a
 /// `LateInitializationError` on an already-initialized field.
-void initExampleDwCore({required String backendUrl}) {
+///
+/// The app passes [backendUrl]; a widget test passes [transport] instead and no
+/// Serverpod client is built at all. That is not an optimisation: a client
+/// brings a connectivity monitor and an auth key manager with it, both of which
+/// reach for platform channels a widget test has no business answering. Without
+/// a key manager there is no session either, so a test that needs a signed-in
+/// profile overrides `dw.requireUserProfileProvider` in its own `ProviderScope`.
+void initExampleDwCore({String? backendUrl, DwServerTransport? transport}) {
   if (_coreInitialized) return;
   _coreInitialized = true;
 
@@ -42,19 +49,8 @@ void initExampleDwCore({required String backendUrl}) {
       // Shown in error reports next to the platform and user.
       appVersion: exampleAppVersion,
     ),
-    client:
-        Client(
-            backendUrl,
-            // Connection-level failures (timeout/offline) → a toast, not an alert;
-            // everything else enters the dw error pipeline with `endpoint.method`
-            // attached and is alerted out of the box with the app context.
-            onFailedCall: dwReportingOnFailedCall(
-              onConnectionError: (_, _) =>
-                  dw.notify.error(appL10n.networkErrorTryAgain),
-            ),
-          )
-          ..connectivityMonitor = FlutterConnectivityMonitor()
-          ..authKeyProvider = DwAuthenticationKeyManager(),
+    client: backendUrl == null ? null : _buildClient(backendUrl),
+    transport: transport,
     // No telegram config here: locally the alerts degrade to logging. To see
     // the full formatted alert in the console use
     // `DwAlerts.init(logErrors: true, logFunction: debugPrint)`.
@@ -64,3 +60,17 @@ void initExampleDwCore({required String backendUrl}) {
         debugPrint('[app] realtime status → $status'),
   );
 }
+
+Client _buildClient(String backendUrl) =>
+    Client(
+        backendUrl,
+        // Connection-level failures (timeout/offline) → a toast, not an alert;
+        // everything else enters the dw error pipeline with `endpoint.method`
+        // attached and is alerted out of the box with the app context.
+        onFailedCall: dwReportingOnFailedCall(
+          onConnectionError: (_, _) =>
+              dw.notify.error(appL10n.networkErrorTryAgain),
+        ),
+      )
+      ..connectivityMonitor = FlutterConnectivityMonitor()
+      ..authKeyProvider = DwAuthenticationKeyManager();

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -284,7 +284,7 @@ packages:
       path: "../../packages/dartway_router"
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.1.2"
   dartway_serverpod_core_client:
     dependency: "direct overridden"
     description:

--- a/template/dartway_starter_flutter/test/admin/settings/admin_settings_form_test.dart
+++ b/template/dartway_starter_flutter/test/admin/settings/admin_settings_form_test.dart
@@ -1,0 +1,110 @@
+import 'package:dartway_starter_client/dartway_starter_client.dart';
+import 'package:dartway_starter_flutter/admin/settings/widgets/admin_settings_form.dart';
+import 'package:dartway_starter_flutter/core/app_settings/app_setting_key.dart';
+import 'package:dartway_starter_flutter/ui_kit/ui_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../support/app_test_core.dart';
+
+/// The starting point for testing a feature in this project: it renders what
+/// the server answered, you interact, and what leaves for the server is exactly
+/// what you meant.
+///
+/// The form takes no callback and returns no value — it saves for itself, the
+/// way a DartWay feature should. So there is nothing to spy on above it, and the
+/// assertions live one level below, on the transport the core sends every write
+/// through. Copy the shape of this file for your own features.
+void main() {
+  setUpAll(bootTestCore);
+  setUp(resetTestCore);
+
+  final admin = adminProfile();
+
+  AppSetting storedAppName(String value) => AppSetting(
+    id: 1,
+    settingKey: AppSettingKey.appName.key,
+    settingValue: value,
+  );
+
+  testWidgets('draws the stored value, and the default where no row exists', (
+    tester,
+  ) async {
+    // Only one of the two settings has a row: `signUpEnabled` falls back to the
+    // default in the catalogue, which is what a fresh database looks like.
+    testTransport.answerGetAll = (_) async =>
+        listResponse([storedAppName('Acme')]);
+
+    await tester.pumpFeature(const AdminSettingsForm(), signedInAs: admin);
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(TextFormField, 'Acme'), findsOneWidget);
+    expect(tester.widget<AppCheckbox>(find.byType(AppCheckbox)).value, isTrue);
+    expect(testTransport.reads.single.className, 'AppSetting');
+  });
+
+  testWidgets('a toggle saves its own row and nothing else', (tester) async {
+    testTransport.answerGetAll = (_) async =>
+        listResponse([storedAppName('Acme')]);
+
+    await tester.pumpFeature(const AdminSettingsForm(), signedInAs: admin);
+    await tester.pumpAndSettle();
+
+    await tester.tapAndSettle(find.byType(AppCheckbox));
+
+    // The point of one row per setting: the write carries `signUpEnabled` and
+    // says nothing about `appName`, so a second admin editing the name at the
+    // same moment cannot be overwritten.
+    expect(testTransport.saves, hasLength(1));
+    final saved = testTransport.saves.single.model as AppSetting;
+    expect(saved.settingKey, AppSettingKey.signUpEnabled.key);
+    expect(saved.settingValue, 'false');
+    // No row existed for it, so this is a create — the id is the server's to
+    // assign.
+    expect(saved.id, isNull);
+  });
+
+  testWidgets('editing a text setting updates the row it already has', (
+    tester,
+  ) async {
+    testTransport.answerGetAll = (_) async =>
+        listResponse([storedAppName('Acme')]);
+
+    await tester.pumpFeature(const AdminSettingsForm(), signedInAs: admin);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, '  Acme Corp  ');
+    // Settle, not pump: `AppTextFormField` delivers `onChanged` from a
+    // post-frame callback, so the form's own state — and with it whether the
+    // Save button is enabled — is one frame behind the keystroke.
+    await tester.pumpAndSettle();
+
+    await tester.tapAndSettle(find.text('Save'));
+
+    expect(testTransport.saves, hasLength(1));
+    final saved = testTransport.saves.single.model as AppSetting;
+    expect(saved.settingKey, AppSettingKey.appName.key);
+    // Trimmed by the row, and written onto the existing id — an update, not a
+    // second row for the same key.
+    expect(saved.settingValue, 'Acme Corp');
+    expect(saved.id, 1);
+  });
+
+  testWidgets('an unchanged text setting has nothing to save', (tester) async {
+    testTransport.answerGetAll = (_) async =>
+        listResponse([storedAppName('Acme')]);
+
+    await tester.pumpFeature(const AdminSettingsForm(), signedInAs: admin);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, 'Acme');
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<AppButton>(find.byType(AppButton)).onTap,
+      isNull,
+      reason: 'the Save button is disabled while the value is the stored one',
+    );
+    expect(testTransport.saves, isEmpty);
+  });
+}

--- a/template/dartway_starter_flutter/test/core/app_settings/app_setting_key_test.dart
+++ b/template/dartway_starter_flutter/test/core/app_settings/app_setting_key_test.dart
@@ -1,0 +1,55 @@
+import 'package:dartway_starter_flutter/core/app_settings/app_setting_key.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The other layer a project tests: rules that are plain logic.
+///
+/// `AppSettingKey.parse` decides what a stored string means, and it has the one
+/// property worth pinning — **there is no failure path**. A setting nobody has
+/// touched, or one somebody hand-edited into nonsense, must not be able to break
+/// a screen. That is a claim about behaviour, and a unit test is the cheapest
+/// place to hold it: no core, no widget, no transport.
+void main() {
+  test('an absent row reads as the declared default', () {
+    expect(AppSettingKey.appName.parse(null), 'DartWay');
+    expect(AppSettingKey.signUpEnabled.parse(null), isTrue);
+  });
+
+  test('a boolean accepts what a checkbox, a config and a hand edit write', () {
+    for (final written in ['true', 'TRUE', '1', 'yes', ' true ']) {
+      expect(
+        AppSettingKey.signUpEnabled.parse(written),
+        isTrue,
+        reason: written,
+      );
+    }
+    for (final written in ['false', 'FALSE', '0', 'no']) {
+      expect(
+        AppSettingKey.signUpEnabled.parse(written),
+        isFalse,
+        reason: written,
+      );
+    }
+  });
+
+  test('nonsense falls back to the default instead of failing', () {
+    expect(AppSettingKey.signUpEnabled.parse('perhaps'), isTrue);
+    expect(AppSettingKey.signUpEnabled.parse(''), isTrue);
+  });
+
+  test('a text value survives a round trip through storage, trimmed', () {
+    for (final value in ['Acme', ' spaced ']) {
+      expect(
+        AppSettingKey.appName.parse(AppSettingKey.appName.format(value)),
+        value.trim(),
+      );
+    }
+  });
+
+  test('an empty text value is a value, not an absent row', () {
+    // Only `null` means "nobody has set this". A stored empty string is
+    // something an admin did, and the default does not quietly undo it — which
+    // is why the Save button, not the parser, is what refuses a blank name.
+    expect(AppSettingKey.appName.parse(''), '');
+    expect(AppSettingKey.appName.parse(null), 'DartWay');
+  });
+}

--- a/template/dartway_starter_flutter/test/support/app_test_core.dart
+++ b/template/dartway_starter_flutter/test/support/app_test_core.dart
@@ -1,0 +1,120 @@
+import 'package:dartway_starter_client/dartway_starter_client.dart';
+// Prefixed because this project's generated client and the DartWay core each
+// declare a `Protocol`, and the core's arrives through the framework barrel.
+import 'package:dartway_starter_client/dartway_starter_client.dart' as app;
+import 'package:dartway_starter_flutter/core/app_l10n.dart';
+import 'package:dartway_starter_flutter/core/default_models.dart';
+import 'package:dartway_starter_flutter/core/dw_core.dart';
+import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+export 'package:dartway_serverpod_core_flutter/testing.dart'
+    show DwRecordingServerTransport, DwUnpreparedServerCall;
+
+/// The server, as far as any widget test in this project is concerned.
+///
+/// One instance for the whole run: the core keeps the transport it was built
+/// with for its lifetime, and there is one core per process. Each test calls
+/// [resetTestCore] to start from nothing recorded and nothing prepared.
+///
+/// It is handed this project's own generated `Protocol()` — the same object the
+/// real Serverpod client carries — so every model is named on the wire exactly
+/// as the server knows it. Nothing else can do that job: a generated model is
+/// an abstract class with a private implementation, and its `runtimeType` reads
+/// `_AppSettingImpl`.
+final testTransport = DwRecordingServerTransport(
+  serializationManager: app.Protocol(),
+);
+
+/// Boots this app's core, once, through the app's own initializer.
+///
+/// Call it from `setUpAll`. It is the real bootstrap with one thing swapped —
+/// the server — so a test never stands a second, subtly different core beside
+/// the one the app ships. The initializer is idempotent, so no test file has to
+/// know whether another one got there first.
+///
+/// The core is *required* to render, not only to interact: a feature builds its
+/// `dw.action(...)` inside `build`, so `dw` is touched before anything is
+/// tapped. A test that forgets this fails at a finder ("found 0 widgets") with
+/// the real cause in a separate exception block above it.
+void bootTestCore() {
+  initExampleDwCore(transport: testTransport);
+  // What `dw.initDwCore` does for the repository, without the session and
+  // socket startup a test has no server to do it against. List skeletons need
+  // this part: `dwBuildListAsync` builds its placeholder from the registered
+  // default model.
+  DefaultModels.initRepository();
+}
+
+/// Forgets everything the transport recorded and every answer prepared for it.
+/// Call from `setUp`.
+void resetTestCore() => testTransport.reset();
+
+/// A signed-in admin, for the screens that are only shown to one.
+UserProfile adminProfile({int id = 1, String firstName = 'Alex'}) =>
+    UserProfile(
+      id: id,
+      userIdentifier: '7900000000$id',
+      firstName: firstName,
+      phone: '7900000000$id',
+      role: UserRole.admin,
+      agreedForMarketingCommunications: false,
+      conditionsAcceptedAt: DateTime.utc(2026),
+    );
+
+extension AppFeaturePump on WidgetTester {
+  /// Taps [finder] and lets everything the tap set off finish.
+  ///
+  /// `pumpAndSettle` alone is not enough after an action that notifies: a
+  /// successful `dw.action(onSuccessNotification: ...)` inserts a toast which
+  /// removes itself on a `Future.delayed`, and settling waits for frames, not
+  /// for timers. A test that stops early ends on "A Timer is still pending even
+  /// after the widget tree was disposed" — an error about the toast, in a test
+  /// about a save.
+  Future<void> tapAndSettle(Finder finder) async {
+    await tap(finder);
+    await pumpAndSettle();
+    await pump(DwUiNotification.defaultDuration);
+  }
+
+  /// Pumps [child] inside everything a page of this app is drawn inside, minus
+  /// the router: localizations, the notification listener, and a Riverpod scope.
+  ///
+  /// [signedInAs] overrides the framework's profile providers. Overriding them
+  /// in the test's own `ProviderScope` is the sanctioned way to stand a user up
+  /// — there is no session here to sign into, and inventing one would test the
+  /// framework's session rather than this feature.
+  Future<void> pumpFeature(Widget child, {UserProfile? signedInAs}) async {
+    await pumpWidget(
+      ProviderScope(
+        overrides: [
+          if (signedInAs != null) ...[
+            dw.userProfileProvider.overrideWithValue(signedInAs),
+            dw.requireUserProfileProvider.overrideWithValue(signedInAs),
+          ],
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DwNotificationsListener(
+            handlers: {DwUiNotification: DwUiNotificationHandler()},
+            child: Scaffold(body: SingleChildScrollView(child: child)),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Wraps [models] the way the server would answer a `getAll` with them.
+DwApiResponse<List<DwModelWrapper>> listResponse(
+  List<SerializableModel> models,
+) => DwApiResponse<List<DwModelWrapper>>(
+  isOk: true,
+  value: models
+      .map((model) => DwModelWrapper.wrap(model: model))
+      .toList(growable: false),
+);

--- a/template/dartway_starter_server/test/integration/app_setting_access_test.dart
+++ b/template/dartway_starter_server/test/integration/app_setting_access_test.dart
@@ -1,0 +1,133 @@
+import 'package:dartway_starter_server/src/crud/app_setting_crud_config.dart';
+import 'package:dartway_starter_server/src/dartway/dartway_core.dart';
+import 'package:dartway_starter_server/src/generated/protocol.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+/// The starting point for testing a **rule** in this project.
+///
+/// `appSettingCrudConfig` says who may write a setting and what makes one
+/// valid. That rule runs inside a request and reads the database to answer, so
+/// nothing below the server can hold it: a widget test proving the admin panel
+/// hides the field proves only that the field is hidden. Copy the shape of this
+/// file when a CRUD config grows a rule of its own.
+///
+/// It runs against a live database — `docker compose up -d postgres_test`, then
+/// `dart test`. See the `dartway-testing` skill for which layer a test belongs
+/// to.
+const _testKey = 'appSettingAccessTest.appName';
+
+void main() {
+  withServerpod('Given the app settings CRUD config', (
+    sessionBuilder,
+    endpoints,
+  ) {
+    late Session adminSession;
+    late Session memberSession;
+
+    setUp(() async {
+      // `withServerpod` builds its own Serverpod and never calls `run`, so
+      // DartWay has to be booted here — the config's `session.isAdmin` resolves
+      // the profile through the core.
+      initDartwayCore(
+        passwords: const {
+          'dwVerificationCodeSalt': 'test-verification-code-salt',
+          'dwAuthKeySalt': 'test-auth-key-salt',
+        },
+      );
+
+      final setupSession = sessionBuilder.build();
+      await _wipeTables(setupSession);
+
+      final admin = await _seedProfile(
+        setupSession,
+        identifier: '+70000000010',
+        role: UserRole.admin,
+      );
+      final member = await _seedProfile(
+        setupSession,
+        identifier: '+70000000011',
+        role: UserRole.user,
+      );
+
+      adminSession = _signedInAs(sessionBuilder, admin);
+      memberSession = _signedInAs(sessionBuilder, member);
+    });
+
+    tearDown(() async => _wipeTables(sessionBuilder.build()));
+
+    test('the admin writes a setting, and the row lands', () async {
+      final response = await appSettingCrudConfig.saveConfig!.save(
+        adminSession,
+        AppSetting(settingKey: _testKey, settingValue: 'Acme'),
+      );
+
+      expect(response.isOk, isTrue);
+      final stored = await AppSetting.db.find(
+        adminSession,
+        where: (row) => row.settingKey.equals(_testKey),
+      );
+      expect(stored.single.settingValue, 'Acme');
+    });
+
+    test('a signed-in member is refused, and nothing is written', () async {
+      final response = await appSettingCrudConfig.saveConfig!.save(
+        memberSession,
+        AppSetting(settingKey: _testKey, settingValue: 'Not allowed'),
+      );
+
+      expect(response.isOk, isFalse);
+      expect(
+        await AppSetting.db.find(
+          memberSession,
+          where: (row) => row.settingKey.equals(_testKey),
+        ),
+        isEmpty,
+        reason: 'a refused save must not reach the table',
+      );
+    });
+
+    test('an empty key is rejected even for the admin', () async {
+      final response = await appSettingCrudConfig.saveConfig!.save(
+        adminSession,
+        AppSetting(settingKey: '   ', settingValue: 'Acme'),
+      );
+
+      expect(response.isOk, isFalse);
+      expect(response.error, isNotNull);
+    });
+  });
+}
+
+Session _signedInAs(TestSessionBuilder sessionBuilder, UserProfile profile) =>
+    sessionBuilder
+        .copyWith(
+          authentication: AuthenticationOverride.authenticationInfo(
+            '${profile.id!}',
+            {},
+          ),
+        )
+        .build();
+
+Future<UserProfile> _seedProfile(
+  Session session, {
+  required String identifier,
+  required UserRole role,
+}) => UserProfile.db.insertRow(
+  session,
+  UserProfile(
+    userIdentifier: identifier,
+    phone: identifier,
+    firstName: 'Test',
+    role: role,
+    agreedForMarketingCommunications: false,
+    conditionsAcceptedAt: DateTime.now().toUtc(),
+  ),
+);
+
+Future<void> _wipeTables(Session session) async {
+  await AppSetting.db.deleteWhere(session, where: (_) => Constant.bool(true));
+  await UserProfile.db.deleteWhere(session, where: (_) => Constant.bool(true));
+}

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -113,6 +113,8 @@ An ADR records **the alternatives that were rejected, and why**. That is the one
 
 For **any** Dart/Flutter code the clean-code contract applies: `.claude/skills/dartway-clean-code/SKILL.md` (the team's hard rules + SOLID/KISS/DRY/YAGNI + tests for the complex stuff). This is a style contract — check against it while writing, refactoring and reviewing.
 
+**Clean-code Part 3 decides what deserves a test; `dartway-testing` decides where it goes and how to write it** — a rule from a CRUD config is an integration test on the server, plain logic is a unit test, and a feature is a widget test with the core booted and the server standing in as a recording transport. A feature saves for itself and hands no callback out, so the technique is not guessable; the skeleton ships a worked example of each in `test/`.
+
 **Finishing a task (Law 6):** when a feature/task is done, run `dartway-finish` before the commit/PR. It audits the diff against the contract, checks the feature's documentation for drift and the test coverage, and **shows suggestions and applies only what was confirmed**.
 
 ## Notes back to the framework (`dartway_notes.md`)
@@ -260,7 +262,7 @@ Live migrations (delete an entry once no project is on the old shape):
 
 ## Skills and commands
 
-- Skills (`.claude/skills/`): `dartway-run`, `dartway-requirements`, `dartway-plan`, `dartway-clean-code`, `dartway-navigation`, `dartway-feature-scaffold`, `dartway-crud-config`, `dartway-ui-kit`, `dartway-data-layer`, `dartway-models`, `dartway-push-delivery`, `dartway-finish` — loaded by relevance to the task.
+- Skills (`.claude/skills/`): `dartway-run`, `dartway-requirements`, `dartway-plan`, `dartway-clean-code`, `dartway-navigation`, `dartway-feature-scaffold`, `dartway-crud-config`, `dartway-ui-kit`, `dartway-data-layer`, `dartway-models`, `dartway-push-delivery`, `dartway-testing`, `dartway-finish` — loaded by relevance to the task.
 - Commands (`.claude/commands/`): `/dartway-checkup` — the state of the project and what to take into work next (whole project by default, a path narrows it); `/commit` — a commit in the project's CI format.
 
 **Task lifecycle:** `dartway-requirements` (analyze the spec → questions → options) → `dartway-plan` (a step-by-step plan + risks) → implementation (the layer skills) → `dartway-finish` (audit + reconciling the specs and doc comments with the code + tests before the PR).

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -32,6 +32,13 @@ final userProfileCrudConfig = DwCrudConfig<UserProfile>(
 
 Don't forget to register the config in `crudConfigurations` at `DwCore.init`. If the config is missing → the API returns `DwApiResponse.notConfigured`.
 
+> **This is the one thing here that fails without a trace**, so `dartway check` guards it: a config
+> written and left out of the list answers exactly as if the file did not exist (`crudConfigUnregistered`,
+> an error), and a model with a table and no config at all is reported too (`crudConfigMissing`, a
+> warning — the absence is also how you say "this table is the server's own", and the checker cannot
+> tell which you meant). A config carrying hand-written save or delete logic that no server test names
+> is `crudRuleUntested`; where that test goes is `dartway-testing`.
+
 ## accessFilter — the heart of secure-by-default
 
 Two separate questions, and until 0.3.0 they were conflated into one:

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -320,49 +320,19 @@ final deleteAction = dw.action<bool>(
 in the widget that owns the button.** Not a callback handed down from a parent, and not a screen-wide
 `busy` flag: `DwActionBuilder` computes busy per button already.
 
-> **What a widget test over a self-writing feature covers, and where its seam is.** A feature that
-> saves for itself gives a test no callback to assert on. That seam went with the parameter, and
-> bringing it back is the wrong trade: **do not keep a callback alive as a test seam** — it buys a
-> weaker screen for a weaker test.
+> **A feature that saves for itself gives a test no callback to assert on** — and **do not keep one
+> alive as a test seam**, it buys a weaker screen for a weaker test. The seam is one level down: the
+> transport handed to `DwCore`, which a test replaces with `DwRecordingServerTransport` from
+> `package:dartway_serverpod_core_flutter/testing.dart`. Two consequences worth knowing while you
+> write the widget, before you write any test:
 >
-> The seam is one level down, and it is the same one the framework uses on itself: **the transport
-> handed to `DwCore`**. Pass `transport: DwRecordingServerTransport(serializationManager:
-> app.Protocol())` from `package:dartway_serverpod_core_flutter/testing.dart` **instead of**
-> `client:`, and nothing in the process has to stand up a Serverpod client for a widget to render.
-> The protocol is the project's own generated one, imported prefixed because the core declares a
-> `Protocol` too — it is the only thing that names the models right, since a generated model is an
-> abstract class whose `runtimeType` reads `_NewsPostImpl`.
+> - the feature reaches `dw` **while building**, not on the tap — `dw.action(...)` is constructed in
+>   `build` — so a widget test needs a booted core even when it never interacts with anything;
+> - **the offline store is not that seam** and is documented not to be. A write always leaves by the
+>   transport first; `dw.repo.localWrites` is reached only after the connection refuses it.
 >
-> It keeps every save and delete that left (`transport.saves`, `transport.deletes`) and answers
-> reads from what the test prepared (`answerGetAll`, `answerGetOne`, `answerGetCount`); a read
-> nobody prepared throws `DwUnpreparedServerCall` naming the call and the field that would answer
-> it, while a save needs no setup — the default echoes the model back, because the assertion is
-> about what *left*. What that gets you is "the button reached `saveModel` with this model", which
-> is what a widget test should assert. What covers the **rule** is still an integration test over
-> the CRUD config on the server, where the rule lives.
->
-> Boot the core from `setUpAll` through **the app's own initializer**, given an optional `transport`
-> parameter, and build no Serverpod client when it is set — a client brings a connectivity monitor
-> and an auth key manager, both of which reach for platform channels. Without a key manager there is
-> no session, so a test that needs a signed-in user overrides `dw.requireUserProfileProvider` in its
-> own `ProviderScope`.
->
-> Two traps about time, not about the transport: `pumpAndSettle` does not drain the toast a
-> successful `onSuccessNotification` leaves behind (pump `DwUiNotification.defaultDuration` after
-> the tap), and a read you made fail is **retried** by Riverpod with a backoff — assert the shape of
-> what was asked, never the number of attempts.
->
-> **The offline store is not that seam, and is documented not to be.** A write always goes to the
-> network first; `dw.repo.localWrites` is reached only after the call fails with a connection error.
-> Reaching for it to watch a save would force every save to declare itself queued, which is a lie
-> about intent.
->
-> One thing to know before writing the test at all: the feature reaches `dw` **while building**, not
-> on the tap — `dw.action(...)` is constructed in `build`. So the core has to be up for the widget
-> to render, even in a test that never interacts. Without it the subtree does not build and the test
-> fails later at a finder ("found 0 widgets"), with the real cause in a separate exception block
-> above. Boot it from `setUpAll` through the app's own initializer, and keep that initializer
-> idempotent so no test file has to know whether another one booted the core first.
+> **How to actually write it — the harness, the prepared reads, the signed-in user, and the two
+> timing traps — is `dartway-testing`.** The skeleton ships a worked example in `test/`.
 
 ## 4a. Derived state — a provider, not assembly in the widget
 

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -325,12 +325,17 @@ in the widget that owns the button.** Not a callback handed down from a parent, 
 > bringing it back is the wrong trade: **do not keep a callback alive as a test seam** — it buys a
 > weaker screen for a weaker test.
 >
-> The seam is one level down, and it is the same one the framework uses on itself: **the Serverpod
-> `client` handed to `DwCore`**. `dw.endpointCaller` is derived from it in the constructor, so a
-> client whose `callServerEndpoint` you override answers for the whole CRUD surface — the core's own
-> write tests count saves exactly that way. What that gets you is "the button reached `saveModel`
-> with this model", which is what a widget test should assert. What covers the **rule** is still an
-> integration test over the CRUD config on the server, where the rule lives.
+> The seam is one level down, and it is the same one the framework uses on itself: **the transport
+> handed to `DwCore`**. Pass `transport: DwRecordingServerTransport(...)` from
+> `package:dartway_serverpod_core_flutter/testing.dart` **instead of** `client:`, and nothing in the
+> process has to stand up a Serverpod client for a widget to render. It keeps every save and delete
+> that left (`transport.saves`, `transport.deletes`) and answers reads from what the test prepared
+> (`answerGetAll`, `answerGetOne`, `answerGetCount`); a read nobody prepared throws
+> `DwUnpreparedServerCall` naming the call and the field that would answer it, while a save needs no
+> setup — the default echoes the model back, because the assertion is about what *left*. What that
+> gets you is "the button reached `saveModel` with this model", which is what a widget test should
+> assert. What covers the **rule** is still an integration test over the CRUD config on the server,
+> where the rule lives.
 >
 > **The offline store is not that seam, and is documented not to be.** A write always goes to the
 > network first; `dw.repo.localWrites` is reached only after the call fails with a connection error.

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -326,16 +326,31 @@ in the widget that owns the button.** Not a callback handed down from a parent, 
 > weaker screen for a weaker test.
 >
 > The seam is one level down, and it is the same one the framework uses on itself: **the transport
-> handed to `DwCore`**. Pass `transport: DwRecordingServerTransport(...)` from
-> `package:dartway_serverpod_core_flutter/testing.dart` **instead of** `client:`, and nothing in the
-> process has to stand up a Serverpod client for a widget to render. It keeps every save and delete
-> that left (`transport.saves`, `transport.deletes`) and answers reads from what the test prepared
-> (`answerGetAll`, `answerGetOne`, `answerGetCount`); a read nobody prepared throws
-> `DwUnpreparedServerCall` naming the call and the field that would answer it, while a save needs no
-> setup — the default echoes the model back, because the assertion is about what *left*. What that
-> gets you is "the button reached `saveModel` with this model", which is what a widget test should
-> assert. What covers the **rule** is still an integration test over the CRUD config on the server,
-> where the rule lives.
+> handed to `DwCore`**. Pass `transport: DwRecordingServerTransport(serializationManager:
+> app.Protocol())` from `package:dartway_serverpod_core_flutter/testing.dart` **instead of**
+> `client:`, and nothing in the process has to stand up a Serverpod client for a widget to render.
+> The protocol is the project's own generated one, imported prefixed because the core declares a
+> `Protocol` too — it is the only thing that names the models right, since a generated model is an
+> abstract class whose `runtimeType` reads `_NewsPostImpl`.
+>
+> It keeps every save and delete that left (`transport.saves`, `transport.deletes`) and answers
+> reads from what the test prepared (`answerGetAll`, `answerGetOne`, `answerGetCount`); a read
+> nobody prepared throws `DwUnpreparedServerCall` naming the call and the field that would answer
+> it, while a save needs no setup — the default echoes the model back, because the assertion is
+> about what *left*. What that gets you is "the button reached `saveModel` with this model", which
+> is what a widget test should assert. What covers the **rule** is still an integration test over
+> the CRUD config on the server, where the rule lives.
+>
+> Boot the core from `setUpAll` through **the app's own initializer**, given an optional `transport`
+> parameter, and build no Serverpod client when it is set — a client brings a connectivity monitor
+> and an auth key manager, both of which reach for platform channels. Without a key manager there is
+> no session, so a test that needs a signed-in user overrides `dw.requireUserProfileProvider` in its
+> own `ProviderScope`.
+>
+> Two traps about time, not about the transport: `pumpAndSettle` does not drain the toast a
+> successful `onSuccessNotification` leaves behind (pump `DwUiNotification.defaultDuration` after
+> the tap), and a read you made fail is **retried** by Riverpod with a backoff — assert the shape of
+> what was asked, never the number of attempts.
 >
 > **The offline store is not that seam, and is documented not to be.** A write always goes to the
 > network first; `dw.repo.localWrites` is reached only after the call fails with a connection error.

--- a/toolkit/skills/dartway-finish/SKILL.md
+++ b/toolkit/skills/dartway-finish/SKILL.md
@@ -108,6 +108,14 @@ is verified through the public kit widget. A test of a private composition → a
 
 ### A.4 Checking the tests
 - Non-trivial logic/money/"downgrade" rollbacks or a bugfix **without a test** → flag it (`dartway-clean-code` Part 3). We do not demand tests for cosmetics.
+- **Ask whether the test sits at the layer the behaviour lives at** (`dartway-testing`). The common
+  miss is not an absent test but a misplaced one: an access rule from a `DwCrudConfig` "covered" by a
+  widget test that only proves the button is hidden — the UI hiding it is not the rule, and the rule
+  is what breaks. That belongs in an integration test on the server; the widget test then covers what
+  it can, which is that the button sends the right model.
+- **Do not ask for a coverage number and do not report one.** The question is whether the thing that
+  would break is covered, at the layer where it lives — a percentage is met by covering what was
+  never at risk.
 
 ### A.5 Automated checks
 - **`dartway check` in the Flutter package is mandatory.** It checks what neither the analyzer nor the lints see: the structure of features and groups, the boundaries (importing another feature's internals at any depth), styles bypassing the kit, missing feature specs, dead code inside a feature (`unusedFeatureFile` — a widget or helper its own feature stopped using; nobody outside may import it, so nothing else can see it is gone), references to non-existent assets. The report is per-feature, with an A–D grade — look at the features the task touched, not just at the overall counter.

--- a/toolkit/skills/dartway-testing/SKILL.md
+++ b/toolkit/skills/dartway-testing/SKILL.md
@@ -41,30 +41,40 @@ prove that the button sends the right model.
 Access and save rules live in `DwCrudConfig`, run inside a real request, and touch the database.
 Nothing below the server can check them, and a mock of the session would only re-state the code.
 
-The machinery is already in the project: `withServerpod` from the generated
-`test/integration/test_tools/serverpod_test_tools.dart`, which stands up a real Serverpod against a
-test database.
+The skeleton ships one to copy: `test/integration/app_setting_access_test.dart` proves that the
+admin writes a setting, that a signed-in member is refused and nothing reaches the table, and that
+an empty key is rejected even for the admin. The machinery around it — `withServerpod` from the
+generated `test/integration/test_tools/serverpod_test_tools.dart` — stands up a real Serverpod
+against the test database.
 
 ```dart
-withServerpod('appSetting write access', (sessionBuilder, endpoints) {
-  setUpAll(() {
-    DwCore.init<UserProfile>(
-      userProfileTable: UserProfile.t,
-      crudConfigurations: const [appSettingCrudConfig],
-      dtoConfigurations: const [],
-      channelConfigurations: const [],
-      userProfileConstructor: (session, {required registrationRequest}) async =>
-          throw UnsupportedError('outside this suite'),
-      dwAlerts: DwAlerts.init(),
-    );
+withServerpod('Given the app settings CRUD config', (sessionBuilder, endpoints) {
+  setUp(() async {
+    // withServerpod builds its own Serverpod and never calls run, so DartWay
+    // has to be booted here — the config's session.isAdmin resolves the profile
+    // through the core.
+    initDartwayCore(passwords: const {...});
+    // …seed an admin and a member, and build a session for each with
+    // AuthenticationOverride.authenticationInfo('${profile.id!}', {})
   });
 
-  test('a member cannot write a setting an admin can', () async {
-    final session = sessionBuilder.build();
-    // …sign the session in as each role and assert the DwApiResponse
+  test('a signed-in member is refused, and nothing is written', () async {
+    final response = await appSettingCrudConfig.saveConfig!.save(
+      memberSession,
+      AppSetting(settingKey: key, settingValue: 'Not allowed'),
+    );
+
+    expect(response.isOk, isFalse);
+    // …and the table is still empty: a refused save must not reach it
   });
 });
 ```
+
+`DwSaveConfig.save` runs the whole pipeline the endpoint runs — `allowSave` → `validateSave` →
+transaction — so the assertion lands on the project's own rule, not on a re-statement of it.
+
+It needs a live database: `docker compose up -d postgres_test`, then `dart test` from the server
+package.
 
 **Write one when the rule is the point:** a role boundary, an ownership check, a validation that
 rejects, `beforeSaveTransaction` / `afterSaveTransaction` ordering, a filter that must not leak
@@ -218,7 +228,25 @@ frame behind. Use `pumpAndSettle`, not `pump`.
   member is fine as *UI*, but it says nothing about access — write the integration test for the
   rule and let the widget test be about the button.
 
-## 5. No coverage thresholds
+## 5. What the checker asks for, and what it will not
+
+`dartway check` names three gaps on the server, by model, and nothing about Flutter tests:
+
+- **`crudConfigMissing`** (warning) — a table with no `DwCrudConfig`. It answers `notConfigured` to
+  every read and write, so the list is empty forever and nothing says why. If the table really is
+  the server's own, that is what the absence means — write it in a doc comment on the model.
+- **`crudConfigUnregistered`** (error) — the config exists and is not in `crudConfigurations`. There
+  is no second reading of this one.
+- **`crudRuleUntested`** (warning) — a config with hand-written save or delete logic that no test
+  under the server's `test/` names. This is §1 of this skill, made checkable.
+
+A config that only declares a shape — an `accessFilter`, an `include` — is asked for nothing: it has
+no rule to hold.
+
+**It will never ask "does this feature have a test".** That is not a gap with a name, it is a
+percentage, and see below.
+
+## 6. No coverage thresholds
 
 We do not set a percentage and we do not gate anything on one. A threshold is met by writing tests
 for what is easy to cover, which is exactly the code that did not need covering — getters, mappers,

--- a/toolkit/skills/dartway-testing/SKILL.md
+++ b/toolkit/skills/dartway-testing/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: dartway-testing
+description: >-
+  How a DartWay project tests itself, by layer: an access or save rule from DwCrudConfig
+  is an integration test on the server against a live database (withServerpod +
+  serverpod_test_tools.dart); plain logic is a unit test; a feature is a widget test with the
+  core booted from setUpAll through the app's own idempotent initializer and the server standing
+  in as DwRecordingServerTransport from package:dartway_serverpod_core_flutter/testing.dart —
+  reads prepared with answerGetAll/answerGetOne/answerGetCount, writes read back off
+  transport.saves/transport.deletes, the signed-in user overridden in the test's own ProviderScope.
+  Covers why the core must be up for a feature to even render, why the offline store is not a test
+  seam, the two timing traps (a toast holds a timer past pumpAndSettle, a failed read is retried),
+  what is deliberately not tested, and why there are no coverage thresholds.
+  Use when writing or reviewing tests, when a test cannot see what a feature saved, or when a
+  widget test fails with LateInitializationError, "found 0 widgets" or a pending Timer.
+---
+
+# DartWay — how a project tests itself
+
+`dartway-clean-code` Part 3 decides **what** deserves a test (the threshold is behaviour
+complexity, never the fact that a line changed). This skill decides **where** that test goes and
+how to write it, because in a DartWay project the answer is not obvious: a feature reads and writes
+through the ambient `dw`, hands no callbacks out, and has no repository to inject.
+
+**The level follows where the behaviour lives.** Three layers, three different questions:
+
+| The behaviour | Lives in | Its test |
+|---|---|---|
+| Who may read or save what, and what a save does to the database | `DwCrudConfig` on the server | **Integration test**, against a live database |
+| A calculation, a parse, a state machine, a rule with no I/O | A plain class in the app | **Unit test** |
+| The screen reads, the user acts, something leaves for the server | A feature widget | **Widget test**, with the core up |
+
+Choosing the wrong layer is the common failure. A widget test cannot prove that a non-admin is
+refused: the UI hiding a button is not the rule, the server is. And an integration test cannot
+prove that the button sends the right model.
+
+---
+
+## 1. Rules — an integration test on the server
+
+Access and save rules live in `DwCrudConfig`, run inside a real request, and touch the database.
+Nothing below the server can check them, and a mock of the session would only re-state the code.
+
+The machinery is already in the project: `withServerpod` from the generated
+`test/integration/test_tools/serverpod_test_tools.dart`, which stands up a real Serverpod against a
+test database.
+
+```dart
+withServerpod('appSetting write access', (sessionBuilder, endpoints) {
+  setUpAll(() {
+    DwCore.init<UserProfile>(
+      userProfileTable: UserProfile.t,
+      crudConfigurations: const [appSettingCrudConfig],
+      dtoConfigurations: const [],
+      channelConfigurations: const [],
+      userProfileConstructor: (session, {required registrationRequest}) async =>
+          throw UnsupportedError('outside this suite'),
+      dwAlerts: DwAlerts.init(),
+    );
+  });
+
+  test('a member cannot write a setting an admin can', () async {
+    final session = sessionBuilder.build();
+    // …sign the session in as each role and assert the DwApiResponse
+  });
+});
+```
+
+**Write one when the rule is the point:** a role boundary, an ownership check, a validation that
+rejects, `beforeSaveTransaction` / `afterSaveTransaction` ordering, a filter that must not leak
+another user's rows. **Not** for CRUD that is configured and does nothing else — that is testing
+the framework, and the framework tests itself.
+
+---
+
+## 2. Plain logic — a unit test
+
+Anything with no `dw`, no widget and no server: a parser, a price, a state machine, an extension
+over a list of models. The cheapest layer, and where most of a project's logic should already be —
+`dartway-clean-code` §2.11 takes it out of the widget for reasons that have nothing to do with
+testing.
+
+The skeleton ships one to copy: `test/core/app_settings/app_setting_key_test.dart` pins that
+`AppSettingKey.parse` has **no failure path** — an absent row, a hand-edited value and nonsense all
+resolve to something a screen can render.
+
+---
+
+## 3. A feature — a widget test with the core up
+
+This is the layer that needs a technique, so it gets the rest of this skill.
+
+### The seam is the transport, and nothing above it
+
+A DartWay feature saves for itself: no callback is passed in, so there is nothing above it to spy
+on. **Do not keep a callback alive as a test seam** — it buys a weaker screen for a weaker test.
+
+The seam is one level down: the transport the core sends every server operation through. A test
+hands `DwCore` its own instead of a Serverpod client, and then a save is a value in a list.
+
+**The offline store is not this seam, and is documented not to be.** A write always leaves by the
+transport first; `dw.repo.localWrites` is reached only after the connection refuses it. Reaching for
+it to watch a save would force every save to declare itself durably queued, which is a lie about the
+feature's intent.
+
+### The harness, written once per project
+
+The skeleton ships it as `test/support/app_test_core.dart`. Read that file; this is what it holds
+and why.
+
+```dart
+// The project's own generated Protocol — the same object the real client carries.
+// It is the only thing that names the models right: a generated model is an
+// abstract class with a private implementation, so its `runtimeType` reads
+// `_AppSettingImpl`. Import it prefixed — the DartWay core declares a `Protocol` too.
+final testTransport = DwRecordingServerTransport(
+  serializationManager: app.Protocol(),
+);
+
+void bootTestCore() {
+  initExampleDwCore(transport: testTransport);  // the app's own core initializer
+  DefaultModels.initRepository();           // list skeletons need the default models
+}
+```
+
+**Boot through the app's own initializer, not a second core built in the test.** A core assembled
+in a test drifts from the one the app ships, and the drift is invisible until it matters. Give the
+initializer an optional `transport` and build **no Serverpod client** when it is set: a client
+brings a connectivity monitor and an auth key manager, both of which reach for platform channels a
+widget test has no business answering.
+
+**Keep the initializer idempotent** (`if (_coreInitialized) return;`). There is one core per
+process and it cannot be replaced, so the second test file in a run would otherwise meet
+`Dw is already initialized` or a `LateInitializationError`.
+
+### The core is needed to *render*, not only to tap
+
+`dw.action(...)` is constructed inside `build`. A feature therefore touches `dw` while building,
+before anything is interacted with — **so a test that never taps anything still needs a booted
+core**. Miss this and the failure does not say so: the subtree fails to build, and the test dies
+later at a finder ("found 0 widgets"), with the real cause in a separate exception block further up
+the output.
+
+### Reads are prepared, writes are read back
+
+```dart
+testTransport.answerGetAll = (_) async => listResponse([storedAppName('Acme')]);
+
+await tester.pumpFeature(const AdminSettingsForm(), signedInAs: adminProfile());
+await tester.pumpAndSettle();
+
+await tester.tapAndSettle(find.byType(AppCheckbox));
+
+expect(testTransport.saves, hasLength(1));
+final saved = testTransport.saves.single.model as AppSetting;
+expect(saved.settingKey, AppSettingKey.signUpEnabled.key);
+```
+
+- **A read must be prepared.** `answerGetOne` / `answerGetAll` / `answerGetCount`; an unprepared one
+  throws `DwUnpreparedServerCall` naming the call and the field that would answer it. That is
+  deliberate: a test that does not know what its subject fetches is the thing being caught, and an
+  empty list would hide it behind an empty state that looks intentional.
+- **A write needs no setup.** `saveModel` echoes the model back and `delete` succeeds, because the
+  assertion is about what *left*. Set `answerSave` / `answerDelete` only when the response matters —
+  the id assigned on insert, a refusal.
+- **What left is read back** off `transport.saves` and `transport.deletes`: the model, the
+  `apiGroup`, the class name on the wire. `transport.reads` holds the requests, so "this list is
+  unfiltered" stops being a claim in a doc comment.
+- **Reset between tests** (`setUp(resetTestCore)`), because the transport outlives them all.
+
+### The signed-in user is an override, not a session
+
+There is no session in a test — no key manager, nothing to sign into. Stand the user up in the
+test's own `ProviderScope`:
+
+```dart
+ProviderScope(
+  overrides: [
+    dw.userProfileProvider.overrideWithValue(profile),
+    dw.requireUserProfileProvider.overrideWithValue(profile),
+  ],
+  child: /* … */,
+)
+```
+
+This is the sanctioned use of `overrides:` — the app never writes a `ProviderScope` of its own
+(`forbidden_provider_scope`), a test may. Inventing a session instead would test the framework's
+session rather than this feature.
+
+### Two traps about time, not about the transport
+
+- **`pumpAndSettle` does not drain a notification.** A successful
+  `dw.action(onSuccessNotification: ...)` inserts a toast that removes itself on a `Future.delayed`;
+  settling waits for frames, not for timers. The test then fails on "A Timer is still pending even
+  after the widget tree was disposed" — an error about a toast, in a test about a save. Pump
+  `DwUiNotification.defaultDuration` after the tap, once, in a shared `tapAndSettle` helper.
+- **A failed read is retried.** Riverpod retries a failed provider on its own with a growing
+  backoff, so a read you made fail is attempted many times while the test settles. Assert the shape
+  of what was asked — `transport.reads.map((r) => r.operation)` — never the number of attempts; a
+  count pins somebody else's default.
+
+And one that is not about time: **`AppTextFormField` delivers `onChanged` from a post-frame
+callback**, so after `enterText` the form's own state (and whether the Save button is enabled) is a
+frame behind. Use `pumpAndSettle`, not `pump`.
+
+---
+
+## 4. What we deliberately do not test
+
+- **The framework.** That `dw.repo.saveModel` reaches the server, that a list provider refetches on
+  an update, that the session survives a restart — all of it is tested in the DartWay repository,
+  against the framework's own code. Re-testing it in a project buys nothing and breaks on every
+  upgrade.
+- **Cosmetics.** A recoloured button, a padding, a rename. A test written for a checkbox contradicts
+  KISS and YAGNI, and it will be deleted by the first person who touches the widget.
+- **Generated code.** Models, the protocol, migrations. There is nothing there a human wrote.
+- **A UI rule that mirrors a server rule.** Asserting that the publish button is hidden from a
+  member is fine as *UI*, but it says nothing about access — write the integration test for the
+  rule and let the widget test be about the button.
+
+## 5. No coverage thresholds
+
+We do not set a percentage and we do not gate anything on one. A threshold is met by writing tests
+for what is easy to cover, which is exactly the code that did not need covering — getters, mappers,
+generated wrappers — while the calculation everyone is afraid of stays at the same one test it had.
+The number goes up and the suite gets worse.
+
+The question at review is not "how much is covered" but "**is the thing that would break covered,
+and at the layer where it lives**". That is what `dartway-finish` asks.
+
+## Common mistakes
+
+- Testing an access rule through the UI instead of an integration test over `DwCrudConfig`.
+- Building a second `DwCore` inside the test instead of calling the app's initializer.
+- A core initializer without the idempotency guard — green alone, red as soon as a second test file
+  boots it.
+- Reaching for `dw.repo.localWrites` to observe a save.
+- Asserting the number of server calls on a path where a read failed.
+- `pump` instead of `pumpAndSettle` after typing into `AppTextFormField`.
+- Keeping a callback parameter on a widget "so it can be tested".


### PR DESCRIPTION
Testing a DartWay feature was folklore: the framework had no seam a test could
hold, so it never tested the path an application actually takes, `example/` had
no `test/` directory at all, and the toolkit's advice named an API that made a
70-line prop out of watching one save. This closes all of it, in four commits
that are worth reading in order.

## 1. A narrow port between the repository and the transport

`dw.repo`'s whole dependency on the generated Serverpod client is eight
operations. They are now a type — `DwServerTransport` — instead of a reach
through `dw.endpointCaller`, and `DwServerpodTransport` is the only place left
in the Flutter half that knows a generated `Caller` exists.

The seam that follows: `DwCore` takes `transport:` instead of `client:`, and
`package:dartway_serverpod_core_flutter/testing.dart` ships
`DwRecordingServerTransport` — it answers reads from what the test prepared,
keeps every save and delete that left, and throws `DwUnpreparedServerCall`
naming the call and the field that would answer it. The four
`ServerpodClientShared` props inside the core package, ~150 lines of
`callServerEndpoint` dispatching on string keys, are gone.

The framework also gets the test it never had: a feature that reads and writes
for itself, rendered against a library-level `dw` booted the way an app boots
one, asserting that it drew, that the tap arrived, and what left.

**Breaking:** `dw.endpointCaller` is replaced by `dw.serverTransport`. In
practice only a dev stand deliberately failing a call ever named it. `dw.client`
stays non-nullable, so no application call site grows a `!`.

Writing that test also found an ordering bug: `DwFlutter` claims the ambient
`dw` in its super-initializer, so a validation in the constructor body could
never run first — a misconfigured core was left registered as the process's one
and only. The check now lives in the initializer list.

## 2. The example proves the port is usable, not merely possible

`example/dartway_example_flutter` gains `test/` and the news feature end to end:
the list drawing what the server answered plus its loading, empty and failed
states, and the sheet publishing what was typed under the signed-in author.

The port passes — a feature test is a transport, a pump and an expect. Four
things it taught, all now in the docs and the skill:

- an app hands the recording transport **its own generated `Protocol()`**. A
  model it cannot name is now refused rather than sent under a name no server
  knows: `runtimeType` reads `_NewsPostImpl` for every generated model, so the
  old fallback was silently wrong exactly where it mattered;
- the app's initializer takes an optional `transport` and builds no Serverpod
  client when it is set, because a client drags a connectivity monitor and an
  auth key manager onto platform channels a widget test cannot answer;
- `pumpAndSettle` does not drain the toast a successful action leaves behind;
- a failed read is retried by Riverpod, so assert the shape of what was asked
  and never the number of attempts.

`example/lib/core/dw_core.dart` also gets the idempotency guard `DESIGN.md:42`
requires and the template already had.

## 3. The skeleton ships tests, and the toolkit gains `dartway-testing`

A new project no longer starts with an empty test folder. `template/` ships the
admin settings feature end to end — the form drawing what the server answered, a
toggle saving its own row and nothing else, a text setting updating the row it
already has — a unit test over `AppSettingKey.parse`, and the harness in
`test/support/` every project would otherwise write from scratch.

The settings feature was chosen because it carries a rule worth pinning: one row
per setting, so two admins editing different settings cannot overwrite each
other. That claim lived in a doc comment; now it fails a test when it stops
being true.

The new `dartway-testing` skill answers the question the toolkit never did — not
*what* deserves a test (`dartway-clean-code` Part 3 already says that) but
*where it goes*: a rule from a `DwCrudConfig` is an integration test on the
server, plain logic is a unit test, a feature is a widget test with the core
booted and the server standing in as a recording transport. Choosing the wrong
layer is the failure it exists to prevent — a widget test cannot prove a
non-admin is refused, because the UI hiding a button is not the rule. It also
says what is deliberately not tested, and that we set **no coverage threshold**:
a percentage is met by covering the code that was never at risk.

`dartway-data-layer` §4 stops explaining the technique and points at the skill,
keeping only what a widget author needs before any test exists. Third and last
pass over that paragraph.

## 4. `dartway check` names what is missing, by model

Three gaps on the server, and every one of them fails **closed** — the code
compiles, the server starts, the migration applies, and the app quietly cannot
do something:

| Check | Level | What it means |
|---|---|---|
| `crudConfigMissing` | warning | A model with a table and no `DwCrudConfig` — the list is empty forever |
| `crudConfigUnregistered` | error | A config that exists and is not in `crudConfigurations` |
| `crudRuleUntested` | warning | A config with hand-written save or delete logic that no server test names |

`crudConfigMissing` is a warning because the absence has a second, legitimate
reading — a table the server owns alone — which the checker cannot tell apart
and you can. `crudConfigUnregistered` has no second reading, and it is the one
that hides best: the file is there, it has the access rules in it, it reviews as
finished, and the API answers as if it had never been written.

**None of the three counts anything.** That is also why two things the checker
could have guessed at are deliberately absent: a Flutter feature's tests are not
countable without becoming the percentage this exists instead of, and an *Event
model* is a domain reading with no marker in the YAML — a rule keyed off an
`*Event` suffix would miss `BalanceEntry` and fire on a lookup table.

The check found one gap in the skeleton on its first run, so `template/` also
gains the integration test that closes it: `appSettingCrudConfig`'s admin-only
rule, proven against a live database. A new project now starts green, and with a
worked example of all three test layers.

## Verification

- `dart analyze packages/` clean (one pre-existing `dead_code` in generated
  server code, identical on master); `flutter analyze` clean in `example/` and
  `template/`.
- Tests, on this branch rebased onto current master: core_flutter 114,
  dartway_flutter 37, dartway_offline 232, dartway_cli 166, example 7,
  template 13 — all pass. The template's new integration test was run against a
  live Postgres (3/3). `dartway check` passes on the template, and its three new
  server checks are silent there.
- `framework-finish`: carets satisfied, no version moved (`dartway_serverpod_core_*`
  0.10.0, `dartway_flutter` 0.6.0 and `dartway_cli` 0.8.0 all already carry an
  unreleased bump over `stable`), toolkit invariant clean, skeleton carries no
  domain models.

## Known, and deliberately left

`dartway check` reports four `crudRuleUntested` warnings on `example/` —
`SessionReview`, `ChatChannel`, `ChatMessage` and `NewsPost` carry rules with no
integration test. They are true findings and exactly what the check is for;
closing them is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
