### PR TITLE
feat(core): a business rule can refuse a DTO action without raising an alert

### DIFF
--- a/docs/2-core/crud-configs.md
+++ b/docs/2-core/crud-configs.md
@@ -106,6 +106,17 @@ reads the same whichever list broke.
 Nothing about the failure text describes the database. What threw goes to the operator, never to the
 client — the same rule the save path states below for `DatabaseException`.
 
+**A business rule saying no is a denial, and every config has a channel for it that is not a
+throw.** In `DwSaveConfig` the rule hooks return the error text (`validateSave` and the ones inside
+the transaction — see the lifecycle below). In `DwDtoActionConfig` it is `validateAction` before the
+transaction opens, and `throw DwActionRejection('This message was already deleted')` from inside
+`actionProcessing`, where throwing is the only thing that rolls a transaction back. Either way the
+caller reads the text the rule was written in, word for word, and nothing reaches `dw.alerts`.
+
+Refusing with a bare `throw Exception('Not enough rights to delete this message')` is the other
+thing. The text is lost on the way out, the caller is shown "Unexpected error while handling the
+saveModel request", and the operator is paged for a rule doing its job.
+
 ## Saving: one lifecycle for insert and update
 
 `DwSaveConfig<T>` has no separate create and update paths. `saveContext.isInsert` tells the hooks
@@ -344,7 +355,10 @@ that is not about a single row.
 Two intermediate steps come first, and skipping them is the usual mistake:
 
 1. **A DTO config.** `DwDtoActionConfig<DTO>` runs an arbitrary transaction from a serializable
