### PR TITLE
fix(core): a failed CRUD call names the model it was about

### DIFF
--- a/docs/2-core/crud-configs.md
+++ b/docs/2-core/crud-configs.md
@@ -84,6 +84,28 @@ reachable at all**. Access is something you grant, never something you forget to
 first encounter is a new model whose screen shows the "not configured" message — the config was
 written and the registration line was not.
 
+## When a call fails
+
+A denial and a failure are different answers. `notConfigured` and `notAuthenticated` above are
+decisions the server made on purpose; a **failure** is something that threw underneath — a table the
+database does not have yet, a column the schema never grew, a filter naming a field that does not
+exist.
+
+Every method of the CRUD endpoint runs inside one error boundary, so a failure is never a bare HTTP
+500. It comes back as `isOk: false` with the operation and the model in the text:
+
+```
+Unexpected error while handling the getAll request for ClubService
+```
+
+and the same failure — exception and the stack of the throw — is reported through `dw.alerts`
+(see [error reporting](error-reporting.md)). **The model name is the part that matters**: one
+endpoint serves every model in the application, so a report that says only which endpoint failed
+reads the same whichever list broke.
+
+Nothing about the failure text describes the database. What threw goes to the operator, never to the
+client — the same rule the save path states below for `DatabaseException`.
+
 ## Saving: one lifecycle for insert and update
 
 `DwSaveConfig<T>` has no separate create and update paths. `saveContext.isInsert` tells the hooks

