### PR TITLE
fix(router): a duplicate route name says which two zones declared it

### DIFF
--- a/packages/dartway_router/CHANGELOG.md
+++ b/packages/dartway_router/CHANGELOG.md
@@ -17,6 +17,36 @@ not active merely because its path is a string prefix of the location (`/news`
 at `/newsletter`), and a zone root with an empty path is active at its own
 address only.
 
+### Changed
+
+A duplicate route name now says which zones declare it.
+
+Route names are global: `DwRouter` keeps one registry for the whole app and
+resolves every route by name. An enum, though, gives its values a namespace of
+their own, so two zones each declaring `projects` compile without a word — and
+the failure surfaced far from the declaration, in the first screen that touched
+the router. The check itself was there, but it reported the bare name and left
+both declarations to be found by hand; worse, when the two zones also collided
+on the path (the usual case) the path check ran first, and its message named
+neither the route nor the zone.
+
+The name check now runs ahead of the path check — a shared name is the cause,
+the shared path its symptom — and the failure carries the whole story:
+
+```
+Duplicate route name "projects".
+Declared by:
+  - AppNavigationZone.projects (navigationZones[0])
+  - AdminNavigationZone.projects (navigationZones[1])
+
+Route names are global across navigation zones. DwRouter keeps a single
+registry for the whole app and resolves routes by name, so a name may be
+declared once and only once. ...
+```
+
+Duplicate paths and invalid paths are reported the same way, naming the enum
+value and the position of its zone in `navigationZones`.
+
 ## 1.1.1 - 2026-07-12
 
 ### Fixed

--- a/packages/dartway_router/lib/src/router/dw_router.dart
+++ b/packages/dartway_router/lib/src/router/dw_router.dart
@@ -307,8 +307,8 @@ class DwRouter<RouterState extends Listenable> {
   ///
   /// Performs comprehensive validation checks:
   /// - Ensures navigation zones are not empty
+  /// - Ensures no duplicate route names across zones
   /// - Ensures no duplicate route paths
-  /// - Ensures no duplicate route names
   /// - Ensures all paths are valid (start with '/')
   /// - Ensures routerState is provided when guards are used
   ///
@@ -324,44 +324,54 @@ class DwRouter<RouterState extends Listenable> {
       throw ArgumentError('navigationZones cannot contain empty zones');
     }
 
-    final allRoutes = navigationZones.expand((z) => z).toList();
+    // Keep every route paired with the zone it came from. Flattening the
+    // zones throws that away, and it is precisely what a collision report
+    // needs: the name of the offending value alone leaves the reader to find
+    // its two declarations by hand.
+    final allRoutes = <_ZonedRoute<RouterState>>[
+      for (var zoneIndex = 0; zoneIndex < navigationZones.length; zoneIndex++)
+        for (final route in navigationZones[zoneIndex])
+          _ZonedRoute(route, zoneIndex),
+    ];
+
+    // Check for duplicate route names.
+    //
+    // Runs before the path check on purpose: two zones declaring one name
+    // usually collide on the path as well, and the path is the symptom while
+    // the shared name is the cause.
+    _checkNoDuplicates(
+      allRoutes,
+      key: (zoned) => zoned.route.name,
+      summary: (name) => 'Duplicate route name "$name".',
+      explanation:
+          'Route names are global across navigation zones. DwRouter keeps a '
+          'single registry for the whole app and resolves routes by name, so a '
+          'name may be declared once and only once. An enum gives its values a '
+          'namespace of their own; the router does not. Rename one of the '
+          'two — for a .simple route the name is also its URL segment, so '
+          'the path moves with it.',
+    );
 
     // Check for duplicate route paths
-    final paths = <String, List<DwNavigationRoute>>{};
-    for (final route in allRoutes) {
-      paths.putIfAbsent(route.fullPath, () => []).add(route);
-    }
-
-    final duplicatePaths = paths.entries.where((e) => e.value.length > 1);
-    if (duplicatePaths.isNotEmpty) {
-      throw ArgumentError(
-        'Duplicate route paths:\n'
-        '${duplicatePaths.map((e) => e.key).join('\n')}',
-      );
-    }
-
-    // Check for duplicate route names
-    final names = <String, List<DwNavigationRoute>>{};
-    for (final route in allRoutes) {
-      names.putIfAbsent(route.name, () => []).add(route);
-    }
-
-    final duplicateNames = names.entries.where((e) => e.value.length > 1);
-    if (duplicateNames.isNotEmpty) {
-      throw ArgumentError(
-        'Duplicate route names:\n'
-        '${duplicateNames.map((e) => e.key).join('\n')}',
-      );
-    }
+    _checkNoDuplicates(
+      allRoutes,
+      key: (zoned) => zoned.route.fullPath,
+      summary: (path) => 'Duplicate route path "$path".',
+      explanation:
+          'A path is built from the zoneRoot of its zone, its parent chain and '
+          'its own segment. Two routes resolving to the same address means one '
+          'of them can never be reached.',
+    );
 
     // Validate that all paths start with '/'
-    for (final route in allRoutes) {
+    for (final zoned in allRoutes) {
+      final route = zoned.route;
       final path =
           route.descriptor.parent == null ? route.routePath : route.fullPath;
 
       if (!path.startsWith('/')) {
         throw ArgumentError(
-          'Invalid route path for ${route.name}: "$path"',
+          'Invalid route path for ${zoned.describe()}: "$path"',
         );
       }
     }
@@ -376,4 +386,54 @@ class DwRouter<RouterState extends Listenable> {
       );
     }
   }