-   model that has no table and returns the models it touched — an action shaped as a save.
+   model that has no table and returns the models it touched — an action shaped as a save. Its
+   rules refuse through `validateAction` (before the transaction, return the error text) or
+   `DwActionRejection` (thrown from inside it, rolls the transaction back), never through a bare
+   exception — see [when a call fails](#when-a-call-fails).
    `DwDtoGetListConfig<DTO, Model>` serves a list of projections built from real rows.
 2. **A model for the event.** If the operation is a fact worth recording — an auth attempt, a
    balance movement — write the fact as a row and put the logic in its save config. That is how

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -20,6 +20,24 @@ while `className` sat right there in the arguments.
 - `getOne` reported the raw `ex.toString()` as the alert headline; all five methods now report the
   same way.
 
+**A `DwDtoActionConfig` can now refuse without crashing.** `actionProcessing` had no way to say no
+except `throw`, and the endpoint's error boundary treats a throw as an incident: the user read
+"Unexpected error while handling the saveModel request", the text the rule was written in was lost
+on the way out, and the operator was paged. One production install collected twenty such alerts in
+two days, every one of them a rule doing its job.
+
+- **New: `validateAction`** — `Future<String?> Function(Session, DTO)`, run before the transaction
+  opens. Return the error text to refuse, or null to let the action through. The same contract as
+  `DwSaveConfig.validateSave`.
+- **New: `DwActionRejection`** — throw it from inside `actionProcessing`, where there is nothing to
+  return the text in and where throwing is the only thing that rolls a Serverpod transaction back.
+  The transaction rolls back and the caller is answered with the message.
+- Both are **answers**: the text reaches the client verbatim and nothing is reported to `dw.alerts`,
+  the way `notConfigured` and `notAuthenticated` already behaved. Any other exception is still a
+  failure — wrapped in the guard's message and alerted, unchanged.
+- Nothing to migrate: a config that refuses by throwing keeps working exactly as before. It now has
+  a way to do it right.
+
 This release also carries the Flutter side's optional local-storage contract for `dw.repo` —
 `DwRepoLocalReads` and `DwRepoLocalWrites`, declared on the core as a plugin. Nothing changes for an
 app that declares no store. See the changelog of `dartway_serverpod_core_flutter`.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
@@ -6,9 +6,68 @@ import 'package:serverpod/serverpod.dart';
 import '../domain/dw_crud_entity.dart';
 import '../../../private/dw_singleton.dart';
 
+/// A refusal by a business rule, thrown from inside
+/// [DwDtoActionConfig.actionProcessing].
+///
+/// The action runs inside a transaction and returns the models it touched, so
+/// a rule that discovers halfway through that the answer is no — the message
+/// was deleted a second ago, the track belongs to somebody else — has nothing
+/// to return its refusal in; and throwing is in any case the only way to roll
+/// a Serverpod transaction back. This is the throw that means "no", as opposed
+/// to the throw that means "broken": [DwDtoActionConfig.save] catches it, the
+/// transaction rolls back, and the caller is answered with [message] word for
+/// word. No alert is raised — a rule saying no is not an incident.
+///
+/// ```dart
+/// actionProcessing: (session, transaction, dto) async {
+///   final post = await ChatPost.db.findById(session, dto.postId,
+///       transaction: transaction);
+///   if (post == null) throw const DwActionRejection('This message is gone');
+///   ...
+/// }
+/// ```
+///
+/// A rule that can be answered before the transaction opens belongs in
+/// [DwDtoActionConfig.validateAction] instead, which returns its text rather
+/// than throwing it — the same answer to the caller, with no exception in the
+/// way.
+///
+/// Thrown anywhere else, it is an ordinary exception with the ordinary
+/// consequences: nothing outside [DwDtoActionConfig.save] knows what it means.
+class DwActionRejection implements Exception {
+  const DwActionRejection(this.message);
+
+  /// The text the caller is shown, verbatim.
+  final String message;
+
+  @override
+  String toString() => 'DwActionRejection: $message';
+}
+
+/// An action shaped as a save: an arbitrary transaction driven by a DTO that
+/// has no table of its own.
+///
+/// The lifecycle, in order:
+/// 1. [validateAction]       — the rules, before the transaction opens
+/// 2. [actionProcessing]     — the work itself, inside the transaction
+/// 3. [afterSaveSideEffects] — notifications and async tasks, outside it; the
+///                             caller does not wait for them
+///
+/// **Refusing and failing are different answers, and the user can tell them
+/// apart.** A refusal carries the text its author wrote — "this message is
+/// gone", "you have no access to this track" — and passes through the
+/// endpoint untouched. A failure is an incident: the guard around every CRUD
+/// method replaces whatever was thrown with "Unexpected error while handling
+/// the saveModel request for X" and reports it to [DwAlerts].
+///
+/// So refuse through [validateAction], or by throwing [DwActionRejection]
+/// from inside [actionProcessing] — and not by throwing anything else. A bare
+/// `throw Exception('Not enough rights to delete this message')` loses its
+/// text on the way out and pages the operator instead of informing the user.
 class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
   const DwDtoActionConfig({
     this.allowAnonymous = false,
+    this.validateAction,
     required this.actionProcessing,
     this.afterSaveSideEffects,
   });
@@ -21,6 +80,25 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
   /// genuinely precedes the login screen.
   final bool allowAnonymous;
 
+  /// The rules that can be answered before any work starts: who the caller is,
+  /// what they are allowed to do, whether the DTO makes sense. Return the
+  /// error text to refuse the action — the caller gets it verbatim, nothing is
+  /// reported to [DwAlerts], and [actionProcessing] never runs — or null to
+  /// let it through.
+  ///
+  /// Runs **before** the transaction opens, so it reads the database as it was
+  /// a moment ago. A rule two callers can race for — a seat, a slot, a
+  /// balance — is checked inside [actionProcessing] instead, where the
+  /// transaction is, and refused with [DwActionRejection].
+  final Future<String?> Function(Session session, DTO dto)? validateAction;
+
+  /// The action itself, inside a transaction: does the work and returns the
+  /// models it touched, so the client can refresh them.
+  ///
+  /// Throw [DwActionRejection] to refuse — the transaction rolls back and the
+  /// caller is told why, in the words written here. Any other exception is a
+  /// failure: it rolls the transaction back too, but the caller is handed the
+  /// generic "unexpected error" message and the operator is paged.
   final Future<List<DwModelWrapper>> Function(
     Session session,
     Transaction transaction,
@@ -34,8 +112,10 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
   /// **Nobody waits for this hook, so nothing it does can reach the caller —
   /// including its failure.** The response has already been built and says
   /// `isOk`. A throw is reported to [DwAlerts] with the DTO's name and the
-  /// stack trace, which reaches the operator and nobody else. Anything the
-  /// caller must be told about belongs in [actionProcessing].
+  /// stack trace, which reaches the operator and nobody else — a
+  /// [DwActionRejection] included, since by now there is nothing left to
+  /// refuse. Anything the caller must be told about belongs in
+  /// [actionProcessing].
   final Future<void> Function(
     Session session,
     DTO dto,
@@ -43,8 +123,15 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
   )?
   afterSaveSideEffects;
 
-  /// Runs [actionProcessing] in a transaction, then fires the side effects.
+  /// Runs [validateAction], then [actionProcessing] in a transaction, then
+  /// fires the side effects.
   Future<DwApiResponse<DwModelWrapper>> save(Session session, DTO dto) async {
+    // --- validateAction (before the transaction) ---
+    if (validateAction != null) {
+      final error = await validateAction!(session, dto);
+      if (error != null) return _rejectedResponse(error);
+    }
+
     // --- transaction block ---
     List<DwModelWrapper> updatedModels = [];
 
@@ -52,6 +139,10 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
       await session.db.transaction((transaction) async {
         updatedModels = await actionProcessing(session, transaction, dto);
       });
+    } on DwActionRejection catch (rejection) {
+      // A rule said no. The transaction is rolled back; this is an answer to
+      // the caller, not a failure — no alert, and the text is the author's.
+      return _rejectedResponse(rejection.message);
     } on DatabaseException catch (e, stackTrace) {
       dw.alerts.reportError(
         'Database error while running the ${DTO.toString()} action',
@@ -76,6 +167,16 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
       updatedModels: updatedModels,
     );
   }
+
+  /// A refusal, answered in the words the rule was written in.
+  ///
+  /// Returned rather than thrown, which is the whole point: the endpoint's
+  /// guard reports what reaches it and rewrites the message, so a refusal that
+  /// travels as an exception arrives at the client as "Unexpected error" and
+  /// at the operator as an incident. `notConfigured` and `notAuthenticated`
+  /// take the same route out.
+  DwApiResponse<DwModelWrapper> _rejectedResponse(String message) =>
+      DwApiResponse(isOk: false, value: null, error: message);
 
   /// Runs [afterSaveSideEffects] with nobody waiting for it, and makes sure a
   /// failure still lands somewhere — unawaited, it would otherwise go to the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/crud/dw_dto_action_config_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/crud/dw_dto_action_config_test.dart
@@ -1,0 +1,272 @@
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:dartway_serverpod_core_server/src/endpoints/dw_crud_endpoint.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+/// The distinction this file is about: a rule that says no, and a server that
+/// broke. Both leave `actionProcessing` without a result, and until the
+/// rejection channel existed both arrived at the user as "Application error"
+/// and at the operator as an alert.
+const _rejectionText = 'This message was already deleted';
+const _validationText = 'You have no access to this track';
+
+/// A failure of the kind alerts exist for: nothing to do with the caller.
+Never theDatabaseIsGone() =>
+    throw StateError('relation "chat_post" does not exist');
+
+/// The DTO an action is driven by: serializable, and deliberately not a
+/// [TableRow] — that is the branch of `saveModel` that reaches a DTO config.
+class TrackAction implements SerializableModel {
+  @override
+  Map<String, dynamic> toJson() => const {};
+}
+
+/// The wrapper as it arrives from a client, with the class name the endpoint
+/// looks its config up by.
+///
+/// The name normally comes from the serialization manager, which only knows
+/// the models of a generated protocol; a test DTO is not in one, so it is
+/// stated here instead. Nothing else about the wrapper changes.
+class TestWrapper extends DwModelWrapper {
+  TestWrapper(SerializableModel object, this._className)
+    : super(object: object);
+
+  final String _className;
+
+  @override
+  String get className => _className;
+}
+
+class TestUserProfile implements TableRow<int?> {
+  @override
+  int? get id => 1;
+
+  @override
+  Table<int?> get table => _userProfileTable;
+
+  @override
+  Map<String, dynamic> toJson() => const {};
+}
+
+class TestTable extends Table<int?> {
+  TestTable(String name) : super(tableName: name) {
+    userIdentifier = ColumnString(DwCoreConst.userIdentifierColumnName, this);
+  }
+
+  late final ColumnString userIdentifier;
+
+  @override
+  List<Column> get columns => [id, userIdentifier];
+}
+
+final _userProfileTable = TestTable('test_user_profile');
+
+/// A transaction handle that only has to exist: the action receives it and
+/// hands it to the repositories it reads through, none of which run here.
+class FakeTransaction implements Transaction {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('The action must not use the transaction here');
+}
+
+/// Runs the transaction body and lets whatever it throws travel outwards —
+/// which is the one behaviour of a real transaction these tests depend on, and
+/// the reason a refusal has to be thrown rather than returned.
+class FakeDatabase implements Database {
+  @override
+  Future<R> transaction<R>(
+    TransactionFunction<R> transactionFunction, {
+    TransactionSettings? settings,
+  }) async => transactionFunction(FakeTransaction());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('The action must not reach the database here');
+}
+
+/// A session carrying its authentication and a database that can open a
+/// transaction. Anything else it is asked for is a test reaching further than
+/// it meant to.
+class TestSession implements Session {
+  TestSession.signedIn(int userProfileId)
+    : userIdentifier = userProfileId.toString();
+
+  final String userIdentifier;
+
+  @override
+  AuthenticationInfo? get authenticated =>
+      AuthenticationInfo(userIdentifier, const <Scope>{}, authId: 'test');
+
+  @override
+  Database get db => FakeDatabase();
+
+  @override
+  void log(
+    String message, {
+    LogLevel? level,
+    dynamic exception,
+    StackTrace? stackTrace,
+  }) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('The endpoint must not reach the database here');
+}
+
+void main() {
+  // `DwCore.init` resolves class names through `Serverpod.instance`, so the
+  // core cannot be initialized before a Serverpod object exists. Constructing
+  // one is enough; nothing is started and no socket is touched.
+  Serverpod(
+    ['--mode', 'test', '--role', 'monolith'],
+    Protocol(),
+    Endpoints(),
+    config: ServerpodConfig.defaultConfig(),
+  );
+
+  final reports = <String>[];
+  final endpoint = DwCrudEndpoint();
+  final session = TestSession.signedIn(42);
+
+  // Set by the actions, read by the tests: what actually ran.
+  var actionRan = false;
+  var sideEffectRan = false;
+
+  DwCore.init<TestUserProfile>(
+    userProfileTable: _userProfileTable,
+    crudConfigurations: [],
+    dtoConfigurations: [
+      // Refuses before the transaction opens, by returning the text.
+      DwDtoActionConfig<TrackAction>(
+        validateAction: (session, dto) async => _validationText,
+        actionProcessing: (session, transaction, dto) async {
+          actionRan = true;
+          return [];
+        },
+      ),
+      // Refuses from inside the transaction, by throwing the rejection.
+      DwDtoActionConfig<RejectingAction>(
+        actionProcessing: (session, transaction, dto) async =>
+            throw const DwActionRejection(_rejectionText),
+        afterSaveSideEffects: (session, dto, updatedModels) async =>
+            sideEffectRan = true,
+      ),
+      // Breaks, the way a server breaks.
+      DwDtoActionConfig<BrokenAction>(
+        actionProcessing: (session, transaction, dto) async =>
+            theDatabaseIsGone(),
+      ),
+      // Does its work and says yes — the control for all of the above.
+      DwDtoActionConfig<PassingAction>(
+        validateAction: (session, dto) async => null,
+        actionProcessing: (session, transaction, dto) async {
+          actionRan = true;
+          return [];
+        },
+      ),
+    ],
+    channelConfigurations: [],
+    userProfileConstructor: (session, {required registrationRequest}) async =>
+        throw UnimplementedError(),
+    dwAlerts: DwAlerts.init(logFunction: reports.add),
+  );
+
+  setUp(() {
+    reports.clear();
+    actionRan = false;
+    sideEffectRan = false;
+  });
+
+  /// Sends [dto] the way a client does: wrapped, under the name of its own
+  /// type — which is the name its config is registered under.
+  Future<DwApiResponse<DwModelWrapper>> saveModel(TrackAction dto) =>
+      endpoint.saveModel(
+        session,
+        wrappedModel: TestWrapper(dto, dto.runtimeType.toString()),
+      );
+
+  group('a refusal from validateAction', () {
+    test('answers with the text the rule was written in', () async {
+      final response = await saveModel(TrackAction());
+
+      expect(response.isOk, isFalse);
+      expect(response.error, _validationText);
+    });
+
+    test('is not reported to dw.alerts', () async {
+      await saveModel(TrackAction());
+
+      expect(reports, isEmpty, reason: 'a refusal is an answer, not an error');
+    });
+
+    test('stops the action before it runs', () async {
+      await saveModel(TrackAction());
+
+      expect(actionRan, isFalse);
+    });
+  });
+
+  group('a refusal thrown from inside the action', () {
+    test('answers with the text the rule was written in', () async {
+      final response = await saveModel(RejectingAction());
+
+      expect(response.isOk, isFalse);
+      // Verbatim, and in particular not rewritten by the endpoint's guard:
+      // the whole point is that the user reads this and not "Unexpected
+      // error while handling the saveModel request".
+      expect(response.error, _rejectionText);
+    });
+
+    test('is not reported to dw.alerts', () async {
+      await saveModel(RejectingAction());
+
+      expect(reports, isEmpty);
+    });
+
+    test('does not fire the side effects', () async {
+      await saveModel(RejectingAction());
+      // The hook is unawaited, so give the microtask that would run it a turn.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sideEffectRan, isFalse);
+    });
+  });
+
+  group('a real failure', () {
+    test('is still wrapped in the guard\'s message', () async {
+      final response = await saveModel(BrokenAction());
+
+      expect(response.isOk, isFalse);
+      expect(response.error, contains('Unexpected error'));
+      expect(response.error, contains('saveModel'));
+      expect(response.error, contains('BrokenAction'));
+    });
+
+    test('is still reported to dw.alerts, with the cause', () async {
+      await saveModel(BrokenAction());
+
+      expect(reports, hasLength(1));
+      expect(reports.single, contains('BrokenAction'));
+      expect(reports.single, contains('relation'));
+    });
+  });
+
+  group('an action that says yes', () {
+    test('still answers isOk, and alerts nobody', () async {
+      final response = await saveModel(PassingAction());
+
+      expect(response.isOk, isTrue);
+      expect(response.error, isNull);
+      expect(actionRan, isTrue);
+      expect(reports, isEmpty);
+    });
+  });
+}
+
+/// The DTOs are one class each because a config is registered under the name
+/// of its type: four behaviours, four names for the endpoint to resolve.
+class RejectingAction extends TrackAction {}
+
+class BrokenAction extends TrackAction {}
+
+class PassingAction extends TrackAction {}

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   The DartWay/Serverpod server playbook: how to write CRUD configs — DwCrudConfig<T> (one per
   model), DwGetModelConfig, DwGetModelListConfig (both require accessFilter), DwSaveConfig
   (allowSave/validateSave/beforeSaveTransaction/afterSaveTransaction/afterSaveTransform/
-  afterSaveSideEffects), DwDeleteConfig (allowDelete/afterDelete), DwModelWrapper,
+  afterSaveSideEffects), DwDeleteConfig (allowDelete/afterDelete), DwDtoActionConfig
+  (validateAction/actionProcessing, refusing with DwActionRejection), DwModelWrapper,
   Event models, the domain(pure)/app(session-aware) boundary. All server logic goes through
   configs, not through endpoints. Use when adding or changing server logic, permissions,
   validations, or side effects for a model.
@@ -382,6 +383,37 @@ Future<int> purgeStale<T extends TableRow>(Session session, Expression stale) as
 
 For **one known model**, keep using that model's own repository (`ClubSession.db.findById(...)`) — typed, public, and more readable. `dw.db` is not a replacement for it.
 
+## DwDtoActionConfig — an action that is not one model
+
+For a write that does not fit "the client saves one row": the client sends a DTO (a serializable model with **no table**), and the config runs an arbitrary transaction.
+
+```dart
+DwDtoActionConfig<CancelBooking>(
+  validateAction: (session, dto) async =>
+      session.signedInUserProfileId == null ? 'Sign in first' : null,
+  actionProcessing: (session, transaction, dto) async {
+    final booking = await Booking.db.findById(session, dto.bookingId,
+        transaction: transaction);
+    if (booking == null) throw const DwActionRejection('This booking is gone');
+    // ... the work; return the models the client should refresh
+    return DwModelWrapper.wrapMany([booking]);
+  },
+)
+```
+
+Order: `validateAction` → **the transaction opens:** `actionProcessing` → outside it, non-blocking: `afterSaveSideEffects`.
+
+**Two ways to refuse, one for each side of the transaction, and neither of them is a bare `throw`:**
+
+- `validateAction` → `Future<String?>` — the error text or null, exactly like `validateSave`. Runs **before** the transaction, so the action never starts.
+- `DwActionRejection` — thrown from inside `actionProcessing`, where there is nothing to return the text in and where throwing is the only thing that rolls a Serverpod transaction back. The transaction rolls back, and the caller gets the message verbatim.
+
+Both are **answers**: nothing is reported to `DwAlerts`, and the text reaches the client word for word.
+
+**`throw Exception('Not enough rights to delete this message')` is not a refusal — it is a crash**, and the framework treats it as one. The endpoint's error boundary replaces the text with `Unexpected error while handling the saveModel request for X` and alerts the operator. The user reads "Application error" instead of the reason, and the alert channel fills up with rules working as intended.
+
+`afterSaveSideEffects` here is the same hook as on `DwSaveConfig` and carries the same warning: nobody waits for it, so nothing it does — a `DwActionRejection` included — can reach the caller.
+
 ## A custom endpoint — the last resort
 
 Only when it does not fit into CRUD (file upload/download — often still shaped as a `FileUploadRequest` model, webhooks, heavy async processing). Document it as an exception.
@@ -391,7 +423,7 @@ Only when it does not fit into CRUD (file upload/download — often still shaped
 | The need | Where it already lives |
 |---|---|
 | The response must carry a value the row does not hold | `!persist` + `extras` + `afterSaveTransform` — "Returning a value the row does not hold" above |
-| The operation is a write that is not one model | `DwDtoActionConfig` |
+| The operation is a write that is not one model | `DwDtoActionConfig` — see above |
 | The answer is a projection over rows rather than the rows | `DwDtoGetListConfig` |
 | The response must carry the model's relations | `afterSaveTransform` re-reading with the same `include` |
 


### PR DESCRIPTION
## The problem

`DwDtoActionConfig.actionProcessing` could only say no by throwing, and `DwCrudEndpoint._guard` treats a throw as an incident. So a refusal by a business rule arrived:

- at the user as `Unexpected error while handling the saveModel request for X` — the text the rule was written in (`throw Exception('You have no access to this track')`) was lost on the way out;
- at the operator as an alert. One production install collected twenty of them in two days, every one a rule doing its job.

## The change

Two refusal channels, one for each side of the transaction — neither of them a bare throw:

- **`validateAction`** → `Future<String?>`, runs before the transaction opens. Return the error text to refuse, null to let the action through. The same contract as `DwSaveConfig.validateSave`, so a permission check does not open a transaction only to roll it back.
- **`DwActionRejection`** — thrown from inside `actionProcessing`, where there is nothing to return the text in and where throwing is the only thing that rolls a Serverpod transaction back. The transaction rolls back and the caller is answered with the message.

Both are **answers**: they leave `save()` as a returned response, so they pass through the guard untouched, reach the client verbatim and report nothing to `dw.alerts` — the way `notConfigured` and `notAuthenticated` already behaved. Any other exception is still a failure: wrapped in the guard's message and alerted, unchanged.

**Nothing to migrate.** A config that refuses by throwing keeps working exactly as before; it now has a way to do it right.

## Tests

`test/crud/dw_dto_action_config_test.dart`, nine tests through the endpoint with a fake transaction that only lets what is thrown travel outwards:

- a refusal through either channel answers with the rule's text word for word and reports nothing to `dw.alerts`;
- `validateAction` stops the action before it runs; a rejection inside the transaction stops the side effects;
- a real failure is still wrapped in `Unexpected error…` and still alerted, with the cause;
- an action that says yes still answers `isOk`.

## Synchronisation

`framework-finish` reports no drift.

- `example/` and `template/` do not use `DwDtoActionConfig` — the change is additive, and their `^0.10.0` carets are unchanged and satisfied;
- the only consumer in the monorepo is `dwPush.tokenRegistrationConfig()`, which refuses by returning; it analyzes clean;
- `toolkit/skills/dartway-crud-config` gains a `DwDtoActionConfig` section (and the hooks in its frontmatter), `docs/2-core/crud-configs.md` gains the refusal contract under "When a call fails";
- no version bump: `master` is already at `0.10.0` against `0.9.0` on `stable`, so the entry joins that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)