--- a/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
+++ b/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
@@ -76,10 +76,10 @@ void main() {
 
         final response = await _openLoginRequest(session);
 
-        // Not the generic "Unexpected error during saveModel DwAuthRequest" a
-        // thrown hook produces, and not the provider's complaint either — that
-        // one names the delivery configuration, and this endpoint answers
-        // anonymous callers.
+        // Not the generic "Unexpected error while handling the saveModel
+        // request for DwAuthRequest" a thrown hook produces, and not the
+        // provider's complaint either — that one names the delivery
+        // configuration, and this endpoint answers anonymous callers.
         expect(response.error, isNotNull);
         expect(response.error, isNot(contains('Unexpected error')));
         expect(response.error, isNot(contains('DwAuthRequest')));

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -2,10 +2,27 @@
 
 ## 0.10.0
 
-Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.10.0 is the
-Flutter side gaining the optional local-storage contract for `dw.repo` — `DwRepoLocalReads` and
-`DwRepoLocalWrites`, declared on the core as a plugin. Nothing changes for an app that declares no
-store. See the changelog of `dartway_serverpod_core_flutter`.
+**A CRUD call that fails now says which model it was about.** `getAll` and `getCount` had no error
+handling of their own, so a missing table, a column the schema never grew or a filter naming a field
+that does not exist escaped as a bare HTTP 500: nothing reached `DwAlerts`, and the client-side
+report read `Failed call: dartway_serverpod_core.dwCrud.getAll` — identical whichever list broke,
+while `className` sat right there in the arguments.
+
+- Every method of `DwCrudEndpoint` now runs inside one error boundary. A thrown failure comes back
+  as `DwApiResponse(isOk: false)` with the operation and the model in the text — `Unexpected error
+  while handling the getAll request for ClubService` — and is reported through `dw.alerts` with the
+  exception. `delete` keeps the id of the row it was about.
+- **`notConfigured` and `notAuthenticated` are unaffected.** They are answers, not accidents: they
+  travel back out unchanged and are not reported.
+- The report now carries **the stack of the throw**. `returnError` took a `stackTrace` and then
+  reported `StackTrace.current`, so every alert from `saveModel` and `delete` pointed at the handler
+  instead of at the code that failed.
+- `getOne` reported the raw `ex.toString()` as the alert headline; all five methods now report the
+  same way.
+
+This release also carries the Flutter side's optional local-storage contract for `dw.repo` —
+`DwRepoLocalReads` and `DwRepoLocalWrites`, declared on the core as a plugin. Nothing changes for an
+app that declares no store. See the changelog of `dartway_serverpod_core_flutter`.
 
 ## 0.9.0
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/endpoints/dw_crud_endpoint.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/endpoints/dw_crud_endpoint.dart
@@ -10,6 +10,13 @@ import '../private/dw_singleton.dart';
 class DwCrudEndpoint extends Endpoint {
   final _deepEquality = const DeepCollectionEquality();
 
+  /// Reports [errorMessage] and answers with a failed [DwApiResponse].
+  ///
+  /// [stackTrace] is the stack of the *throw*, and it is what gets reported —
+  /// the helper falls back to its own stack only when the caller has none.
+  /// Passing the caught stack and then reporting `StackTrace.current` is not a
+  /// smaller version of the same thing: it points every report at this line
+  /// instead of at the code that failed.
   DwApiResponse<T> returnError<T>(
     String errorMessage, {
     Object? exception,
@@ -18,9 +25,45 @@ class DwCrudEndpoint extends Endpoint {
     dw.alerts.reportError(
       errorMessage,
       exception: exception,
-      stackTrace: StackTrace.current,
+      stackTrace: stackTrace ?? StackTrace.current,
     );
     return DwApiResponse(isOk: false, value: null, error: errorMessage);
+  }
+
+  /// The error boundary **every** method of this endpoint runs inside.
+  ///
+  /// One endpoint serves every model in the application, so an exception that
+  /// escapes it becomes a bare HTTP 500 whose client-side report reads
+  /// `Failed call: dartway_serverpod_core.dwCrud.getAll` — identical whichever
+  /// list broke, while `className` sat right there in the arguments. Inside the
+  /// guard the same failure comes back as `isOk: false` with the model named,
+  /// and passes through `dw.alerts` on the way.
+  ///
+  /// It is a wrapper rather than five `try`/`catch` blocks because the bug this
+  /// closes was not carelessness — `getCount` and `getAll` were simply the two
+  /// of five where the block was never written. A method that forgets the
+  /// wrapper is caught by `dw_crud_endpoint_guard_test.dart`, which reads this
+  /// file and fails on any endpoint method whose body does not delegate here.
+  ///
+  /// Only *thrown* failures are its business. `notConfigured` and
+  /// `notAuthenticated` are answers, not accidents: they are returned by the
+  /// body and travel back out unchanged, unreported.
+  Future<DwApiResponse<T>> _guard<T>(
+    String operation,
+    String className,
+    Future<DwApiResponse<T>> Function() body, {
+    String? details,
+  }) async {
+    try {
+      return await body();
+    } catch (ex, stackTrace) {
+      return returnError<T>(
+        'Unexpected error while handling the $operation request '
+        'for $className${details == null ? '' : ' ($details)'}',
+        exception: ex,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   Stream<SerializableModel> subscribeOnUpdates(
@@ -56,54 +99,42 @@ class DwCrudEndpoint extends Endpoint {
     required String className,
     required DwBackendFilter filter,
     String? apiGroup,
-  }) async {
-    try {
-      final caller = dw.getCrudConfig(className, api: apiGroup);
+  }) => _guard('getOne', className, () async {
+    final caller = dw.getCrudConfig(className, api: apiGroup);
 
-      session.log(
-        'getOne for $className with filter: ${filter.attributeMap}',
-        level: LogLevel.debug,
-      );
+    session.log(
+      'getOne for $className with filter: ${filter.attributeMap}',
+      level: LogLevel.debug,
+    );
 
-      if (caller?.getModelConfigs == null || caller!.getModelConfigs!.isEmpty) {
-        return DwApiResponse.notConfigured(source: 'getOne for $className');
-      }
-
-      final config = caller.getModelConfigs!.firstWhereOrNull(
-        (e) => _deepEquality.equals(
-          e.filterPrototype.attributeMap,
-          filter.attributeMap,
-        ),
-      );
-
-      if (config == null) {
-        return DwApiResponse.notConfigured(source: 'getOne for $className');
-      }
-
-      if (!await _isCallerAllowed(session, config.allowAnonymous)) {
-        return DwApiResponse.notAuthenticated(source: 'getOne for $className');
-      }
-
-      return await config.call(session, caller.table, filter);
-    } catch (ex) {
-      dw.alerts.reportError(ex.toString(), stackTrace: StackTrace.current);
-
-      return DwApiResponse(
-        isOk: false,
-        value: null,
-        error:
-            'Unexpected error while handling the getOne request '
-            'for $className',
-      );
+    if (caller?.getModelConfigs == null || caller!.getModelConfigs!.isEmpty) {
+      return DwApiResponse.notConfigured(source: 'getOne for $className');
     }
-  }
+
+    final config = caller.getModelConfigs!.firstWhereOrNull(
+      (e) => _deepEquality.equals(
+        e.filterPrototype.attributeMap,
+        filter.attributeMap,
+      ),
+    );
+
+    if (config == null) {
+      return DwApiResponse.notConfigured(source: 'getOne for $className');
+    }
+
+    if (!await _isCallerAllowed(session, config.allowAnonymous)) {
+      return DwApiResponse.notAuthenticated(source: 'getOne for $className');
+    }
+
+    return await config.call(session, caller.table, filter);
+  });
 
   Future<DwApiResponse<int>> getCount(
     Session session, {
     required String className,
     DwBackendFilter? filter,
     String? apiGroup,
-  }) async {
+  }) => _guard('getCount', className, () async {
     final caller = dw.getCrudConfig(className, api: apiGroup);
 
     session.log(
@@ -126,7 +157,7 @@ class DwCrudEndpoint extends Endpoint {
       session,
       whereClause: filter?.prepareWhere(caller.table),
     );
-  }
+  });
 
   Future<DwApiResponse<List<DwModelWrapper>>> getAll(
     Session session, {
@@ -136,7 +167,7 @@ class DwCrudEndpoint extends Endpoint {
     int? limit,
     int? offset,
     String? apiGroup,
-  }) async {
+  }) => _guard('getAll', className, () async {
     final crudConfig = dw.getCrudConfig(className, api: apiGroup);
 
     DwGetListInterface? caller = crudConfig?.getListConfig;
@@ -167,74 +198,58 @@ class DwCrudEndpoint extends Endpoint {
       limit: limit,
       offset: offset,
     );
-  }
+  });
 
   Future<DwApiResponse<DwModelWrapper>> saveModel(
     Session session, {
     required DwModelWrapper wrappedModel,
     String? apiGroup,
-  }) async {
-    try {
-      final model = wrappedModel.object;
-      final className = wrappedModel.dwMappingClassname;
+  }) => _guard('saveModel', wrappedModel.dwMappingClassname, () async {
+    final model = wrappedModel.object;
+    final className = wrappedModel.dwMappingClassname;
 
-      if (model is! TableRow) {
-        // throw UnsupportedError(
-        //   'Received item of unsupported type: ${model.runtimeType}. Only TableRow could be saved to database',
-        // );
-        final caller = dw.getDtoConfig(className, api: apiGroup);
+    if (model is! TableRow) {
+      // throw UnsupportedError(
+      //   'Received item of unsupported type: ${model.runtimeType}. Only TableRow could be saved to database',
+      // );
+      final caller = dw.getDtoConfig(className, api: apiGroup);
 
-        if (caller == null || caller is! DwDtoActionConfig) {
-          return DwApiResponse.notConfigured(source: 'saveModel $className');
-        }
-        if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
-          return DwApiResponse.notAuthenticated(source: 'saveModel $className');
-        }
-        return await caller.save(session, model);
-      } else {
-        final caller = dw.getCrudConfig(className, api: apiGroup)?.saveConfig;
-
-        if (caller == null) {
-          return DwApiResponse.notConfigured(source: 'saveModel $className');
-        }
-        if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
-          return DwApiResponse.notAuthenticated(source: 'saveModel $className');
-        }
-        return await caller.save(session, model);
+      if (caller == null || caller is! DwDtoActionConfig) {
+        return DwApiResponse.notConfigured(source: 'saveModel $className');
       }
-    } catch (ex, st) {
-      return returnError(
-        'Unexpected error during saveModel ${wrappedModel.dwMappingClassname}',
-        exception: ex,
-        stackTrace: st,
-      );
+      if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
+        return DwApiResponse.notAuthenticated(source: 'saveModel $className');
+      }
+      return await caller.save(session, model);
+    } else {
+      final caller = dw.getCrudConfig(className, api: apiGroup)?.saveConfig;
+
+      if (caller == null) {
+        return DwApiResponse.notConfigured(source: 'saveModel $className');
+      }
+      if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
+        return DwApiResponse.notAuthenticated(source: 'saveModel $className');
+      }
+      return await caller.save(session, model);
     }
-  }
+  });
 
   Future<DwApiResponse<bool>> delete(
     Session session, {
     required String className,
     required int modelId,
     String? apiGroup,
-  }) async {
-    try {
-      final caller = dw.getCrudConfig(className, api: apiGroup)?.deleteConfig;
+  }) => _guard('delete', className, () async {
+    final caller = dw.getCrudConfig(className, api: apiGroup)?.deleteConfig;
 
-      if (caller == null) {
-        return DwApiResponse.notConfigured(source: 'delete $className');
-      }
-
-      if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
-        return DwApiResponse.notAuthenticated(source: 'delete $className');
-      }
-
-      return await caller.delete(session, modelId);
-    } catch (ex, st) {
-      return returnError(
-        'Unexpected error during delete $className with id $modelId',
-        exception: ex,
-        stackTrace: st,
-      );
+    if (caller == null) {
+      return DwApiResponse.notConfigured(source: 'delete $className');
     }
-  }
+
+    if (!await _isCallerAllowed(session, caller.allowAnonymous)) {
+      return DwApiResponse.notAuthenticated(source: 'delete $className');
+    }
+
+    return await caller.delete(session, modelId);
+  }, details: 'id $modelId');
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/endpoints/dw_crud_endpoint_error_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/endpoints/dw_crud_endpoint_error_test.dart
@@ -1,0 +1,256 @@
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:dartway_serverpod_core_server/src/endpoints/dw_crud_endpoint.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+/// The failure the issue was written about: the table is not in the database
+/// yet, or a filter names a column the schema never grew. It comes out of the
+/// config, below the endpoint, and it is thrown — never returned.
+///
+/// Its own function so the top frame of the stack has a name to look for: the
+/// point of the stack-trace test is that the report points *here* and not at
+/// the handler that caught it.
+Never tableIsMissing() =>
+    throw StateError('relation "broken_list" does not exist');
+
+class BrokenList implements TableRow<int?> {
+  @override
+  int? get id => null;
+
+  @override
+  Table<int?> get table => _brokenListTable;
+
+  @override
+  Map<String, dynamic> toJson() => const {};
+}
+
+class PrivateList implements TableRow<int?> {
+  @override
+  int? get id => null;
+
+  @override
+  Table<int?> get table => _brokenListTable;
+
+  @override
+  Map<String, dynamic> toJson() => const {};
+}
+
+class TestUserProfile implements TableRow<int?> {
+  @override
+  int? get id => 1;
+
+  @override
+  Table<int?> get table => _userProfileTable;
+
+  @override
+  Map<String, dynamic> toJson() => const {};
+}
+
+class TestTable extends Table<int?> {
+  TestTable(String name) : super(tableName: name) {
+    userIdentifier = ColumnString(DwCoreConst.userIdentifierColumnName, this);
+  }
+
+  late final ColumnString userIdentifier;
+
+  @override
+  List<Column> get columns => [id, userIdentifier];
+}
+
+final _brokenListTable = TestTable('broken_list');
+final _userProfileTable = TestTable('test_user_profile');
+
+/// A list config that fails the way a broken list does in production: on the
+/// way to the rows, before there is anything to answer with.
+class ExplodingListConfig<T extends TableRow> extends DwGetModelListConfig<T> {
+  const ExplodingListConfig({super.allowAnonymous}) : super(accessFilter: null);
+
+  @override
+  Future<DwApiResponse<List<DwModelWrapper>>> getModelList(
+    Session session, {
+    Expression? whereClause,
+    List<Order>? orderByList,
+    int? limit,
+    int? offset,
+  }) async => tableIsMissing();
+
+  @override
+  Future<DwApiResponse<int>> getCount(
+    Session session, {
+    Expression? whereClause,
+  }) async => tableIsMissing();
+}
+
+class ExplodingDeleteConfig<T extends TableRow> extends DwDeleteConfig<T> {
+  const ExplodingDeleteConfig({super.allowAnonymous});
+
+  @override
+  Future<DwApiResponse<bool>> delete(Session session, int modelId) async =>
+      tableIsMissing();
+}
+
+/// A session carrying nothing but its authentication: the endpoint decides
+/// access from `signedInUserProfileId`, and logs. Anything else it is asked
+/// for means a test reached the database, which none of these should.
+class TestSession implements Session {
+  TestSession.anonymous() : userIdentifier = null;
+
+  TestSession.signedIn(int userProfileId)
+    : userIdentifier = userProfileId.toString();
+
+  final String? userIdentifier;
+
+  @override
+  AuthenticationInfo? get authenticated {
+    final identifier = userIdentifier;
+    if (identifier == null) return null;
+    return AuthenticationInfo(identifier, const <Scope>{}, authId: 'test');
+  }
+
+  @override
+  void log(
+    String message, {
+    LogLevel? level,
+    dynamic exception,
+    StackTrace? stackTrace,
+  }) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('The endpoint must not reach the database here');
+}
+
+void main() {
+  // `DwCore.init` builds the framework's own config for the signed-in profile,
+  // and `DwBackendFilter.equalsPrototype` resolves its class name through
+  // `Serverpod.instance` — so the core cannot be initialized before a Serverpod
+  // object exists. Constructing one is enough; nothing here is started, and no
+  // socket or database is touched.
+  Serverpod(
+    ['--mode', 'test', '--role', 'monolith'],
+    Protocol(),
+    Endpoints(),
+    config: ServerpodConfig.defaultConfig(),
+  );
+
+  final reports = <String>[];
+  final endpoint = DwCrudEndpoint();
+  final session = TestSession.signedIn(42);
+
+  DwCore.init<TestUserProfile>(
+    userProfileTable: _userProfileTable,
+    crudConfigurations: [
+      DwCrudConfig<BrokenList>(
+        table: _brokenListTable,
+        getListConfig: const ExplodingListConfig<BrokenList>(
+          allowAnonymous: true,
+        ),
+        deleteConfig: const ExplodingDeleteConfig<BrokenList>(
+          allowAnonymous: true,
+        ),
+      ),
+      DwCrudConfig<PrivateList>(
+        table: _brokenListTable,
+        getListConfig: const ExplodingListConfig<PrivateList>(),
+      ),
+    ],
+    dtoConfigurations: [],
+    channelConfigurations: [],
+    userProfileConstructor: (session, {required registrationRequest}) async =>
+        throw UnimplementedError(),
+    dwAlerts: DwAlerts.init(logFunction: reports.add),
+  );
+
+  setUp(reports.clear);
+
+  group('a thrown failure', () {
+    test('getAll answers with a failure naming the model', () async {
+      final response = await endpoint.getAll(session, className: 'BrokenList');
+
+      expect(response.isOk, isFalse);
+      expect(response.error, contains('getAll'));
+      expect(response.error, contains('BrokenList'));
+    });
+
+    test('getCount answers with a failure naming the model', () async {
+      final response = await endpoint.getCount(
+        session,
+        className: 'BrokenList',
+      );
+
+      expect(response.isOk, isFalse);
+      expect(response.error, contains('getCount'));
+      expect(response.error, contains('BrokenList'));
+    });
+
+    test('delete keeps the id of the row it was about', () async {
+      final response = await endpoint.delete(
+        session,
+        className: 'BrokenList',
+        modelId: 7,
+      );
+
+      expect(response.isOk, isFalse);
+      expect(response.error, contains('BrokenList'));
+      expect(response.error, contains('id 7'));
+    });
+
+    test('is reported to dw.alerts, once', () async {
+      await endpoint.getAll(session, className: 'BrokenList');
+
+      expect(reports, hasLength(1));
+      expect(reports.single, contains('BrokenList'));
+      expect(reports.single, contains('relation'));
+    });
+  });
+
+  group('the reported stack trace', () {
+    /// The frames of the `📜 StackTrace` code block of an alert.
+    List<String> framesOf(String report) {
+      final open = report.indexOf('```');
+      final close = report.lastIndexOf('```');
+      expect(open, greaterThan(-1), reason: 'the alert carries no stack trace');
+      return report.substring(open + 3, close).trim().split('\n');
+    }
+
+    test('is the stack of the throw, not of the handler', () async {
+      await endpoint.getAll(session, className: 'BrokenList');
+
+      final frames = framesOf(reports.single);
+
+      // The whole of the regression: reporting `StackTrace.current` from
+      // inside the handler compiles, reads as handled, and points every
+      // report at the handler instead of at the code that failed.
+      expect(frames.first, contains('tableIsMissing'));
+
+      // `returnError` can only appear in a stack that was captured inside it —
+      // which is exactly what the discarded `stackTrace` argument used to be
+      // replaced by. `_guard` does appear, and belongs there: it is the
+      // asynchronous suspension the throw travelled through.
+      expect(reports.single, isNot(contains('returnError')));
+    });
+  });
+
+  group('what the guard must leave alone', () {
+    test('an unregistered model is still "not configured"', () async {
+      final response = await endpoint.getAll(session, className: 'NoSuchModel');
+
+      expect(response.isOk, isFalse);
+      expect(response.error, contains('Action not configured on server'));
+      expect(reports, isEmpty, reason: 'a denial is an answer, not an error');
+    });
+
+    test('an anonymous caller is still "authentication required"', () async {
+      final response = await endpoint.getAll(
+        TestSession.anonymous(),
+        className: 'PrivateList',
+      );
+
+      expect(response.isOk, isFalse);
+      expect(response.error, contains('Authentication required'));
+      // The config would have thrown had the gate let the call through — the
+      // guard must not turn a denial into an error, nor the other way round.
+      expect(reports, isEmpty);
+    });
+  });
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/endpoints/dw_crud_endpoint_guard_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/endpoints/dw_crud_endpoint_guard_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:test/test.dart';
+
+/// The bug this suite stands over was not a careless `try` block — it was two
+/// methods of five where the block had never been written, on an endpoint whose
+/// error handling has to be remembered once per method. Wrapping the two would
+/// have left the same trap for the sixth method someone adds next year, so the
+/// endpoint routes every method through one private `_guard`.
+///
+/// Nothing in the type system can insist on that: Serverpod fixes the shape of
+/// an endpoint method, and a body written straight into it compiles perfectly
+/// well. This test is the insistence. It reads the endpoint and fails on any
+/// public method that answers with a [DwApiResponse] without delegating to the
+/// guard — before the method reaches a project, rather than the first time its
+/// list breaks in production.
+void main() {
+  late String source;
+
+  /// Public methods declared on the endpoint that answer with a
+  /// `Future<DwApiResponse<...>>` — every CRUD call the client can make.
+  late List<RegExpMatch> declarations;
+
+  setUpAll(() async {
+    // Resolved through the package config rather than from the working
+    // directory, so the suite reads the same file wherever it is run from.
+    final uri = await Isolate.resolvePackageUri(
+      Uri.parse(
+        'package:dartway_serverpod_core_server/src/endpoints/dw_crud_endpoint.dart',
+      ),
+    );
+
+    source = File.fromUri(uri!).readAsStringSync();
+    declarations = RegExp(
+      r'^  Future<DwApiResponse<.+?>>\s+([a-zA-Z]\w*)\(',
+      multiLine: true,
+    ).allMatches(source).toList();
+  });
+
+  String bodyOf(int index) => source.substring(
+    declarations[index].start,
+    index + 1 < declarations.length ? declarations[index + 1].start : null,
+  );
+
+  test('the scan sees the endpoint it is meant to guard', () {
+    // A regex that matched nothing would let every assertion below pass
+    // without reading a line of the endpoint.
+    expect(
+      declarations.map((m) => m.group(1)),
+      containsAll(['getOne', 'getCount', 'getAll', 'saveModel', 'delete']),
+    );
+  });
+
+  test('every CRUD method runs inside the guard', () {
+    for (var i = 0; i < declarations.length; i++) {
+      final name = declarations[i].group(1);
+
+      expect(
+        bodyOf(i),
+        contains('_guard('),
+        reason:
+            'DwCrudEndpoint.$name does not delegate to _guard, so anything '
+            'thrown under it escapes as a bare 500 that names no model and '
+            'reaches no alert. Wrap the body: '
+            "_guard('$name', className, () async { ... }).",
+      );
+    }
+  });
+}

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -39,6 +39,12 @@ Don't forget to register the config in `crudConfigurations` at `DwCore.init`. If
 > tell which you meant). A config carrying hand-written save or delete logic that no server test names
 > is `crudRuleUntested`; where that test goes is `dartway-testing`.
 