+
+  /// Throws unless [key] is unique across every route of every zone.
+  ///
+  /// The failure names the duplicated value and each route that declares it,
+  /// zone included, so that the message itself ends the investigation.
+  void _checkNoDuplicates(
+    List<_ZonedRoute<RouterState>> routes, {
+    required String Function(_ZonedRoute<RouterState> route) key,
+    required String Function(String key) summary,
+    required String explanation,
+  }) {
+    final grouped = <String, List<_ZonedRoute<RouterState>>>{};
+    for (final zoned in routes) {
+      grouped.putIfAbsent(key(zoned), () => []).add(zoned);
+    }
+
+    final duplicates =
+        grouped.entries.where((e) => e.value.length > 1).toList();
+    if (duplicates.isEmpty) return;
+
+    throw ArgumentError(
+      duplicates
+          .map(
+            (entry) => '${summary(entry.key)}\n'
+                'Declared by:\n'
+                '${entry.value.map((z) => '  - ${z.describe()}').join('\n')}\n'
+                '\n$explanation',
+          )
+          .join('\n\n'),
+    );
+  }
+}
+
+/// A route paired with the index of the zone that declares it.
+///
+/// [DwRouter.navigationZones] is a list of lists; flattening it loses the one
+/// fact a duplicate-route message has to carry — which zones the colliding
+/// declarations came from.
+class _ZonedRoute<RouterState extends Listenable> {
+  const _ZonedRoute(this.route, this.zoneIndex);
+
+  final DwNavigationRoute<RouterState> route;
+
+  /// Position of the route's zone in [DwRouter.navigationZones].
+  final int zoneIndex;
+
+  /// `AdminRoutes.projects (navigationZones[1])` — the enum that declares
+  /// the value, and where its zone sits in the list handed to the router.
+  String describe() =>
+      '${route.runtimeType}.${route.name} (navigationZones[$zoneIndex])';
 }

--- a/packages/dartway_router/test/dw_router_test.dart
+++ b/packages/dartway_router/test/dw_router_test.dart
@@ -134,6 +134,130 @@ enum AuthRoutes implements DwNavigationRoute<TestRouterState> {
   List<DwNavigationGuard<TestRouterState>> get zoneGuards => [];
 }
 
