### PR TITLE
docs(toolkit): localization is a requirement to check, not a starting state to assume

### DIFF
--- a/docs/3-flutter/ui-kit.md
+++ b/docs/3-flutter/ui-kit.md
@@ -202,11 +202,33 @@ AppText.body(context.l10n.issuesTitle)   // ✅
 AppText.body('Issues')                   // ❌ — content, nailed into a widget
 ```
 
-Every DartWay project is localized from the first day, and the skeleton arrives that way: `l10n/*.arb`,
+Every DartWay project is localized. That is a requirement on the project, and a project created by
+`dartway create` arrives satisfying it: `flutter_localizations` and `generate: true` in the pubspec,
+`l10n.yaml`, `lib/l10n/*.arb` with the generated `lib/l10n/gen/` committed beside them,
 `appLocaleProvider` (the system locale by default, switchable at runtime — and by DartWay Studio over
 the bridge), `context.l10n` inside widgets, `appL10n` for the code that runs outside the tree, such as
-notification bodies and error toasts. One language means one `.arb` file and costs nothing; adding
-localization afterwards means walking every screen, which is why it is not decided per project.
+notification bodies and error toasts.
+
+If your app does not have that wiring, putting it in is the first thing to fix rather than something
+to live with — and nothing will tell you: the compiler is happy, the tests pass and `dartway check`
+is silent. The symptom is one item of an otherwise English menu turning up in another language,
+because without a single place for text, the language of a string is decided by whoever typed it. One
+language means one `.arb` file and costs nothing; retrofitting localization means walking every screen
+and moving every string, which is why it is not decided per project.
+
+**Adding a string means running a generator.** A new key goes into every `.arb`, then `flutter
+gen-l10n` regenerates the typed `AppLocalizations`. It is the project's second and last generator —
+`serverpod generate` is the other — and like that one it is a separate CLI rather than `build_runner`,
+it runs when the `.arb` files change rather than on every save, and **its output is committed**, for
+the same reason the generated protocol is: a tree that only compiles after somebody remembers to run
+a generator is broken for whoever cloned it.
+
+**A widget test carries a requirement on its environment.** A tree that renders localized text needs
+`localizationsDelegates`, `supportedLocales` **and an explicit `locale:`** — without the delegates the
+first `context.l10n` fails a null check, and without the locale the test resolves against the machine
+it runs on, so an assertion on the app's text passes for its author and fails for the next person to
+clone the repository. The skeleton puts all three in its `test/support/` harness, once, rather than in
+every test file.
 
 **Yes, this costs you `const`.** A widget that displays a localized string cannot be `const` — the
 value is resolved from the context at runtime. The boundary simply moves one level down: `const Icon`,

--- a/example/dartway_example_flutter/test/support/example_test_core.dart
+++ b/example/dartway_example_flutter/test/support/example_test_core.dart
@@ -99,6 +99,13 @@ extension ExampleFeaturePump on WidgetTester {
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          // Explicit, and not a detail: left out, the tree resolves against the
+          // locale of the machine running the test, so `find.text('Save')`
+          // asserts on whichever language that machine happened to pick. The
+          // suite then passes for whoever wrote it and fails for the next
+          // person to clone the repository, with a diff that mentions no
+          // locale. Pin it to the language the assertions are written in.
+          locale: const Locale('en'),
           home: DwNotificationsListener(
             handlers: {DwUiNotification: DwUiNotificationHandler()},
             child: Scaffold(body: child),

--- a/template/dartway_starter_flutter/test/support/app_test_core.dart
+++ b/template/dartway_starter_flutter/test/support/app_test_core.dart
@@ -99,6 +99,13 @@ extension AppFeaturePump on WidgetTester {
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          // Explicit, and not a detail: left out, the tree resolves against the
+          // locale of the machine running the test, so `find.text('Save')`
+          // asserts on whichever language that machine happened to pick. The
+          // suite then passes for whoever wrote it and fails for the next
+          // person to clone the repository, with a diff that mentions no
+          // locale. Pin it to the language the assertions are written in.
+          locale: const Locale('en'),
           home: DwNotificationsListener(
             handlers: {DwUiNotification: DwUiNotificationHandler()},
             child: Scaffold(body: SingleChildScrollView(child: child)),

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -42,11 +42,17 @@ A project may add a fourth one, `*_shared` — pure Dart for code that has to be
 5. **Naming.** Classes — at least 2 words (`UserProfile`, not `User`). Variables are fully descriptive and match the type (`userProfile`, `userProfileId`). Fields relating to a user always carry the word Profile: `userProfileId`, `authorProfileId`, `updatedByProfileId`. Forbidden: `id`/`data`/`info`/`obj`/`temp`/`val`/`item`/`x`.
 6. **Done = audit + a description next to the code.** A feature is not finished until `dartway-finish` has been run: an audit of the diff against the cleanliness contract, and a reconciliation of the feature's description with the new behavior. **The description lives in the code, not in a separate doc:** a screen's behavior — in the `DwFeatureSpec` of the feature widget, the server-side agreements — in the doc comments above the CRUD config. We do not keep separate "a doc per feature" files: a description far from the code drifts from it on the very first edit, and it drifts silently — the code compiles while the doc lies. Verified on a production project: a feature's doc described an API that had not been in the code for a year, and the agent wrote non-working code from it.
 
-## Code generation: not used by default
+## Code generation: two sanctioned generators, and no `build_runner`
 
-The only generator in the project is **`serverpod generate`** (models and client). It is a separate CLI, not `build_runner`, and it is unavoidable. Being a separate CLI is also why its output has to be re-formatted afterwards — it carries its own `dart_style`, and the sequence that keeps that from flooding every diff is in the Server section below (`serverpod generate` → `create-migration` → `dart format`, in that order).
+The project has exactly two: **`serverpod generate`** (models and the client package) and **`flutter gen-l10n`** (the typed `AppLocalizations` from `lib/l10n/*.arb`). Both are unavoidable — the first because the wire is generated, the second because the localization law in the Flutter section is not obeyable without it — and both share the same three properties.
 
-Everything else is written by hand:
+- **A separate CLI, not `build_runner`.** Neither one watches the tree, and neither is part of the edit loop: `serverpod generate` runs when a model's YAML changes, `flutter gen-l10n` when an `.arb` changes. Nothing runs on save.
+- **The output is committed.** The generated protocol is in the repository and so is `lib/l10n/gen/`, for the same reason: a tree that compiles only after somebody remembers to run a generator is a tree that is broken for whoever cloned it, and broken with an error that blames their code.
+- **They are run by hand, so they can be forgotten.** An `.arb` edited without a `gen-l10n` run gives `undefined getter` on a key that is plainly there — the same trap as a forgotten `serverpod generate`, and it reads as a typo rather than as a missing step.
+
+`serverpod generate` being a separate CLI is also why its output has to be re-formatted afterwards — it carries its own `dart_style`, and the sequence that keeps that from flooding every diff is in the Server section below (`serverpod generate` → `create-migration` → `dart format`, in that order). `flutter gen-l10n` ships no formatter of its own and needs no such step.
+
+Everything beyond those two is written by hand:
 
 - **providers and state** — plain `Provider` / `NotifierProvider`, no `riverpod_generator`. A family key is a record (`({int courseId, int? parentId})`): it has meaningful equality by construction, which is exactly what the generator is wanted for;
 - **state data classes** — a plain immutable class with `copyWith` and `==`, no `freezed`. Domain models already arrive generated from Serverpod;
@@ -260,6 +266,23 @@ Live migrations (delete an entry once no project is on the old shape):
   that a provider named in tests through `overrideWith` stays a named provider, it just changes
   address.
 
+- **An unlocalized app → the localization law (Flutter section).** *You have the old shape if:*
+  `grep -c flutter_localizations __FLUTTER_PKG__/pubspec.yaml` returns 0, `__FLUTTER_PKG__/lib/l10n/`
+  does not exist, or `grep -r 'context\.l10n' __FLUTTER_PKG__/lib` finds nothing while the widgets
+  are full of readable strings. Any one of the three is enough, and none of them makes anything fail
+  — which is why this migration exists at all. *Target:* the wiring the law lists, and every
+  user-visible string coming from `context.l10n` or `appL10n`. *What has accumulated:* **the wiring
+  goes in one commit, the strings screen by screen.** The wiring is small and mechanical — the
+  pubspec, `l10n.yaml`, one `.arb` in the project's own language, the locale provider, the delegates
+  on `MaterialApp`, the test harness — and half-present wiring is the state that has no honest
+  reading. The strings are not small: one production app carried around 450 of them across some 150
+  files, so they move as you touch a screen, like any other legacy. Two things to expect on the way
+  in. Every widget test that builds its own `MaterialApp` starts failing at the first lookup, all in
+  the same way, because a tree with no delegates has no `AppLocalizations` to find — fix it in the
+  shared harness, not in each test. And the first `.arb` is not automatically English: write it in
+  whatever language the app's strings are already in, or the migration turns into an unasked-for
+  translation.
+
 ## Skills and commands
 
 - Skills (`.claude/skills/`): `dartway-run`, `dartway-requirements`, `dartway-plan`, `dartway-clean-code`, `dartway-navigation`, `dartway-feature-scaffold`, `dartway-crud-config`, `dartway-ui-kit`, `dartway-data-layer`, `dartway-models`, `dartway-push-delivery`, `dartway-testing`, `dartway-finish` — loaded by relevance to the task.
@@ -298,7 +321,13 @@ Nothing else may sit at the top level, and nothing may carry one of those names 
 - **Data (the data layer):** access only through `dw.repo` — reads are providers under the native `ref.watch`/`read`/`refresh` (`dw.repo.model`/`maybeModel`/`modelList`), writes are `dw.repo.saveModel`/`deleteModel`. Lists — `dwBuildListAsync(loadingItemsCount:)`; narrowing by query — `backendFilter`, local filtering you do yourself with `.where` in the widget. The contract — `dartway-data-layer`, creating a feature — `dartway-feature-scaffold`.
 - **`ProviderScope` is not written by the app.** The only one belongs to `DwAppRunner`; tests may create their own with `overrides:`. A nested scope in the widget tree looks like it works — widgets under it do read the override — but a provider reaching the same provider through `Ref` starts from the root container and silently gets the base value instead: no exception, no warning, just a different value. **A value that must differ per subtree travels as a family key or a constructor argument**, not through a scope. Enforced by `forbidden_provider_scope` (`dartway_lints`) — `riverpod_lint`'s own rule for this cannot help, it only understands generated providers.
 - **The UI Kit is the only source of styles:** in the zones and in `shared/`, direct `Color`/`TextStyle`/`BorderRadius`/`context.textTheme`/`context.colorScheme` are forbidden; the only import is `ui_kit.dart`. Skill — `dartway-ui-kit`.
-- **Every project is localized, and user-visible text is never written in code.** The skeleton arrives with it wired: `l10n/*.arb`, `appLocaleProvider` (system locale by default, switchable at runtime and by Studio over the bridge), `context.l10n` in widgets and `appL10n` for code outside the tree — notification bodies, error toasts. A project with one language keeps one `.arb` and pays nothing; adding localization later means walking every screen, which is why it is not a choice made per project.
+- **Every project is localized, and user-visible text is never written in code.** This is a requirement on the project, not a report on how it began. **Check that the wiring is actually there, and if it is not, putting it there is the first thing fixed — not something to live with.** What has to be present: `flutter_localizations` and `generate: true` in the Flutter pubspec, `l10n.yaml` and `lib/l10n/*.arb` with its generated output committed beside them, `appLocaleProvider` (system locale by default, switchable at runtime and by Studio over the bridge), `context.l10n` in widgets and `appL10n` for code outside the tree — notification bodies, error toasts.
+
+  A project created by `dartway create` arrives with all of it, and the skeleton is where to read what each piece looks like. A project that reached this methodology by another road may have none of it, and **nothing will say so**: the compiler is happy, the tests are green, `dartway check` is silent, and the app looks finished. It surfaces as one item of an otherwise consistent menu turning up in a different language — because with no single place for text, the language of a string is decided by whoever happened to type it. That is a human noticing a screenshot, which is not a check.
+
+  A project with one language keeps one `.arb` and pays nothing; retrofitting localization means walking every screen and moving every string, which is why it is not a choice made per project. New strings are added to **every** `.arb`, then `flutter gen-l10n` is run and its output committed (see "Code generation" above).
+
+  **A widget test mounts three things, not two:** `localizationsDelegates`, `supportedLocales`, **and an explicit `locale:`**. The third is the one that reads as pedantry — without it the test resolves against the locale of the machine it runs on, so an assertion on the template's text passes for the author and fails for whoever else runs the suite. The skeleton's `test/support/` harness does it in one place; the rest is in `dartway-testing`.
 
   The reason is one sentence and it covers both places the rule bites: **a string the user reads is content, not decoration** — so `ui_kit` may not hold it (the kit does not own meaning) and a feature may not hardcode it (the feature does not own the language). `AppText.body(context.l10n.issuesTitle)`, never `AppText.body('Issues')`.
 

--- a/toolkit/skills/dartway-testing/SKILL.md
+++ b/toolkit/skills/dartway-testing/SKILL.md
@@ -143,6 +143,34 @@ widget test has no business answering.
 process and it cannot be replaced, so the second test file in a run would otherwise meet
 `Dw is already initialized` or a `LateInitializationError`.
 
+### Localization is mounted with a locale, not just with delegates
+
+Every user-visible string in a DartWay app comes from `context.l10n`, so a widget test needs the
+tree to be able to answer that lookup. The harness mounts **three** things, and the third is the one
+that gets left out:
+
+```dart
+MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  // Explicit, because the default is the locale of the machine running the test.
+  locale: const Locale('en'),
+  home: /* … */,
+)
+```
+
+- **Without the delegates**, the first `context.l10n` fails a null check, and the failure lands where
+  the subject fails to build rather than where the localization is missing. When localization is
+  introduced into a living app this hits every test at once — one app saw 149 of 385 turn red in one
+  step, all with the same error. That is one line in the shared harness, not a line per test file.
+- **Without an explicit `locale:`**, the tree resolves against the platform locale, so
+  `find.text('Save')` asserts on whichever language the machine happened to pick. The suite is green
+  for the person who wrote it and red for the next person to clone the repository, with a diff that
+  says nothing about locales. Pin it to the language the assertions are written in.
+
+A test that needs another language passes that locale instead — that is the point of it being a
+value in one place rather than an ambient default.
+
 ### The core is needed to *render*, not only to tap
 
 `dw.action(...)` is constructed inside `build`. A feature therefore touches `dw` while building,
@@ -265,4 +293,6 @@ and at the layer where it lives**". That is what `dartway-finish` asks.
 - Reaching for `dw.repo.localWrites` to observe a save.
 - Asserting the number of server calls on a path where a read failed.
 - `pump` instead of `pumpAndSettle` after typing into `AppTextFormField`.
+- A `MaterialApp` in a test with the localization delegates but no `locale:` — green on the
+  author's machine, red on the next one.
 - Keeping a callback parameter on a widget "so it can be tested".

--- a/toolkit/skills/dartway-ui-kit/SKILL.md
+++ b/toolkit/skills/dartway-ui-kit/SKILL.md
@@ -187,14 +187,14 @@ AppText.body(post.description)
 AppText.caption('${date.dayLabel} · ${date.timeLabel}')
 ```
 