+A registered config can still **fail** — a table not migrated yet, a filter naming a column the
+schema does not have. That is a different answer from "not configured", and it reads differently:
+`Unexpected error while handling the getAll request for ClubService`, with the exception and the
+stack reported to `DwAlerts`. When a list is broken, the text tells you which of the two you are
+looking at — the registration, or the query.
+
 ## accessFilter — the heart of secure-by-default
 
 Two separate questions, and until 0.3.0 they were conflated into one:


### PR DESCRIPTION
`dwCrud.getAll` and `getCount` had no `try`/`catch`, so anything thrown below them left as a bare HTTP 500. The failure was mute at both ends: on the server it never passed through `dw.alerts`, and on the client the report read

```
Failed call: dartway_serverpod_core.dwCrud.getAll
```

One endpoint serves every model in the application, so that line reads the same whichever list broke — while `className` is a parameter of the very method that failed.

## What changed

**One guard, not two more `try` blocks.** The bug was not carelessness: the wrapper has to be remembered once per method, and `getCount` and `getAll` were the two of five where it had never been written. Fixing only those leaves the same trap for the sixth method. Every method of `DwCrudEndpoint` now delegates its body to a private `_guard(operation, className, body)`, which is the endpoint's only error boundary.

- A thrown failure comes back as `DwApiResponse(isOk: false)` with the operation and the model in the text — `Unexpected error while handling the getAll request for ClubService` — and is reported through `dw.alerts` with the exception. `delete` keeps the id of the row it was about.
- **`notConfigured` and `notAuthenticated` are untouched.** They are answers, not accidents: the body returns them and they travel back out unchanged, unreported. This endpoint is the security seam ("access not configured ⇒ access denied"), so a denial must not become an error, nor an error a denial — both directions are asserted.
- **The reported stack is the stack of the throw.** `returnError` took a `stackTrace` and then reported `StackTrace.current`, so every alert from `saveModel` and `delete` pointed at the handler instead of at the code that failed. It now reports the stack it was given, falling back to its own only when it has none.
- `getOne` reported the raw `ex.toString()` as the alert headline and never went through the helper. All five methods now report the same way.

