### PR TITLE
fix(deploy): the migration step reports what it did, and fails when it did nothing

### DIFF
--- a/docs/4-server/push-delivery.md
+++ b/docs/4-server/push-delivery.md
@@ -69,6 +69,57 @@ dozen numbers you don't understand. The one knob worth knowing is
 `maxConcurrentDeliveries`: each in-flight send holds a database connection for
 the whole provider round-trip, so keep it a small fraction of your Postgres pool.
 
+## Adding the module to a database that already has data
+
+Nothing special is required, and it is worth knowing why, because the shape of a
+Serverpod module's `migrations/` folder suggests otherwise. Open
+`dartway_push_server/migrations/` and the first migration there creates a whole
+schema — `serverpod_log`, `serverpod_migrations`, `dw_auth_key` and the rest,
+alongside the `dw_push_*` tables. That is what `serverpod create-migration`
+writes for any module: it folds every module the module itself depends on into
+`migration.sql` and `definition.sql`, and offers no way to ask it not to. The
+core module's first migration has the identical shape.
+
+**Those two files are never applied to anything.** In Serverpod 3.4.11 the
+runtime migration manager is constructed with the *project* directory and
+migrates exactly one module — the project. A module's chain is read once, by
+`serverpod create-migration` running **in your project**, and only
+`definition_project.json` of the module's latest version, which lists the eight
+tables the module owns and nothing else. Those tables are merged into your
+project's target schema, and the difference against your previous migration
+becomes an ordinary `CREATE TABLE` step in **your** migration. Adding push to a
+five-year-old database is therefore the same three commands as adding a model of
+your own:
+
+```bash
+serverpod generate
+serverpod create-migration
+dartway deploy run --env production
+```
+
+The deploy's migration step now prints what the container said and fails when it
+says the schema did not move ([the CLI page](../5-tooling/cli.md)), so a
+collision is visible on the run that caused it rather than days later.
+
+If the `dw_push_*` tables somehow already exist — created by hand, or left behind
+by a migration that was rolled back in the repository but not in the database —
+the migration will die on `relation "dw_push_delivery" already exists`, and every
+later migration stays queued behind it. Do not resolve that by dropping tables:
+the supported route is a **repair migration**, which diffs the *live* database
+against the target schema instead of replaying history — Serverpod's own answer
+to "everything else is already here".
+
+```bash
+serverpod create-repair-migration --mode production
+# then start the server once with --apply-repair-migration
+```
+
+`create-repair-migration` connects to the database named by that mode's
+configuration to read what is actually there, so it has to be run from somewhere
+that can reach it. The repair lands in `repair-migration/`, is committed like any
+other migration, and is applied by a single run carrying
+`--apply-repair-migration` — after which the ordinary queue moves again.
+
 ## Where the credentials come from
 
 **Short values are passwords; a whole document is a file.** `fcmProjectId`,

--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -333,6 +333,33 @@ deleted, in case somebody edited it on the box while debugging.
 every public URL. It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders
 infrastructure on every push turns a routine change into an infrastructure one.
 
+**The migration step prints what the container said, and fails on it.** It used to print its title
+and nothing else, because a step's output was shown only when its exit code was non-zero — and this
+particular exit code cannot be asked. Serverpod wraps the whole apply in a `try`/`catch`: a failure
+sets `verified = false`, and `verified` aborts the process **only in development**. Outside it the
+failure is swallowed, the maintenance role ends with the exit code it started with, and a container
+that applied nothing exits 0 exactly like one that applied everything. So "we deployed" stopped
+implying "the schema caught up": the application went on running new code against an old schema, the
+deploy log said nothing, and re-running it produced the same green step and the same broken schema.
+
+The outcome is only ever stated in the text, so the text is now read and shown. `Applied database
+migration:` with the versions, or `Latest database migration already applied.`, passes. Any of
+`Failed to apply migration <version>.`, `Failed to apply database migrations.` or Serverpod's own
+`The database does not match the target database:` fails the step — the last of those being the case
+where nothing threw and the schema still did not catch up. So does silence: a container that exits 0
+without mentioning the schema never reached the migration code, which usually means an `ENTRYPOINT`
+in shell form (see `server_entrypoint`). A failed step stops the deploy before `up`, so the previous
+version keeps serving while you read the reason, which is quoted in the log along with what to run
+next.
+
+There is deliberately no separate schema assertion in `deploy check`. The authoritative comparison
+already runs inside the migration container — Serverpod checks the live schema against the target
+definition table by table on every maintenance start — and the fix was to stop discarding its
+verdict, not to add a second one. A `check` that compared `migration_registry.txt` against the
+`serverpod_migrations` table would compare two version strings rather than a schema, go green on a
+database whose row says the right version while a table is missing, and answer before the deploy has
+run at all: green exactly where the deploy is red.
+
 `secret` moves credentials between the maintainer's `passwords.yaml` and a server, one environment
 at a time: `push` sends `shared` plus that environment, `pull` brings back what the server has and
 the file lacks, `list` shows names only. `set` stores one value, `put-file` uploads a whole file — a

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -27,6 +27,40 @@
   domain reading with no marker in the YAML (a rule keyed off an `*Event` suffix would miss the one
   called `BalanceEntry` and fire on a lookup table).
 