+// Two zones that each own a concept called `projects`. Nothing inside either
+// enum objects to it — the collision only exists at the router.
+enum ProjectsZone implements DwNavigationRoute<TestRouterState> {
+  dashboard(DwNavigationRouteDescriptor.zoneRoot(pageWidget: HomePage())),
+  projects(
+    DwNavigationRouteDescriptor.simple(
+      pageWidget: ProfilePage(),
+      parent: dashboard,
+    ),
+  );
+
+  const ProjectsZone(this.descriptor);
+
+  @override
+  final DwNavigationRouteDescriptor<TestRouterState> descriptor;
+
+  @override
+  String get zoneRoot => '';
+
+  @override
+  DwShellRoutePageBuilder? get shellRouteBuilder => null;
+
+  @override
+  DwStatefulShellRouteBuilder? get statefulShellRouteBuilder => null;
+
+  @override
+  List<DwNavigationGuard<TestRouterState>> get zoneGuards => [];
+}
+
+// Lives under /admin, so its `projects` builds a different path: the name is
+// the only thing that collides.
+enum AdminProjectsZone implements DwNavigationRoute<TestRouterState> {
+  adminDashboard(DwNavigationRouteDescriptor.zoneRoot(pageWidget: HomePage())),
+  projects(
+    DwNavigationRouteDescriptor.simple(
+      pageWidget: ProfilePage(),
+      parent: adminDashboard,
+    ),
+  );
+
+  const AdminProjectsZone(this.descriptor);
+
+  @override
+  final DwNavigationRouteDescriptor<TestRouterState> descriptor;
+
+  @override
+  String get zoneRoot => 'admin';
+
+  @override
+  DwShellRoutePageBuilder? get shellRouteBuilder => null;
+
+  @override
+  DwStatefulShellRouteBuilder? get statefulShellRouteBuilder => null;
+
+  @override
+  List<DwNavigationGuard<TestRouterState>> get zoneGuards => [];
+}
+
+// Sits at the site root as well, so its `projects` collides on the path too.
+enum SecondProjectsZone implements DwNavigationRoute<TestRouterState> {
+  projects(DwNavigationRouteDescriptor.simple(pageWidget: ProfilePage()));
+
+  const SecondProjectsZone(this.descriptor);
+
+  @override
+  final DwNavigationRouteDescriptor<TestRouterState> descriptor;
+
+  @override
+  String get zoneRoot => '';
+
+  @override
+  DwShellRoutePageBuilder? get shellRouteBuilder => null;
+
+  @override
+  DwStatefulShellRouteBuilder? get statefulShellRouteBuilder => null;
+
+  @override
+  List<DwNavigationGuard<TestRouterState>> get zoneGuards => [];
+}
+
+// /reports, reached through a route named `reports`.
+enum ReportsZone implements DwNavigationRoute<TestRouterState> {
+  reports(DwNavigationRouteDescriptor.simple(pageWidget: ProfilePage()));
+
+  const ReportsZone(this.descriptor);
+
+  @override
+  final DwNavigationRouteDescriptor<TestRouterState> descriptor;
+
+  @override
+  String get zoneRoot => '';
+
+  @override
+  DwShellRoutePageBuilder? get shellRouteBuilder => null;
+
+  @override
+  DwStatefulShellRouteBuilder? get statefulShellRouteBuilder => null;
+
+  @override
+  List<DwNavigationGuard<TestRouterState>> get zoneGuards => [];
+}
+
+// /reports as well, this time as a zone root — same address, different name.
+enum OverviewZone implements DwNavigationRoute<TestRouterState> {
+  overview(DwNavigationRouteDescriptor.zoneRoot(pageWidget: HomePage()));
+
+  const OverviewZone(this.descriptor);
+
+  @override
+  final DwNavigationRouteDescriptor<TestRouterState> descriptor;
+
+  @override
+  String get zoneRoot => 'reports';
+
+  @override
+  DwShellRoutePageBuilder? get shellRouteBuilder => null;
+
+  @override
+  DwStatefulShellRouteBuilder? get statefulShellRouteBuilder => null;
+
+  @override
+  List<DwNavigationGuard<TestRouterState>> get zoneGuards => [];
+}
+
 void main() {
   group('DwRouter', () {
     test('should create router with valid configuration', () {
@@ -174,32 +298,6 @@ void main() {
           contains('navigationZones cannot contain empty zones'),
         )),
       );
-    });
-
-    test('should throw ArgumentError when route paths are duplicated', () {
-      // Note: This test is simplified since enum names are unique by definition
-      // In practice, duplicate paths would come from different route configurations
-      final router = DwRouter<TestRouterState>(
-        navigationZones: [
-          TestRoutes.values,
-        ],
-        pageBuilder: DwPageBuilder.material,
-      );
-
-      expect(router.router, isA<GoRouter>());
-    });
-
-    test('should throw ArgumentError when route names are duplicated', () {
-      // This is harder to test since enum names are unique by definition
-      // But we can test the validation logic exists
-      final router = DwRouter<TestRouterState>(
-        navigationZones: [
-          TestRoutes.values,
-        ],
-        pageBuilder: DwPageBuilder.material,
-      );
-
-      expect(router.router, isA<GoRouter>());
     });
 
     test('should throw ArgumentError when guards are used without routerState',
@@ -319,6 +417,95 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(tester.takeException(), isNull);
+      });
+    });
+
+    group('duplicate route names across zones', () {
+      test(
+          'two zones declaring the same name fail when the router is '
+          'assembled, naming the value and both zones', () {
+        expect(
+          () => DwRouter<TestRouterState>(
+            navigationZones: [
+              ProjectsZone.values,
+              AdminProjectsZone.values,
+            ],
+            pageBuilder: DwPageBuilder.material,
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('Duplicate route name "projects"'),
+                contains('ProjectsZone.projects (navigationZones[0])'),
+                contains('AdminProjectsZone.projects (navigationZones[1])'),
+                contains('Route names are global across navigation zones'),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('the same name in one zone and a different one in another is fine',
+          () {
+        final router = DwRouter<TestRouterState>(
+          navigationZones: [
+            ProjectsZone.values,
+            ReportsZone.values,
+          ],
+          pageBuilder: DwPageBuilder.material,
+        );
+
+        expect(router.router, isA<GoRouter>());
+        expect(router.navigationZones.length, 2);
+      });
+
+      test('a name collision is reported ahead of the path it also breaks', () {
+        // Both zones sit at the site root, so `projects` collides on the path
+        // as well. The path is the symptom; the message must name the cause.
+        expect(
+          () => DwRouter<TestRouterState>(
+            navigationZones: [
+              ProjectsZone.values,
+              SecondProjectsZone.values,
+            ],
+            pageBuilder: DwPageBuilder.material,
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('Duplicate route name "projects"'),
+                isNot(contains('Duplicate route path')),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('a duplicate path names its routes and their zones too', () {
+        expect(
+          () => DwRouter<TestRouterState>(
+            navigationZones: [
+              ReportsZone.values,
+              OverviewZone.values,
+            ],
+            pageBuilder: DwPageBuilder.material,
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('Duplicate route path "/reports"'),
+                contains('ReportsZone.reports (navigationZones[0])'),
+                contains('OverviewZone.overview (navigationZones[1])'),
+              ),
+            ),
+          ),
+        );
       });
     });
 

--- a/toolkit/skills/dartway-navigation/SKILL.md
+++ b/toolkit/skills/dartway-navigation/SKILL.md
@@ -18,6 +18,7 @@ Navigation rules for DartWay projects. The router is a wrapper over go_router: `
 
 - **Enum routes only** — no string route names in calls.
 - **A zone is an enum** implementing `DwNavigationRoute<AppRouterState>`; route definitions live in `core/router/`, not in widgets.
+- **Route names are global** — a name belongs to the whole app, not to its enum. The same value in two zones is an error; see [Route names are global](#route-names-are-global).
 - **Guards live in the zone** (`zoneGuards`), not scattered across screens.
 - **Parameters are type-safe only**, via an enum with `DwNavigationParamsMixin`.
 - Do not mix navigation logic with UI.
@@ -133,6 +134,37 @@ final appRouterProvider = Provider<DwRouter<AppRouterState>>((ref) {
 
 In the app: `MaterialApp.router(routerConfig: ref.watch(appRouterProvider).router)`.
 
+## Route names are global
+
+`navigationZones` is where the names of every zone meet. Each zone is an enum,
+and an enum gives its values a namespace of their own — so
+`AppNavigationZone.projects` and `AdminNavigationZone.projects` both compile
+without a word of complaint. The router works the other way round: it keeps a
+**single registry for the whole app** and resolves every route by name
+(`goNamed(...)`, `topRouteFromState`), so one name can belong to one route only.
+Two zones owning a concept called `projects` is the natural thing to write, and
+it is an error.
+
+`DwRouter` refuses to assemble in that case and names both declarations:
+
+```
+Duplicate route name "projects".
+Declared by:
+  - AppNavigationZone.projects (navigationZones[0])
+  - AdminNavigationZone.projects (navigationZones[1])
+```
+
+The router is usually built inside a provider, so the throw lands wherever that
+provider is first read — typically the first screen, or a widget test that has
+nothing to do with navigation. Read the message, not the stack.
+
+For a `.simple` route the name is also its URL segment, so renaming one moves
+its path with it: there is no way to keep `/admin/projects` while calling the
+value something else (`extraPathSegment` prefixes the segment, it does not
+replace it). Pick the word that describes *that* screen —
+`AdminNavigationZone.projectAdmin` — rather than a syllable bolted on to dodge
+the collision.
+
 ## Transitions
 
 The route name is `.name` (the enum), the full path is `.fullPath`. A transition:
@@ -176,5 +208,6 @@ Mixin methods: `set(value)` → the map for a transition; `fromPath(context)` / 
 
 - String route names and raw parameter maps instead of enums.
 - Checking authorization inside a screen instead of `zoneGuards`.
+- The same route name in two zones — the enums have separate namespaces, the router does not.
 - A forgotten `parent` on `.simple`/`.parameterized` — the route will not take its place in the zone tree.
 - Changing state without `notifyListeners()` — the guards will not re-run.


### PR DESCRIPTION
Zones are separate enums, so two of them can each declare a `projects` with no
conflict inside either — and nothing said the namespace is shared. `DwRouter`
resolves by name and keeps one registry for the whole app, so the second
declaration is an error. It surfaced as fourteen failing widget tests in an
unrelated area, none of which mentioned navigation, the new zone or the name.

**The check was already there; what it threw away was the answer.** Two things
made it useless. The message named the colliding value and nothing else, because
the zones are flattened into one list before the check and the origin is dropped
at that moment. And the **path** check ran first — two zones at the same zone
root declaring the same name collide on the path as well, so what a developer
actually saw was `Duplicate route paths: /projects`, a symptom, while the name
check that would have named the cause was never reached.

Names are checked before paths now, cause before symptom, and every route
carries the index of the zone that declared it, so the message reads:

    Duplicate route name "projects".
    Declared by:
      - ProjectsZone.projects (navigationZones[0])
      - AdminProjectsZone.projects (navigationZones[1])

    Route names are global across navigation zones. …
    An enum gives its values a namespace of their own; the router does not.

The path check and the leading-slash check gained the same treatment while the
information was finally in reach.

`dartway-navigation` now says it as a rule, with the reason attached: the enum
shape argues the other way, which is why writing it was the natural thing to do
rather than a careless one. It also says where the throw lands — wherever the
router provider is first read, far from the declaration — so the instruction is
to read the message rather than the stack.

Two tests went out with this: both were named for duplicate detection, both
built a valid router and asserted `isA<GoRouter>()`, and their comments carried
the very misconception being corrected — "enum names are unique by definition".
Four real ones replace them, three of which fail against the previous code.

Closes #111

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