## Tests

`test/endpoints/dw_crud_endpoint_error_test.dart` drives a config that throws on the way to the rows through the real endpoint, and pins both claims:

- a failing `getAll` / `getCount` / `delete` answers `isOk: false` with the model named, reported to `dw.alerts` once;
- the first frame of the reported stack is the function that threw. Reverting the one-line fix turns that assertion into `#0 DwCrudEndpoint.returnError (…dw_crud_endpoint.dart:28:30)` — the regression it exists for;
- an unregistered model still answers `notConfigured`, and an anonymous caller `Authentication required`, with nothing reported in either case.

`test/endpoints/dw_crud_endpoint_guard_test.dart` is what makes forgetting the guard visible. Nothing in the type system can insist on it — Serverpod fixes the shape of an endpoint method and a body written straight into it compiles fine — so the suite reads the endpoint and fails on any public method answering with a `Future<DwApiResponse<…>>` that does not delegate to `_guard`, naming the method and quoting the wrapper to write. Adding an unguarded `exists` method to try it produces exactly that failure.

## Synchronisation

- `docs/2-core/crud-configs.md` — a new "When a call fails" section: a denial and a failure are different answers, and what each looks like.
- `toolkit/skills/dartway-crud-config` — the same distinction, next to the existing "not configured" note, so an agent debugging a broken list can read the difference off the text.
- `example/` and `template/` need no change and were confirmed rather than assumed: both server packages analyze with zero errors against the branch. The one stale spot was a comment in `example/`'s auth delivery test quoting the old message verbatim; it now quotes the new one, and its assertions (`isNot(contains('Unexpected error'))`) hold either way.
- `CHANGELOG.md` — the entry joins the pending `0.10.0` section. No version bump: master is already at `0.10.0` against `0.9.0` on `origin/stable`, and the carets in `example/` and `template/` are `^0.10.0` already.
- No model or protocol changed, so nothing was generated and the `manualDeserialization` patch is untouched.

Closes #108