+- **The migration step of a deploy can now report its outcome, and until now it could not.** It
+  printed its title and nothing else, because a step's output was shown only when its exit code was
+  non-zero — and this particular exit code answers a different question. Serverpod wraps the whole
+  apply in a `try`/`catch`: a failure sets `verified = false`, and `verified` aborts the process
+  **only in development**. Outside it the failure is swallowed, the maintenance role ends with
+  `throw ExitException(_exitCode)` having never touched `_exitCode`, and a container that applied
+  nothing exits 0 exactly like one that applied everything. So the deploy reported success for work
+  it did not do: the application went on running new code against an old schema, nothing in the log
+  mentioned it, and re-running produced the same green step and the same broken schema — while the
+  command's own help describes `deploy run` as "update, rebuild, migrate, restart".
+
+  The step now prints the container's output whatever happened, and reads the outcome out of it.
+  `Applied database migration:` with the versions it names, or `Latest database migration already
+  applied.`, passes. `Failed to apply migration <version>.`, `Failed to apply database migrations.`
+  and Serverpod's own `The database does not match the target database:` each fail it — the last
+  being the case where nothing threw and the schema still did not catch up. So does silence: a
+  container that exits 0 without mentioning the schema never reached the migration code, which is
+  usually an `ENTRYPOINT` in shell form swallowing `--apply-migrations`. A failed step stops the
+  deploy before `up`, so the previous version keeps serving while the reason — quoted, with what to
+  run next — is read.
+
+  The mechanism is a step-level one rather than a special case: `DwDeployStep` gained `showOutput`
+  and `verdict`, so any step whose exit code and result can disagree says which text settles it.
+  The Serverpod literals are pinned by tests, and a Serverpod that renames one turns the step silent
+  rather than green.
+
+  No `deploy check` assertion was added for the schema, deliberately. The authoritative comparison
+  already runs inside the migration container — Serverpod checks the live schema against the target
+  definition table by table on every maintenance start — and the fix was to stop discarding its
+  verdict rather than to add a second one. Comparing `migration_registry.txt` against the
+  `serverpod_migrations` table would compare two version strings rather than a schema, pass on a
+  database whose row says the right version while a table is missing, and answer before the deploy
+  had run: green exactly where the deploy is red.
+
 - **The deploy templates now ship the configuration that serves a Flutter web build, and it caches
   by what is actually hashed.** Nothing was shipped before, so every project wrote its own, and what
   they wrote applied the rule everybody knows — "fingerprinted assets are immutable, cache them for

--- a/packages/dartway_cli/lib/src/commands/deploy_run.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_run.dart
@@ -109,10 +109,29 @@ Future<int> runDeploy(Command<int> command, ArgResults results) async {
     final step = steps[index];
     stdout.writeln('\n[${index + 1}/${steps.length}] ${step.title}');
     final result = await step.run();
+
+    // A step that declares it prints its own output prints it whatever
+    // happened. "Only on failure" is how a step that reports its outcome in
+    // text — and its exit code regardless — comes out green and blank.
+    if (step.showOutput) {
+      _indent(stdout, '${result.stdout}\n${result.stderr}');
+    }
+
     if (!result.ok) {
+      stderr.writeln('Step "${step.id}" failed:');
+      if (!step.showOutput) {
+        stderr.writeln(
+          result.stderr.trim().isEmpty ? result.stdout : result.stderr,
+        );
+      }
+      return 1;
+    }
+
+    final verdict = step.verdict?.call(result);
+    if (verdict != null) {
       stderr
-        ..writeln('Step "${step.id}" failed:')
-        ..writeln(result.stderr.trim().isEmpty ? result.stdout : result.stderr);
+        ..writeln('Step "${step.id}" exited 0 and did not do its work:')
+        ..writeln(verdict);
       return 1;
     }
     if (step.id == 'update-checkout') {
@@ -156,4 +175,17 @@ Future<int> runDeploy(Command<int> command, ArgResults results) async {
 
   stdout.writeln('\nDeployment completed.');
   return 0;
+}
+
+/// Writes [text] under the step that produced it, one indented line at a time,
+/// dropping the blank ones. Keeps a step's own output visibly subordinate to
+/// its title instead of merging into the deploy's own log.
+void _indent(Stdout sink, String text) {
+  for (final line in text.split('\n')) {
+    final trimmed = line.trimRight();
+    if (trimmed.isEmpty) {
+      continue;
+    }
+    sink.writeln('  $trimmed');
+  }
 }

--- a/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'compose_files.dart';
 import 'deploy_target.dart';
+import 'migration_report.dart';
 import 'serverpod_config.dart';
 import 'ssh_runner.dart';
 
@@ -14,11 +15,27 @@ class DwDeployStep {
     required this.id,
     required this.title,
     required this.run,
+    this.showOutput = false,
+    this.verdict,
   });
 
   final String id;
   final String title;
   final Future<DwSshResult> Function() run;
+
+  /// Whether the step's output belongs in the log even when it succeeded.
+  ///
+  /// Off for most steps — a deploy that reprints every `docker compose` line is
+  /// a deploy nobody reads. On where the output *is* the result and the exit
+  /// code is not.
+  final bool showOutput;
+
+  /// A second opinion on a step that exited 0: why it must fail anyway, or null
+  /// when it is genuinely fine.
+  ///
+  /// An exit code is a claim about the process, not about the work. Where the
+  /// two can disagree, the step says which text settles it.
+  final String? Function(DwSshResult result)? verdict;
 }
 
 /// Deploys an already-provisioned server: update the checkout, rebuild, apply