-**All user-facing text comes from l10n, not from a string literal.** The skeleton is localized (en/ru); `AppText.body('Book a spot')` with a hardcoded string desyncs the feature from the rest of the app. Take the text from `context.l10n`:
+**All user-facing text comes from l10n, not from a string literal.** Every DartWay project is localized — a requirement, not a description of how the project started, and if the wiring is missing it is fixed before the strings pile up (see the localization law and its migration entry in `CLAUDE.md`). `AppText.body('Book a spot')` with a hardcoded string desyncs the feature from the rest of the app. Take the text from `context.l10n`:
 
 ```dart
 final l10n = context.l10n;
 AppText.body(l10n.bookSpot)
 ```
 
-A new string = add a key to **both** ARBs (`lib/l10n/app_en.arb` and `app_ru.arb`) and run `flutter gen-l10n`. Only non-text stays a literal in the UI (icons, debug labels behind `kDebugMode`).
+A new string = add a key to **every** ARB the project keeps (the skeleton ships `lib/l10n/app_en.arb` and `app_ru.arb`), run `flutter gen-l10n`, and **commit its output** — `lib/l10n/gen/` belongs in the repository for the same reason the generated protocol does. `gen-l10n` is a separate CLI, not `build_runner`: it runs when an `.arb` changes, not on every save. Only non-text stays a literal in the UI (icons, debug labels behind `kDebugMode`).
 
 ```dart
 // ui_kit/theme/app_text.dart


### PR DESCRIPTION
Addresses #119.

## The defect

`toolkit/CLAUDE.md` states the law — every project is localized, user-visible text is never written in code — and settles it in the same breath: *"The skeleton arrives with it wired."*

The skeleton is not lying. `template/dartway_starter_flutter` really does ship `lib/l10n/app_en.arb`, `app_ru.arb`, `lib/l10n/gen`, `l10n.yaml`, `flutter_localizations`, `generate: true` and 16 files using `context.l10n`; a project created today by `dartway create` gets all of it. **The generalisation is what is wrong.** A claim about the skeleton was written as though it were a claim about every project, and a project that reached this methodology by another road may have none of it. In one app there was no `l10n/`, no `.arb`, no `flutter_localizations`, not one `context.l10n` — around 450 user-visible strings across some 150 files, written straight into the widgets, with nobody having broken a rule. The rule described a starting state that never arrived, so there was nothing to break.

It is silent in the way that matters: the compiler is happy, the tests are green, `dartway check` says nothing. What surfaced it was a human noticing one item of an otherwise consistent menu in the wrong language — because with no single place for text, the language of a string is decided by whoever typed it.

## What changed

**The law is now a requirement, not a report on how the project began** (`toolkit/CLAUDE.md`). It lists what has to be present and says plainly that if it is not there, wiring it is the first thing fixed rather than something to live with. What is true is kept — the skeleton does arrive wired, and it is where to read what each piece looks like — but it no longer answers the question on behalf of a project that did not come from the skeleton.

**A migration entry** under "Migrations: a project that lives by an older version of a law", in the shape that section requires: how to tell (three greppable signs, none of which makes anything fail), what the target is, and what to do with what has accumulated — the wiring in one commit because half-present wiring has no honest reading, the strings screen by screen like any other legacy. It also warns about the two things that bite on the way in: every widget test with its own `MaterialApp` failing at once, and the first `.arb` not being automatically English.

**`flutter gen-l10n` is named as the second sanctioned generator.** The old line — *"The only generator in the project is `serverpod generate`"* — was false against the very skeleton the toolkit ships, and read literally it pushed a reader towards hand-writing `AppLocalizations`: losing the compile-time check on keys and hand-rolling plural categories per language. It now carries the same caveats `serverpod generate` does — a separate CLI rather than `build_runner`, run when the `.arb` files change rather than inside the edit loop, and **its output is committed**, for the reason the generated protocol is.

**The testing rule** (`toolkit/skills/dartway-testing`, plus a line in the law and one in "Common mistakes"): a widget test mounts the delegates, the supported locales, **and an explicit `locale:`**. Without the delegates the first `context.l10n` fails a null check — which is how 149 of 385 tests went red in one step when localization was introduced into a living app. Without the locale the tree resolves against the machine running the test, so an assertion on the app's own text passes for its author and fails for the next person to clone the repository, with a diff that mentions no locale.

**The two test harnesses now pin the locale** so the skeleton demonstrates the rule rather than only stating it — `template/dartway_starter_flutter/test/support/app_test_core.dart` and `example/dartway_example_flutter/test/support/example_test_core.dart`. Both already mounted the delegates and the supported locales and set no locale. This is the only code in the change. Verified rather than assumed: flipping the pin to `Locale('ru')` turns the template's admin-settings tests red, which is exactly the failure that was waiting for somebody else's machine.

**The echoes** the synchronisation law asks for: `toolkit/skills/dartway-ui-kit` (the "skeleton is localized" claim, and the `gen-l10n` step, which now says to commit its output) and `docs/3-flutter/ui-kit.md` (same rewording, plus the generator and the testing requirement).

## Deferred, deliberately

The issue's second ask — a `dartway check` rule along the lines of `l10nNotWired`, catching a project that has already drifted — **is not in this PR.** Evgenii scoped this one to making the written word true; the checker rule is a separate decision about growing the CLI, and the issue should stay open for it. Hence "Addresses", not "Closes".

## Checks

- `flutter analyze` clean in `template/dartway_starter_flutter` and `example/dartway_example_flutter`.
- `flutter test` green in both: 13 and 7.
- `framework-finish`: no drift. Nothing under `packages/` changed, so there is no public API change, no version bump and no caret to move; the bridge is untouched. The toolkit invariant was read rather than grepped — the new text uses `__FLUTTER_PKG__` for paths, names no project, and the one language named for illustration was made neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