@@ -82,6 +99,9 @@ class DwDeployRunner {
   /// `</dev/null` is not decoration: without it `compose run -T` consumes the
   /// rest of the surrounding script from stdin and the following commands
   /// silently never run.
+  ///
+  /// Whether this did anything is read out of the output, not out of the exit
+  /// code — see [DwMigrationReport].
   Future<DwSshResult> applyMigrations() {
     final entrypoint = target.serverEntrypoint;
     final override = entrypoint == null ? '' : "--entrypoint '$entrypoint' ";
@@ -124,6 +144,13 @@ class DwDeployRunner {
       id: 'migrate',
       title: 'Apply database migrations',
       run: applyMigrations,
+      // The container's own account of what it did is the only account there
+      // is: it exits 0 either way. Printing it unconditionally is half of that
+      // — the other half is refusing to continue when it says the schema did
+      // not move.
+      showOutput: true,
+      verdict: (result) =>
+          DwMigrationReport.read('${result.stdout}\n${result.stderr}').failure,
     ),
     DwDeployStep(id: 'up', title: 'Start services', run: up),
     DwDeployStep(

--- a/packages/dartway_cli/lib/src/deploy/migration_report.dart
+++ b/packages/dartway_cli/lib/src/deploy/migration_report.dart
@@ -83,6 +83,16 @@ class DwMigrationReport {
       if (line.contains(_integrityFailed)) {
         drifted = true;
         stated.add(line);
+        // `verifyDatabaseIntegrity` prints the header and then one ` - <what>`
+        // line per difference it found. The header says the schema is behind;
+        // those lines say which table, which is the half an operator acts on.
+        for (var next = index + 1; next < lines.length; next++) {
+          final difference = lines[next];
+          if (!difference.startsWith('- ')) {
+            break;
+          }
+          stated.add(difference);
+        }
         continue;
       }
       if (line.contains(_disabled)) {

--- a/packages/dartway_cli/lib/src/deploy/migration_report.dart
+++ b/packages/dartway_cli/lib/src/deploy/migration_report.dart
@@ -1,0 +1,247 @@
+/// What the migration container said about the schema — and why its exit code
+/// is not allowed to answer instead.
+///
+/// `dartway deploy run` applies migrations by starting the server image once in
+/// Serverpod's maintenance role with `--apply-migrations`. Serverpod 3.4.11
+/// wraps that whole apply in a `try`/`catch` (`Serverpod._applyMigrations`): a
+/// failure sets `verified = false`, and the only consequence of `verified`
+/// being false is `if (config.runMode == development) throw ExitException(1)`.
+/// Outside development the failure is swallowed. The maintenance role then ends
+/// with `throw ExitException(_exitCode)`, and nothing on the failed path ever
+/// touches `_exitCode` — so a container that applied nothing exits 0, exactly
+/// like one that applied everything.
+///
+/// The outcome is only ever stated in the text, so the text is what has to be
+/// read. These are the literals Serverpod 3.4.11 writes; they are pinned by
+/// tests here, and a Serverpod that renames one turns the step [silent] rather
+/// than green, which is the safe direction to be wrong in.
+library;
+
+/// What became of the schema during one migration step.
+enum DwMigrationOutcome {
+  /// Migrations were pending and are now applied.
+  applied,
+
+  /// Nothing was pending; the schema was already at the latest version.
+  alreadyCurrent,
+
+  /// An apply was attempted and threw. The schema is where it was.
+  failed,
+
+  /// Nothing threw, and the live database still does not match the target —
+  /// Serverpod's own `verifyDatabaseIntegrity` says so.
+  drifted,
+
+  /// The project has the migration feature switched off, so the step could not
+  /// have done anything.
+  disabled,
+
+  /// The container said nothing about the schema at all.
+  silent,
+}
+
+/// The outcome of one `--apply-migrations` run, read out of its output.
+class DwMigrationReport {
+  const DwMigrationReport._(this.outcome, this.stated, this.appliedVersions);
+
+  /// Reads [output] — the container's stdout and stderr together, since the
+  /// success lines land on one and the failures on the other.
+  factory DwMigrationReport.read(String output) {
+    final lines = output.split('\n').map((line) => line.trim()).toList();
+
+    final stated = <String>[];
+    var failed = false;
+    var drifted = false;
+    var disabled = false;
+    var applied = false;
+    var alreadyCurrent = false;
+    final versions = <String>[];
+
+    for (var index = 0; index < lines.length; index++) {
+      final line = lines[index];
+      if (line.isEmpty) {
+        continue;
+      }
+
+      if (line.contains(_applyFailed) ||
+          line.contains(_repairFailed) ||
+          line.contains(_versionFailed)) {
+        failed = true;
+        stated.add(line);
+        // `MigrationManager` prints the exception on the line after the
+        // version it failed on, and that line is the whole diagnosis — the
+        // constraint or relation Postgres refused. Quoting the marker without
+        // it hands the reader a stopped deploy and no reason.
+        final detail = index + 1 < lines.length ? lines[index + 1] : '';
+        if (detail.isNotEmpty &&
+            !detail.startsWith('#') &&
+            !_isMarker(detail)) {
+          stated.add(detail);
+        }
+        continue;
+      }
+      if (line.contains(_integrityFailed)) {
+        drifted = true;
+        stated.add(line);
+        continue;
+      }
+      if (line.contains(_disabled)) {
+        disabled = true;
+        stated.add(line);
+        continue;
+      }
+      if (line.contains(_alreadyApplied)) {
+        alreadyCurrent = true;
+        stated.add(line);
+        continue;
+      }
+      if (line.contains(_appliedHeader)) {
+        applied = true;
+        stated.add(line);
+        // Serverpod prints the header, then one ` - <version>` line per
+        // migration it ran.
+        for (var next = index + 1; next < lines.length; next++) {
+          final bullet = lines[next];
+          if (!bullet.startsWith('- ')) {
+            break;
+          }
+          versions.add(bullet.substring(2).trim());
+        }
+        continue;
+      }
+    }
+
+    // Order matters: a run that applied two migrations and then failed on the
+    // third has said both things, and the failure is the one that decides.
+    final DwMigrationOutcome outcome;
+    if (failed) {
+      outcome = DwMigrationOutcome.failed;
+    } else if (drifted) {
+      outcome = DwMigrationOutcome.drifted;
+    } else if (disabled) {
+      outcome = DwMigrationOutcome.disabled;
+    } else if (applied) {
+      outcome = DwMigrationOutcome.applied;
+    } else if (alreadyCurrent) {
+      outcome = DwMigrationOutcome.alreadyCurrent;
+    } else {
+      outcome = DwMigrationOutcome.silent;
+    }
+
+    return DwMigrationReport._(
+      outcome,
+      List.unmodifiable(stated),
+      List.unmodifiable(versions),
+    );
+  }
+
+  /// `Serverpod._applyMigrations`, on the catch-all around the whole apply.
+  static const String _applyFailed = 'Failed to apply database migrations.';
+
+  /// Same method, when `--apply-repair-migration` found nothing to apply.
+  static const String _repairFailed =
+      'Failed to apply database repair migration.';
+
+  /// `MigrationManager._migrateToLatestModule`, naming the version that threw.
+  static const String _versionFailed = 'Failed to apply migration ';
+
+  /// `MigrationManager.verifyDatabaseIntegrity`, which runs after the apply and
+  /// compares the live schema against the target definition table by table.
+  static const String _integrityFailed =
+      'The database does not match the target database:';
+
+  /// `Serverpod.start`, when the project builds without the migration feature.
+  static const String _disabled = 'Migrations are disabled in this project';
+
+  /// `Serverpod._applyMigrations`, when nothing was pending.
+  static const String _alreadyApplied =
+      'Latest database migration already applied.';
+
+  /// Covers both `Applied database migration:` and its plural.
+  static const String _appliedHeader = 'Applied database migration';
+
+  /// Whether [line] is one of the outcome markers, so that a line following a
+  /// failure is quoted as its detail only when it is not an outcome of its own.
+  static bool _isMarker(String line) =>
+      line.contains(_applyFailed) ||
+      line.contains(_repairFailed) ||
+      line.contains(_versionFailed) ||
+      line.contains(_integrityFailed) ||
+      line.contains(_disabled) ||
+      line.contains(_alreadyApplied) ||
+      line.contains(_appliedHeader);
+
+  final DwMigrationOutcome outcome;
+
+  /// The lines that decided [outcome], in the order the container printed them.
+  final List<String> stated;
+
+  /// Versions named under an `Applied database migration(s):` header.
+  final List<String> appliedVersions;
+
+  /// Whether the schema caught up.
+  bool get ok =>
+      outcome == DwMigrationOutcome.applied ||
+      outcome == DwMigrationOutcome.alreadyCurrent;
+
+  /// Why the step must fail, or null when the schema caught up.
+  ///
+  /// Every branch names what to run next, because the reader is looking at a
+  /// deploy that has just stopped and the useful question is not "what
+  /// happened" but "what now".
+  String? get failure {
+    if (ok) {
+      return null;
+    }
+    final quoted = stated.map((line) => '  $line').join('\n');
+    switch (outcome) {
+      case DwMigrationOutcome.applied:
+      case DwMigrationOutcome.alreadyCurrent:
+        return null;
+      case DwMigrationOutcome.failed:
+        return 'The migration container reported a failure and still exited 0 '
+            '— Serverpod only aborts on this in development.\n$quoted\n'
+            'The schema is where it was, and every later migration is stuck '
+            'behind this one. Services were not restarted, so the running '
+            'version is still serving. Read the lines above for the SQL that '
+            'threw; a database that has drifted from the migration history is '
+            'brought back with "serverpod create-repair-migration" and a '
+            'deploy that passes --apply-repair-migration.';
+      case DwMigrationOutcome.drifted:
+        return 'Nothing threw, and the live schema still does not match what '
+            'this build expects.\n$quoted\n'
+            'That is the deploy shipping new code against an old schema, which '
+            'is the failure this step exists to catch. Either a migration is '
+            'missing from the repository — "serverpod create-migration" — or '
+            'the database was changed outside the migration history, which '
+            '"serverpod create-repair-migration" reconciles.';
+      case DwMigrationOutcome.disabled:
+        return 'The server image was built without the migration feature, so '
+            'this step could not have applied anything.\n$quoted\n'
+            'Enable the database feature in the server package, or take the '
+            'step out of the deploy deliberately rather than letting it report '
+            'work it cannot do.';
+      case DwMigrationOutcome.silent:
+        return 'The migration container exited 0 without saying anything about '
+            'the schema.\n'
+            'It should have printed one of "Applied database migration(s):", '
+            '"Latest database migration already applied." or "Failed to apply '
+            'database migrations." Silence means it never reached the migration '
+            'code — a container that died early, an ENTRYPOINT in shell form '
+            'that swallowed --apply-migrations (see the "server_entrypoint" '
+            'key), or SERVERPOD_SILENCE_LIFECYCLE_MESSAGES=1 in its '
+            'environment. Whichever it is, nothing here establishes that the '
+            'schema caught up.';
+    }
+  }
+
+  /// One line for the deploy log on a step that went well.
+  String get summary => switch (outcome) {
+    DwMigrationOutcome.applied =>
+      appliedVersions.isEmpty
+          ? 'migrations applied'
+          : 'applied: ${appliedVersions.join(', ')}',
+    DwMigrationOutcome.alreadyCurrent => 'schema already at the latest version',
+    _ => outcome.name,
+  };
+}

--- a/packages/dartway_cli/test/deploy_migration_report_test.dart
+++ b/packages/dartway_cli/test/deploy_migration_report_test.dart
@@ -1,0 +1,218 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/deploy/compose_files.dart';
+import 'package:dartway_cli/src/deploy/deploy_runner.dart';
+import 'package:dartway_cli/src/deploy/deploy_target.dart';
+import 'package:dartway_cli/src/deploy/migration_report.dart';
+import 'package:dartway_cli/src/deploy/serverpod_config.dart';
+import 'package:dartway_cli/src/deploy/ssh_runner.dart';
+import 'package:test/test.dart';
+
+/// The literals below are copied out of Serverpod 3.4.11 — `Serverpod
+/// ._applyMigrations`, `MigrationManager._migrateToLatestModule` and
+/// `MigrationManager.verifyDatabaseIntegrity` — rather than paraphrased. They
+/// are the whole contract: nothing else distinguishes a migration container
+/// that did the work from one that did not, since both exit 0.
+const _appliedOne = '''
+SERVERPOD version: 3.4.11, dart: 3.11.0, time: 2026-08-19 06:00:00.000Z
+Applied database migration:
+ - 20260813134456435
+''';
+
+const _appliedSeveral = '''
+Applied database migrations:
+ - 20260722180525356
+ - 20260723050630677
+''';
+
+const _alreadyCurrent = '''
+SERVERPOD version: 3.4.11, dart: 3.11.0, time: 2026-08-19 06:00:00.000Z
+Latest database migration already applied.
+''';
+
+/// What the container actually printed in the reported incident: the module's
+/// tables were already there, the migration threw, and the process exited 0.
+const _failedApply = '''
+Failed to apply migration 20260813134456435.
+DatabaseQueryException: { message: relation "dw_push_delivery" already exists, code: 42P07 }
+2026-08-19 06:00:00.000Z ERROR: Failed to apply database migrations.
+2026-08-19 06:00:00.000Z ERROR: Exception: relation "dw_push_delivery" already exists
+#0      MigrationManager._migrateToLatestModule
+''';
+
+const _drifted = '''
+WARNING: The database does not match the target database:
+ - Table "dw_push_delivery" is missing.
+Hint: Did you forget to run `serverpod generate`, apply the migrations (--apply-migrations), or run a repair migration (--apply-repair-migration)?
+''';
+
+DwDeployTarget _target() => DwDeployTarget(
+  environment: 'staging',
+  host: '203.0.113.10',
+  sshUser: 'root',
+  deployUser: 'deployer',
+  os: 'ubuntu',
+  repo: 'git@github.com:acme/shop.git',
+  branch: 'master',
+  sslEmail: 'ops@example.com',
+  webAppDomain: 'app.example.com',
+);
+
+DwServerpodConfig _serverpod() => DwServerpodConfig(
+  environment: 'staging',
+  relativePath: 'shop_server/config/staging.yaml',
+  apiServer: DwServerEndpoint(
+    name: 'apiServer',
+    port: 8080,
+    publicHost: 'api.example.com',
+    publicPort: 443,
+    publicScheme: 'https',
+  ),
+  insightsServer: null,
+  webServer: null,
+  databaseHost: 'postgres',
+  databasePort: 5432,
+  databaseName: 'shop',
+  databaseUser: 'shop',
+  redisEnabled: false,
+  redisHost: null,
+);
+
+DwDeployStep _migrateStep() => DwDeployRunner(
+  ssh: DwSshRunner(host: '203.0.113.10', user: 'root'),
+  target: _target(),
+  serverpod: _serverpod(),
+  stdout: stdout,
+).steps(skipGitUpdate: true).firstWhere((step) => step.id == 'migrate');
+
+void main() {
+  group('reading the outcome out of the container output', () {
+    test('one applied migration is named', () {
+      final report = DwMigrationReport.read(_appliedOne);
+
+      expect(report.outcome, DwMigrationOutcome.applied);
+      expect(report.appliedVersions, ['20260813134456435']);
+      expect(report.failure, isNull);
+      expect(report.summary, contains('20260813134456435'));
+    });
+
+    test('the plural header is read the same way', () {
+      final report = DwMigrationReport.read(_appliedSeveral);
+
+      expect(report.outcome, DwMigrationOutcome.applied);
+      expect(report.appliedVersions, [
+        '20260722180525356',
+        '20260723050630677',
+      ]);
+      expect(report.failure, isNull);
+    });
+
+    test('nothing pending is a pass, not silence', () {
+      final report = DwMigrationReport.read(_alreadyCurrent);
+
+      expect(report.outcome, DwMigrationOutcome.alreadyCurrent);
+      expect(report.ok, isTrue);
+      expect(report.failure, isNull);
+    });
+
+    test('a failed apply fails, whatever the exit code claimed', () {
+      final report = DwMigrationReport.read(_failedApply);
+
+      expect(report.outcome, DwMigrationOutcome.failed);
+      expect(report.ok, isFalse);
+      expect(report.failure, contains('exited 0'));
+      // The reason has to travel with the verdict: a deploy that stops without
+      // the SQL error in the log sends the reader to the server for it.
+      expect(report.stated.join('\n'), contains('20260813134456435'));
+    });
+
+    test('a schema that did not catch up fails even though nothing threw', () {
+      final report = DwMigrationReport.read(_drifted);
+
+      expect(report.outcome, DwMigrationOutcome.drifted);
+      expect(report.failure, contains('create-repair-migration'));
+    });
+
+    test('a failure outranks the migrations that landed before it', () {
+      final report = DwMigrationReport.read('$_appliedSeveral$_failedApply');
+
+      expect(report.outcome, DwMigrationOutcome.failed);
+      expect(report.appliedVersions, isNotEmpty);
+      expect(report.failure, isNotNull);
+    });
+
+    test('drift is reported as drift when nothing threw', () {
+      final report = DwMigrationReport.read('$_appliedOne$_drifted');
+
+      expect(report.outcome, DwMigrationOutcome.drifted);
+    });
+
+    test('a disabled migration feature is not a successful step', () {
+      final report = DwMigrationReport.read(
+        'Migrations are disabled in this project, skipping applying '
+        'migration(s).',
+      );
+
+      expect(report.outcome, DwMigrationOutcome.disabled);
+      expect(report.failure, isNotNull);
+    });
+
+    test('saying nothing about the schema is a failure, not a pass', () {
+      // The exact shape of the reported blind spot: a step that prints its
+      // title and nothing else used to be indistinguishable from a good one.
+      final report = DwMigrationReport.read('Creating shop-backend-run-1a2b\n');
+
+      expect(report.outcome, DwMigrationOutcome.silent);
+      expect(report.ok, isFalse);
+      expect(report.failure, contains('server_entrypoint'));
+    });
+
+    test('an empty transcript is silence too', () {
+      expect(DwMigrationReport.read('').outcome, DwMigrationOutcome.silent);
+    });
+  });
+
+  group('the migrate step', () {
+    test('prints its output whether or not it succeeded', () {
+      expect(_migrateStep().showOutput, isTrue);
+    });
+
+    test('passes a successful container', () {
+      final verdict = _migrateStep().verdict!(
+        DwSshResult(exitCode: 0, stdout: _appliedOne, stderr: ''),
+      );
+
+      expect(verdict, isNull);
+    });
+
+    test('fails a container that exited 0 having applied nothing', () {
+      final verdict = _migrateStep().verdict!(
+        DwSshResult(exitCode: 0, stdout: '', stderr: _failedApply),
+      );
+
+      expect(verdict, isNotNull);
+      expect(verdict, contains('relation "dw_push_delivery" already exists'));
+    });
+
+    test('reads stdout and stderr together', () {
+      // Serverpod puts the success lines on stdout and the failures on stderr,
+      // so a verdict that looked at one stream would miss half the outcomes.
+      final verdict = _migrateStep().verdict!(
+        DwSshResult(exitCode: 0, stdout: _appliedOne, stderr: _drifted),
+      );
+
+      expect(verdict, isNotNull);
+    });
+
+    test('the step is still the one docker compose invocation', () {
+      // Guards against the verdict being wired to a second, separate command:
+      // a check that asks a different question than the deploy answered is the
+      // shape this whole change exists to remove.
+      expect(_migrateStep().title, 'Apply database migrations');
+      expect(
+        DwComposeFiles.commandIn('/home/deployer/shop', 'run --rm -T'),
+        contains('-f ${DwComposeFiles.projectOverride}'),
+      );
+    });
+  });
+}

--- a/packages/dartway_cli/test/deploy_migration_report_test.dart
+++ b/packages/dartway_cli/test/deploy_migration_report_test.dart
@@ -133,6 +133,16 @@ void main() {
       expect(report.failure, contains('create-repair-migration'));
     });
 
+    test('drift names the table, not only that there is drift', () {
+      // The header says the schema is behind; the lines under it say which
+      // table. Quoting the header alone hands an operator a stopped deploy and
+      // nothing to go and look at.
+      final report = DwMigrationReport.read(_drifted);
+
+      expect(report.failure, contains('dw_push_delivery'));
+      expect(report.failure, isNot(contains('Hint:')));
+    });
+
     test('a failure outranks the migrations that landed before it', () {
       final report = DwMigrationReport.read('$_appliedSeveral$_failedApply');
 

--- a/packages/dartway_push/dartway_push_server/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_server/CHANGELOG.md
@@ -12,6 +12,30 @@ app that kept the JSON in `passwords.yaml` moves it with
 `deploy/config.yaml`; nothing else in the wiring changes. The plain constructor
 still takes the JSON directly, for an app that obtains it some other way.
 
+- **What a project inherits from this module is now pinned by a test.** The
+  module's `migrations/` folder looks alarming: its first migration creates a
+  whole schema — `serverpod_log`, `dw_auth_key` and the rest — rather than only
+  the tables the module owns, which reads like a module that can be installed
+  into an empty database and nowhere else. That shape is what
+  `serverpod create-migration` writes for any module, the core module included;
+  it folds every dependency module into `migration.sql` and `definition.sql` and
+  offers no way to ask it not to. Those two files are also never applied to
+  anything: Serverpod 3.4.11 builds its migration manager from the *project*
+  directory and migrates one module, the project. A module's chain is read once,
+  by `create-migration` in the project, and only `definition_project.json` of the
+  module's latest version — which is why the tables reach a live database as an
+  ordinary `CREATE TABLE` inside the project's own migration.
+
+  So the file that decides the module's effect on somebody's database is that
+  one, and it is now asserted to list exactly the eight `dw_*` tables the module
+  owns, each attributed to `dartway_push`, with the registry checked against the
+  version directories on disk. The bootstrap-shaped SQL is inert; this file
+  quietly growing a table the module does not own would not be.
+
+  The push delivery documentation gained a section on adding the module to a
+  database that already has data: the three commands it takes, and the repair
+  migration that gets a database out of a collision without dropping tables.
+
 - **A service-account JSON is not a password, and steering it into one was our
   doing.** The comment that shipped with push described `fcmServiceAccountJson`
   as "the whole service-account JSON … on one line", and `fromPasswords` was the

--- a/packages/dartway_push/dartway_push_server/test/push/migration_artifacts_test.dart
+++ b/packages/dartway_push/dartway_push_server/test/push/migration_artifacts_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// What a project inherits when it adds this module, and why only one file in
+/// `migrations/` decides it.
+///
+/// Serverpod 3.4.11 never replays a module's migration chain against a
+/// database. `ServerMigrationManager` is constructed with the *project*
+/// directory, and `MigrationManager.migrateToLatest` migrates exactly one
+/// module — the one `session.db.serializationManager.getModuleName()` names,
+/// which is the project. A module's `migration.sql` and `definition.sql` are
+/// read by nothing.
+///
+/// What *is* read is `definition_project.json` of the module's **last**
+/// version, once, by `serverpod create-migration` running in the project
+/// (`MigrationGenerator._loadModuleDatabaseDefinitions`). Its tables are merged
+/// into the project's target definition, and the difference against the
+/// project's previous definition becomes the project's own migration. So this
+/// one file is the entire blast radius of the module on somebody's database: a
+/// table that appears in it appears as a `CREATE TABLE` in every project that
+/// runs `create-migration` next.
+///
+/// Which is why it is pinned here. The module's own `definition.sql` lists the
+/// whole world — `serverpod_log`, `dw_auth_key` and the rest — because the
+/// generator folds every dependency module into it and offers no way to ask it
+/// not to. That file being a bootstrap is inert. This one quietly growing a
+/// table the module does not own would not be.
+void main() {
+  const migrations = 'migrations';
+
+  /// Exactly the tables this module owns. Adding a name here is a deliberate
+  /// act: it becomes a `CREATE TABLE` in every project on the module.
+  const ownedTables = {
+    'dw_device_push_token',
+    'dw_push_delivery',
+    'dw_push_message',
+    'dw_push_message_recipient',
+    'dw_push_metric_bucket',
+    'dw_push_recipient_state',
+    'dw_push_runtime_state',
+    'dw_push_source_link',
+  };
+
+  const moduleName = 'dartway_push';
+
+  List<String> registeredVersions() =>
+      File('$migrations/migration_registry.txt')
+          .readAsLinesSync()
+          .map((line) => line.trim())
+          .where((line) => line.isNotEmpty && !line.startsWith('#'))
+          .toList();
+
+  List<String> versionDirectories() =>
+      Directory(migrations)
+          .listSync()
+          .whereType<Directory>()
+          .map(
+            (directory) =>
+                directory.uri.pathSegments.lastWhere((s) => s.isNotEmpty),
+          )
+          .toList()
+        ..sort();
+
+  Map<String, dynamic> projectDefinition(String version) =>
+      jsonDecode(
+            File(
+              '$migrations/$version/definition_project.json',
+            ).readAsStringSync(),
+          )
+          as Map<String, dynamic>;
+
+  List<Map<String, dynamic>> tablesOf(Map<String, dynamic> definition) =>
+      (definition['tables'] as List).cast<Map<String, dynamic>>();
+
+  group('what a project inherits from this module', () {
+    test('is exactly the tables the module owns', () {
+      final definition = projectDefinition(registeredVersions().last);
+
+      expect(
+        tablesOf(definition).map((table) => table['name']).toSet(),
+        ownedTables,
+        reason:
+            'definition_project.json of the last migration is what '
+            '"serverpod create-migration" merges into every project on this '
+            'module. A name here that the module does not own becomes a '
+            'CREATE TABLE against a database that already has that table.',
+      );
+    });
+
+    test('and every one of them is attributed to this module', () {
+      final definition = projectDefinition(registeredVersions().last);
+
+      expect(definition['moduleName'], moduleName);
+      for (final table in tablesOf(definition)) {
+        expect(table['module'], moduleName, reason: '${table['name']}');
+      }
+    });
+  });
+
+  group('the migration registry', () {
+    test('lists every version directory, and only those', () {
+      // The registry warns in its own header that a merge can collide here. A
+      // version in the registry with no directory makes `MigrationVersion.load`
+      // throw in every project that generates a migration; a directory absent
+      // from the registry is never read at all.
+      expect(registeredVersions(), versionDirectories());
+    });
+
+    test('names the newest version last', () {
+      // `_loadMigrationVersionsFromModules` takes `migrationVersions.last` and
+      // nothing else. If that is not the newest, projects inherit an older
+      // table set with nothing to say so.
+      expect(registeredVersions().last, versionDirectories().last);
+    });
+
+    test('every version carries the files the loaders require', () {
+      for (final version in registeredVersions()) {
+        for (final artefact in const [
+          'definition_project.json',
+          'definition.json',
+          'definition.sql',
+          'migration.json',
+          'migration.sql',
+        ]) {
+          expect(
+            File('$migrations/$version/$artefact').existsSync(),
+            isTrue,
+            reason: '$version/$artefact',
+          );
+        }
+      }
+    });
+  });
+}

--- a/template/deploy/README.md
+++ b/template/deploy/README.md
@@ -37,6 +37,27 @@ every push turns a routine change into an infrastructure one. `compose.override.
 is the opposite: it is never copied to the server, only named on every Compose
 call, so the file the deploy merges is the committed one.
 
+## Migrations — what "migrate" in that one-liner actually promises
+
+The migration step prints everything the container said and fails when the text
+says the schema did not move: `Failed to apply migration <version>.`, `Failed to
+apply database migrations.`, Serverpod's `The database does not match the target
+database:` — and silence, which means the container never reached the migration
+code at all.
+
+It reads the text because the exit code cannot be asked. Serverpod aborts on a
+failed migration **only in development**; in staging and production the failure
+is swallowed and the container exits 0, so "migrate" used to mean "a container
+ran" and nothing more. A deploy could report success while the application went
+on running new code against an old schema.
+
+A failed step stops the deploy before services are restarted, so the previous
+version keeps serving while you read the reason. If the reason is that the
+database has drifted from the migration history — a table that is physically
+there and unrecorded, or the reverse — the route back is
+`serverpod create-repair-migration --mode <env>` and one run with
+`--apply-repair-migration`, not a hand-written `DROP TABLE`.
+
 ## Caching — why a redeploy might not reach the browser
 
 **A Flutter web build hashes nothing.** `index.html`, `flutter_bootstrap.js`,

--- a/toolkit/skills/dartway-push-delivery/SKILL.md
+++ b/toolkit/skills/dartway-push-delivery/SKILL.md
@@ -80,6 +80,29 @@ void initDartwayCore({required Map<String, String> passwords}) {
 }
 ```
 
+### The module reaches an existing database like any other model change
+
+`serverpod generate` → `serverpod create-migration` → deploy. Nothing else, and
+no special handling for a database that has been in production for years.
+
+Worth knowing, because the module's `migrations/` folder says otherwise: its
+first migration creates a whole schema — `serverpod_log`, `dw_auth_key` and the
+rest — rather than only the `dw_push_*` tables. That is what
+`serverpod create-migration` writes for **any** module, the DartWay core module
+included; it folds every dependency module into `migration.sql` and
+`definition.sql` and offers no way to ask it not to. Serverpod 3.4.11 never
+applies those two files: its migration manager is built from the *project*
+directory and migrates one module, the project. The module's chain is read once,
+by `create-migration` in the app, and only `definition_project.json` of its
+latest version — so the module's tables arrive as an ordinary `CREATE TABLE` in
+the app's own migration.
+
+Do not hand-edit anything under the module's `migrations/`, and do not copy its
+SQL into the app. If a deploy dies on `relation "dw_push_*" already exists`, the
+tables are physically there while the migration history says they are not — the
+route out is `serverpod create-repair-migration --mode <env>` and one run with
+`--apply-repair-migration`, never a `DROP TABLE`.
+
 ### Credentials come from two places, and which one is not a preference
 
 **Short values go in `passwords.yaml`; a credential that is a whole document


### PR DESCRIPTION
`Apply database migrations` printed its title and nothing else — the step loop
showed a step's output only when the exit code was non-zero — and Serverpod
outside development swallows a failed apply and leaves the container exiting 0.
So the step was green whether the schema caught up or not, and a deploy that
did nothing read as a deploy that worked. The application then ran new code
against an old schema, and the first sign of it was an error a user hit; re-running
produced the same green step and the same broken schema.

The step now prints its output whatever happened, and the run fails on what the
text says rather than on the exit code alone: a failed apply, a failed repair,
Serverpod's own "The database does not match the target database", migrations
disabled — and on **silence**, because exit 0 with no mention of the schema
means the container never reached the migration code at all. The markers are
copied from Serverpod 3.4.11 and pinned by tests, so an upstream reword shows up
here as a failing test rather than as a step that quietly stops noticing. The
step runs before `up`, so a failure leaves the previous version serving.

**A second schema check in `deploy check` was considered and refused.** The
authoritative comparison already runs inside the migration container —
`verifyDatabaseIntegrity` compares the live schema against the target definition
table by table on every maintenance start. The bug was that its verdict was
discarded, not that it was missing. Comparing `migration_registry.txt` against
the `serverpod_migrations` table instead would compare two version strings, pass
on a database whose row says the right version while a table is absent, and
answer before the deploy has run — green exactly where the deploy is red, which
is the failure this repository has now fixed twice.

Alongside it, the push module's own artefacts get the guard they lacked: its
latest definition claims exactly the eight tables it owns, each attributed to
`dartway_push`, its registry matches the version directories, and every version
carries the files the loaders read. And the docs, the skill and the deploy
README now say what to do when a module is added to a database that already has
data — including `create-repair-migration --mode <env>`, which is Serverpod's
supported way out of a collision, and never `DROP TABLE`.

Closes #109

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
