### PR TITLE
feat(core): a server refusal reaches the client as an answer, not an exception

### DIFF
--- a/docs/2-core/crud-configs.md
+++ b/docs/2-core/crud-configs.md
@@ -117,6 +117,12 @@ Refusing with a bare `throw Exception('Not enough rights to delete this message'
 thing. The text is lost on the way out, the caller is shown "Unexpected error while handling the
 saveModel request", and the operator is paged for a rule doing its job.
 
+**The difference travels to the client.** A refused response carries `isRefusal`, and the Flutter
+side raises it as a `DwRefusal` — shown to the user in the rule's own words, and kept out of the
+alert channel. A failure carries no such mark and stays an error the app reports. Nothing in a
+config sets the flag by hand: refusing the documented way is what sets it. See
+[error reporting](error-reporting.md#a-refusal-is-not-an-error).
+
 ## Saving: one lifecycle for insert and update
 
 `DwSaveConfig<T>` has no separate create and update paths. `saveContext.isInsert` tells the hooks

--- a/docs/2-core/error-reporting.md
+++ b/docs/2-core/error-reporting.md
@@ -54,6 +54,39 @@ Features come for free: any widget implementing `DwFeature` (see the example
 app) is picked up by `DwFeature.scanMounted()` at the moment of the error — the
 alert names the features of the screen where it happened.
 
+## A refusal is not an error
+
+A rule on the server saying no — `validateSave` returning its text, an action
+throwing `DwActionRejection`, `allowSave` refusing — comes back as a
+`DwApiResponse` marked `isRefusal`, and `dw.repo` raises it as a **`DwRefusal`**
+rather than as an ordinary exception. Three things follow, none of which the app
+has to arrange:
+
+- **the user reads the rule's own words.** `dw.action` shows `refusal.message`
+  instead of its generic `onErrorNotification` — "This message was already
+  deleted" rather than "Could not delete";
+- **the alert channel stays quiet.** The out-of-the-box policy steps over a
+  refusal the way it steps over connection blips: a rule doing its job is not an
+  incident, and twenty of them in two days is how one production channel stopped
+  being read;
+- **a custom policy still sees it**, and sorts it out by type instead of by
+  matching the message:
+
+  ```dart
+  onErrorReport: (report) {
+    if (report.error is DwRefusal) return; // the user has already been told
+    mySentry.capture(report.error, report.stackTrace);
+  },
+  ```
+
+An app can throw one itself for a rule of its own — `throw const DwRefusal('This
+file is larger than 10 MB')` — and get the same treatment. Write the message for
+a user: it reaches the screen unedited.
+
+Everything else is unchanged, and deliberately so: a `DatabaseException`, an
+exception the server's guard caught, or a call the server has no config for
+still arrive as ordinary exceptions and are still reported.
+
 ## Custom policy
 
 Set `DwConfig.onErrorReport` to receive the full `DwErrorReport` (error,

--- a/docs/3-flutter/actions.md
+++ b/docs/3-flutter/actions.md
@@ -164,6 +164,14 @@ the pipeline and [features and specs](features-and-specs.md) for where the featu
 Give an action an explicit `label` when its notification texts are generic — twelve alerts titled
 "Action failed: Saved" tell you nothing.
 
+### Unless the server refused, which is not a failure
+
+A rule on the server that said no arrives as a **`DwRefusal`**, and the action treats it as the
+answer it is: the user is shown `refusal.message` — the words the rule was written in, not the
+action's `onErrorNotification` — and the framework's alerting leaves it alone. The report still
+reaches a custom `DwConfig.onErrorReport`, which sorts it out by type. See
+[error reporting](../2-core/error-reporting.md#a-refusal-is-not-an-error).
+
 ## Notifications
 
 `dw.notify.success / warning / error / info` post a `DwUiNotification` from anywhere, including

--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -7,8 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.10.0
-
+  dartway_serverpod_core_client: ^0.11.0
   # The client half of the optional push module. Required because the generated
   # protocol imports it — the server consumes the module, so its `Caller` shows
   # up in this package's `client.dart`. Drop both together if an app does not

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -277,7 +277,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -305,21 +305,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_studio_binding:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -38,12 +38,10 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.6.0
-
+  dartway_flutter: ^0.7.0
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.10.0
-
+  dartway_serverpod_core_flutter: ^0.11.0
   dartway_studio_bridge: ^0.8.0
 
   dartway_studio_binding: ^0.1.0

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -9,8 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.10.0
-
+  dartway_serverpod_core_server: ^0.11.0
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.
   dartway_push_server: ^0.3.0

--- a/packages/dartway_flutter/CHANGELOG.md
+++ b/packages/dartway_flutter/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.7.0
+
+**`DwRefusal`** — the one error that is an answer. It carries a `message` written for the user
+("This message was already deleted"), and everything downstream treats it as a decision rather than
+an incident:
+
+- `dw.action` shows that message instead of the action's `onErrorNotification`. The rule's text was
+  written for this case; the action's was written for every case.
+- it still travels through `dw.handleError`, so an app's `DwConfig.onErrorReport` sees it and sorts
+  it out with one type check. The core's built-in alerting does not raise it — see
+  `dartway_serverpod_core_flutter` 0.11.0, where a server response marked `isRefusal` becomes one.
+- an app can throw one from its own code for a local rule ("this file is larger than 10 MB") and get
+  the same treatment.
+
 ## 0.6.0
 
 **`dw.plugins.maybeOf<T>()`** — the lookup for a *role* rather than an integration. `of<T>()` is an

--- a/packages/dartway_flutter/example/pubspec.lock
+++ b/packages/dartway_flutter/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "99.0.0"
+    version: "93.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "10.0.1"
   ansicolor:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   fake_async:
     dependency: transitive
     description:
@@ -177,10 +177,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_native_splash
-      sha256: "9db4b80b044e9af17cc4b1272137fc7ace0054d879ef8210a76adc34aaf4cdff"
+      sha256: "4fb9f4113350d3a80841ce05ebf1976a36de622af7d19aca0ca9a9911c7ff002"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.8"
+    version: "2.4.7"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -243,10 +243,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      sha256: "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.1"
+    version: "4.9.2"
   intl:
     dependency: transitive
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -323,10 +323,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -512,26 +512,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:
@@ -616,10 +616,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/packages/dartway_flutter/lib/dartway_flutter.dart
+++ b/packages/dartway_flutter/lib/dartway_flutter.dart
@@ -48,6 +48,8 @@ export 'src/ui/confirmation/dw_ui_confirmation.dart';
 // diagnostics/error_reporting: app-state context captured into every report.
 // dw_error_report re-exports the source enum and the context snapshot.
 export 'src/diagnostics/error_reporting/dw_error_report.dart';
+// The one error that is an answer rather than an incident — see DwRefusal.
+export 'src/diagnostics/error_reporting/dw_refusal.dart';
 
 // diagnostics/dw_feature: mark a widget as a product feature and discover the
 // mounted ones at runtime — feature catalogs, error context, Studio passports.

--- a/packages/dartway_flutter/lib/src/diagnostics/error_reporting/dw_refusal.dart
+++ b/packages/dartway_flutter/lib/src/diagnostics/error_reporting/dw_refusal.dart
@@ -1,0 +1,44 @@
+/// A refusal: the operation did not happen because a rule said no, and
+/// [message] is what the rule said.
+///
+/// Thrown where a failure would otherwise be, because the code that meets it
+/// is the code that catches exceptions — but it is not one, and everything
+/// downstream is meant to tell the difference:
+///
+/// - `dw.action` shows [message] to the user instead of the action's generic
+///   `onErrorNotification`. The text was written for this exact case; "Could
+///   not delete" was written for all of them.
+/// - the framework's own error policy does not alert it. A rule doing its job
+///   is not an incident, and a channel that receives one for every refused
+///   click stops being read.
+/// - an app's own `DwConfig.onErrorReport` still receives it, and sorts it out
+///   with one type check — `if (report.error is DwRefusal) return;` — rather
+///   than by comparing the message against strings it hopes the server still
+///   uses.
+///
+/// Most of them arrive from the server: a `DwApiResponse` carrying
+/// `isRefusal`, raised by `DwRepository.processApiResponse`. Throwing one from
+/// the app's own code is the same statement made locally — "this is the user's
+/// answer, not a bug" — and gets the same treatment.
+///
+/// ```dart
+/// if (file.lengthSync() > maxUpload) {
+///   throw const DwRefusal('This file is larger than 10 MB');
+/// }
+/// ```
+///
+/// **[message] is shown to a user**, so write it for one: no identifiers, no
+/// class names, no stack of an underlying error. A refusal nobody can act on
+/// is a failure wearing the wrong type.
+class DwRefusal implements Exception {
+  const DwRefusal(this.message);
+
+  /// What the rule said, in the words it was written in — the text that
+  /// reaches the screen unedited.
+  final String message;
+
+  /// The message alone: this is the one exception whose `toString` is meant
+  /// for a person, and it lands in notifications and report titles as such.
+  @override
+  String toString() => message;
+}

--- a/packages/dartway_flutter/lib/src/ui/actions/dw_ui_action.dart
+++ b/packages/dartway_flutter/lib/src/ui/actions/dw_ui_action.dart
@@ -6,6 +6,12 @@ import 'package:flutter/material.dart';
 /// A UI-aware async action: confirmation → run → notify → follow-up → error
 /// report, all in one value.
 ///
+/// A [DwRefusal] thrown inside it — by the repository, on a server response a
+/// rule refused, or by the app's own code — is shown to the user in its own
+/// words rather than as the action's generic error text. It still travels
+/// through `dw.handleError`, so an app's error policy sees everything and
+/// decides for itself; the framework's built-in policy does not alert it.
+///
 /// Create one through [DwFlutter.action] — `dw.action(...)` — never directly:
 /// the action's work is woven into the ambient `dw` services (it calls
 /// `dw.confirm`, `dw.notify`, `dw.handleError`), so its factory lives on `dw`.
@@ -61,7 +67,13 @@ extension DwActionExtension on DwFlutter {
 
         return value;
       } catch (error, stackTrace) {
-        if (onErrorNotification != null) {
+        // A refusal speaks for itself: it carries the text whoever wrote the
+        // rule wrote, about this call and this user, so it wins over the
+        // action's [onErrorNotification] — which was written once, for every
+        // way the action could fail.
+        if (error is DwRefusal) {
+          notify.error(error.message);
+        } else if (onErrorNotification != null) {
           notify.error(onErrorNotification);
         }
         onError?.call(error, stackTrace);

--- a/packages/dartway_flutter/pubspec.yaml
+++ b/packages/dartway_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_flutter
 description: "The Flutter skeleton of a DartWay app: bootstrap runner, guarded UI actions, the AsyncValue rendering contract, notifications and error reporting. Riverpod-native."
-version: 0.6.0
+version: 0.7.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_flutter/test/dw_error_pipeline_test.dart
+++ b/packages/dartway_flutter/test/dw_error_pipeline_test.dart
@@ -1,6 +1,15 @@
 import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// Collects what `dw.notify.*` delivered, in place of showing it.
+class _CapturingHandler implements DwNotificationHandler<DwUiNotification> {
+  final shown = <DwUiNotification>[];
+
+  @override
+  void show(BuildContext context, DwUiNotification event) => shown.add(event);
+}
 
 class _FeatureBox extends StatelessWidget implements DwFeature {
   const _FeatureBox(this.id);
@@ -96,6 +105,84 @@ void main() {
 
       final report = reports.single;
       expect(report.context.entries, {'good': 'value'});
+    });
+  });
+
+  group('a refusal is an answer, not an incident', () {
+    final notifications = _CapturingHandler();
+
+    /// The app as a refusal meets it: a notification listener mounted, so what
+    /// `dw.action` decides to show is observable.
+    Future<BuildContext> pumpApp(WidgetTester tester) async {
+      notifications.shown.clear();
+      await tester.pumpWidget(
+        ProviderScope(
+          child: DwNotificationsListener(
+            handlers: {DwUiNotification: notifications},
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      );
+      return tester.element(find.byType(SizedBox));
+    }
+
+    testWidgets('is shown to the user in its own words', (tester) async {
+      final context = await pumpApp(tester);
+
+      final action = dwInstance.action<void>(
+        (_) => throw const DwRefusal('This message was already deleted'),
+        onErrorNotification: 'Could not delete',
+      );
+      await action(context);
+      await tester.pump();
+
+      // The rule's text wins over the action's generic one: it was written
+      // for this case, and the generic one for every case.
+      expect(
+        notifications.shown.single.message,
+        'This message was already deleted',
+      );
+      expect(notifications.shown.single.type, DwUiNotificationType.error);
+    });
+
+    testWidgets('an ordinary failure still shows the action text', (
+      tester,
+    ) async {
+      final context = await pumpApp(tester);
+
+      final action = dwInstance.action<void>(
+        (_) => throw StateError('boom'),
+        onErrorNotification: 'Could not delete',
+      );
+      await action(context);
+      await tester.pump();
+
+      expect(notifications.shown.single.message, 'Could not delete');
+    });
+
+    testWidgets('still reaches the error policy, as a DwRefusal', (
+      tester,
+    ) async {
+      final context = await pumpApp(tester);
+
+      await dwInstance.action<void>(
+        (_) => throw const DwRefusal('You have no access to this track'),
+      )(context);
+
+      // The app decides what to do with it — the point of the type is that
+      // one check is enough: `if (report.error is DwRefusal) return;`
+      expect(reports.single.error, isA<DwRefusal>());
+      expect(
+        (reports.single.error as DwRefusal).message,
+        'You have no access to this track',
+      );
+    });
+
+    test('reads as its message, so a report title says something', () {
+      expect(
+        const DwRefusal('This booking is gone').toString(),
+        'This booking is gone',
+      );
     });
   });
 

--- a/packages/dartway_lints/example/pubspec.lock
+++ b/packages/dartway_lints/example/pubspec.lock
@@ -217,10 +217,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "56e81e662e6e54e59b231da57e90ac0d06ac67d8e3f2273c129a37ae6282b40c"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.3.2"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -330,14 +330,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  listen:
-    dependency: transitive
-    description:
-      name: listen
-      sha256: "47501a08016a43fcad79252439d723f50f14f88fa7bfd8a177e0a417e5c9e1f2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -350,10 +342,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -366,10 +358,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -430,10 +422,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "84351b3472a447f7b89f961f95c73287009d58c59d8cc1267425d995f78e50f1"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.3.2"
   rxdart:
     dependency: transitive
     description:
@@ -571,26 +563,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:
@@ -672,5 +664,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.41.0 <4.0.0"

--- a/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
+++ b/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "99.0.0"
+    version: "93.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "10.0.1"
   ansicolor:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       path: "../../../dartway_flutter"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_offline_flutter:
     dependency: "direct main"
     description:
@@ -196,21 +196,21 @@ packages:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_serverpod_core_flutter:
     dependency: "direct overridden"
     description:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dbus:
     dependency: transitive
     description:
@@ -332,10 +332,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_native_splash
-      sha256: "9db4b80b044e9af17cc4b1272137fc7ace0054d879ef8210a76adc34aaf4cdff"
+      sha256: "4fb9f4113350d3a80841ce05ebf1976a36de622af7d19aca0ca9a9911c7ff002"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.8"
+    version: "2.4.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -348,10 +348,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: "56e81e662e6e54e59b231da57e90ac0d06ac67d8e3f2273c129a37ae6282b40c"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.3.2"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -446,10 +446,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+19"
+    version: "0.8.13+17"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -570,14 +570,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  listen:
-    dependency: transitive
-    description:
-      name: listen
-      sha256: "47501a08016a43fcad79252439d723f50f14f88fa7bfd8a177e0a417e5c9e1f2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -590,10 +582,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -606,10 +598,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -766,10 +758,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "84351b3472a447f7b89f961f95c73287009d58c59d8cc1267425d995f78e50f1"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.3.2"
   serverpod_client:
     dependency: transitive
     description:
@@ -798,10 +790,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.27"
+    version: "2.4.23"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -971,26 +963,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:
@@ -1091,10 +1083,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
@@ -1104,5 +1096,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"

--- a/packages/dartway_offline/dartway_offline_flutter/pubspec.yaml
+++ b/packages/dartway_offline/dartway_offline_flutter/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.6.0
+  dartway_flutter: ^0.7.0
   dartway_offline_shared: ^0.1.0
-  dartway_serverpod_core_flutter: ^0.10.0
+  dartway_serverpod_core_flutter: ^0.11.0
   drift: 2.31.0
   drift_flutter: 0.2.8
   background_downloader: ^9.5.7

--- a/packages/dartway_push/dartway_push_client/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_client/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   # wrapper types. Inside the workspace this resolved without being declared,
   # which is exactly the kind of dependency that only fails once the package is
   # published and somebody else resolves it.
-  dartway_serverpod_core_client: ^0.10.0
+  dartway_serverpod_core_client: ^0.11.0

--- a/packages/dartway_push/dartway_push_flutter/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_flutter/pubspec.yaml
@@ -16,14 +16,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.6.0
-
+  dartway_flutter: ^0.7.0
   # The device registration request, and the CRUD action that carries it. The
   # app half talks to the server half through the generated protocol, not
   # through an endpoint of its own.
   dartway_push_client: ^0.2.0
-  dartway_serverpod_core_flutter: ^0.10.0
-
+  dartway_serverpod_core_flutter: ^0.11.0
   flutter_riverpod: ^3.0.0
 
 dev_dependencies:

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_server: ^0.10.0
-
+  dartway_serverpod_core_server: ^0.11.0
   collection: ^1.19.1
   crypto: ^3.0.6
   googleapis_auth: ^2.3.3

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.11.0
+
+`DwApiResponse` gains **`isRefusal`** and the `DwApiResponse.refusal(message)` constructor, mirroring
+the server's envelope: whether the `error` is a rule saying no rather than something breaking. False
+when the key is absent, which is how a server older than the flag reads — every error stays an
+incident, exactly as before. See `dartway_serverpod_core_flutter` 0.11.0.
+
 ## 0.10.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.10.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_api_response.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_api_response.dart
@@ -33,21 +33,36 @@ class DwApiResponse<T> implements SerializableModel {
     this.warning,
     this.error,
     this.updatedModels,
+    this.isRefusal = false,
   });
+
+  /// A rule on the server said no, and [message] is what it said.
+  ///
+  /// The twin of `DwApiResponse.refusal` on the server side; here it is what a
+  /// locally built response uses to refuse the same way the server would.
+  const DwApiResponse.refusal(String message)
+    : isOk = false,
+      value = null,
+      error = message,
+      warning = null,
+      updatedModels = null,
+      isRefusal = true;
 
   const DwApiResponse.notConfigured()
     : isOk = false,
       value = null,
       error = 'This action is not supported by the server',
       warning = null,
-      updatedModels = null;
+      updatedModels = null,
+      isRefusal = false;
 
   const DwApiResponse.forbidden()
     : isOk = false,
       value = null,
       error = 'Not enough permissions',
       warning = null,
-      updatedModels = null;
+      updatedModels = null,
+      isRefusal = true;
 
   /// The caller is not signed in and the config did not opt into anonymous
   /// access. Distinct from [DwApiResponse.forbidden]: there the caller is
@@ -58,13 +73,25 @@ class DwApiResponse<T> implements SerializableModel {
       value = null,
       error = 'Authentication required${source != null ? ' ($source)' : ''}',
       warning = null,
-      updatedModels = null;
+      updatedModels = null,
+      isRefusal = false;
 
   final bool isOk;
   final T? value;
   final String? warning;
   final String? error;
   final List<DwModelWrapper>? updatedModels;
+
+  /// Whether [error] is a rule saying no rather than something breaking.
+  ///
+  /// The two share the `error` field, and only the server knows which it
+  /// built. `DwRepository.processApiResponse` reads this flag to answer with a
+  /// `DwRefusal` — a message meant for the user — instead of an exception the
+  /// app's error policy would report as an incident.
+  ///
+  /// **False when the key is absent**, which is how a server older than the
+  /// flag reads: every error stays an incident, exactly as before.
+  final bool isRefusal;
 
   static K? manualDeserialization<K>(Map<String, dynamic> jsonSerialization) {
     if (K == DwApiResponse<List<int>>) {
@@ -105,6 +132,7 @@ class DwApiResponse<T> implements SerializableModel {
                       .deserialize<DwModelWrapper>(e),
                 )
                 .toList(),
+      isRefusal: jsonSerialization['isRefusal'] as bool? ?? false,
     );
   }
 
@@ -115,6 +143,7 @@ class DwApiResponse<T> implements SerializableModel {
       'value': _serializeValue(value),
       if (warning != null) 'warning': warning,
       if (error != null) 'error': error,
+      if (isRefusal) 'isRefusal': true,
       if (updatedModels != null)
         'updatedModels': updatedModels?.toJson(valueToJson: (v) => v.toJson()),
     };

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.10.0
+version: 0.11.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.11.0
+
+**A server refusal is no longer an exception like any other.** `processApiResponse` turned every
+`error` into `throw Exception(...)`, so a rule saying no arrived at the app indistinguishable from a
+crash: the alert channel filled with ordinary refusals, and telling them apart meant matching the
+message against strings.
+
+- A response carrying `isRefusal` is now answered with **`DwRefusal`** (from `dartway_flutter`),
+  which holds the text the rule was written in. Everything else still throws the same `Exception` it
+  did.
+- **The framework's own error policy no longer alerts a refusal.** `DwCore.dispatchReport` steps
+  over it the way it already steps over connection blips. An app that installed its own
+  `DwConfig.onErrorReport` still receives it and decides for itself — one type check,
+  `if (report.error is DwRefusal) return;`, instead of a list of message prefixes.
+- `dw.action` shows the refusal's own words to the user instead of the action's generic
+  `onErrorNotification` — see `dartway_flutter` 0.7.0.
+
+**What changes for an app that does nothing:** refusals stop arriving in the alert channel, and the
+user reads the rule's text rather than a generic error. An app whose `onErrorReport` filtered
+refusals by matching message strings can delete that code.
+
 ## 0.10.0
 
 **Everything `dw.repo` sends to the server now goes through one narrow port, `DwServerTransport`,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/core/dw_core.dart
@@ -210,10 +210,16 @@ class DwCore<
   /// Out-of-the-box alerting: unless the app installed its own error policy
   /// in [DwConfig], every reported error goes to [dwAlerts] enriched with the
   /// app-state context (route, mounted features, action/call, user).
-  /// Connection blips are UX, not alerts — they are filtered out here.
+  /// Connection blips are UX, not alerts — they are filtered out here, and so
+  /// are refusals, which are answers ([DwRefusal]).
   @override
   void dispatchReport(DwErrorReport report) {
     if (hasCustomErrorHandling) return super.dispatchReport(report);
+
+    // A rule saying no is not an incident. It has already reached the user in
+    // its own words through `dw.action`; alerting it as well was how twenty
+    // ordinary refusals became twenty pages in two days.
+    if (report.error is DwRefusal) return;
 
     if (isStreamingConnectionError(report.error)) return;
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repository.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repository.dart
@@ -3,6 +3,7 @@
 
 import 'dart:math';
 
+import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -477,25 +478,26 @@ class DwRepository {
     // where a sign-out would otherwise slip through and leave a snapshot of a
     // session that has ended sitting on the device, past the purge that was
     // supposed to take it.
-    final result = await readBinding.store
-        .keep<DwRepoReadSnapshotStoreResult>((tx) async {
-          if (!identical(localReads, readBinding.store)) {
-            return DwRepoReadSnapshotStoreResult.stale;
-          }
-          if (!readBinding.binding.isActive) {
-            return DwRepoReadSnapshotStoreResult.stale;
-          }
-          if (!await tx.isBindingCurrent(readBinding.binding)) {
-            return DwRepoReadSnapshotStoreResult.stale;
-          }
-          final kept = await tx.storeSnapshot(
-            queryKey: queryKey,
-            snapshot: snapshot,
-          );
-          return kept
-              ? DwRepoReadSnapshotStoreResult.stored
-              : DwRepoReadSnapshotStoreResult.ignored;
-        });
+    final result = await readBinding.store.keep<DwRepoReadSnapshotStoreResult>((
+      tx,
+    ) async {
+      if (!identical(localReads, readBinding.store)) {
+        return DwRepoReadSnapshotStoreResult.stale;
+      }
+      if (!readBinding.binding.isActive) {
+        return DwRepoReadSnapshotStoreResult.stale;
+      }
+      if (!await tx.isBindingCurrent(readBinding.binding)) {
+        return DwRepoReadSnapshotStoreResult.stale;
+      }
+      final kept = await tx.storeSnapshot(
+        queryKey: queryKey,
+        snapshot: snapshot,
+      );
+      return kept
+          ? DwRepoReadSnapshotStoreResult.stored
+          : DwRepoReadSnapshotStoreResult.ignored;
+    });
     return result != DwRepoReadSnapshotStoreResult.stale;
   }
 
@@ -830,8 +832,15 @@ class DwRepository {
       );
     }
 
+    // A rule saying no and a server breaking both arrive in `error`, and only
+    // the server knows which it built. `isRefusal` is that knowledge: answered
+    // with a [DwRefusal], the message reaches the user in the words the rule
+    // was written in, and the app's error policy can sort it out by type
+    // instead of by matching the text.
     if (response.error != null) {
-      throw Exception(response.error);
+      throw response.isRefusal
+          ? DwRefusal(response.error!)
+          : Exception(response.error);
     }
     if (!response.isOk) {
       throw StateError('Repository response reported an unsuccessful read.');

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.10.0
+version: 0.11.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -24,10 +24,9 @@ dependencies:
 
   serverpod_client: ^3.4.11
 
-  dartway_flutter: ^0.6.0
-  dartway_serverpod_core_client: ^0.10.0
-  dartway_serverpod_core_shared: ^0.10.0
-
+  dartway_flutter: ^0.7.0
+  dartway_serverpod_core_client: ^0.11.0
+  dartway_serverpod_core_shared: ^0.11.0
   collection: ^1.19.1
   crypto: ^3.0.6
   flutter_riverpod: ^3.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_refusal_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_refusal_test.dart
@@ -1,0 +1,148 @@
+import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
+import 'package:dartway_serverpod_core_flutter/src/repository/dw_repository.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The refusal as it arrives from a server that knows the difference, and the
+/// failure it used to be indistinguishable from.
+const _refusalText = 'This message was already deleted';
+const _failureText = 'Unexpected error while handling the saveModel request';
+
+class _Note implements SerializableModel {
+  const _Note({this.id});
+
+  final int? id;
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{'id': id};
+}
+
+void main() {
+  final alerts = <String>[];
+  late DwRecordingServerTransport transport;
+  // The app's `dw` is a global the application declares; a test holds the core
+  // it built instead.
+  late DwCore<ServerpodClientShared, _Note> core;
+
+  // One core per test process — the singleton forbids re-creation. No custom
+  // error policy, so the framework's own alerting is what runs.
+  setUpAll(() {
+    transport = DwRecordingServerTransport(
+      classNames: <Type, String>{_Note: 'Note'},
+    );
+    core = DwCore<ServerpodClientShared, _Note>(
+      config: const DwConfig(),
+      transport: transport,
+      dwAlerts: DwAlerts.init(logFunction: alerts.add),
+      getUserId: (_) => null,
+    );
+    DwRepository.setupRepository(defaultModel: const _Note(id: 0));
+  });
+
+  setUp(() {
+    transport.reset();
+    alerts.clear();
+  });
+
+  group('processApiResponse', () {
+    test('answers a refusal with a DwRefusal carrying the rule text', () {
+      const response = DwApiResponse<bool>.refusal(_refusalText);
+
+      expect(
+        () => DwRepository.processApiResponse<bool>(
+          response,
+          updateListeners: false,
+        ),
+        throwsA(
+          isA<DwRefusal>().having((e) => e.message, 'message', _refusalText),
+        ),
+      );
+    });
+
+    test('answers a failure with an ordinary exception, as before', () {
+      const response = DwApiResponse<bool>(
+        isOk: false,
+        value: null,
+        error: _failureText,
+      );
+
+      expect(
+        () => DwRepository.processApiResponse<bool>(
+          response,
+          updateListeners: false,
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e is DwRefusal,
+            'is a refusal',
+            isFalse,
+          ),
+        ),
+      );
+    });
+
+    test('a permission denial is a refusal too', () {
+      expect(
+        () => DwRepository.processApiResponse<bool>(
+          const DwApiResponse<bool>.forbidden(),
+          updateListeners: false,
+        ),
+        throwsA(
+          isA<DwRefusal>().having(
+            (e) => e.message,
+            'message',
+            'Not enough permissions',
+          ),
+        ),
+      );
+    });
+
+    test('an older server, which marks nothing, still reports failures', () {
+      // The flag absent from the JSON is what a server built before it looks
+      // like: every error stays an incident, exactly as it did.
+      final response = DwApiResponse<bool>.fromJson(const {
+        'isOk': false,
+        'value': null,
+        'error': _refusalText,
+      });
+
+      expect(response.isRefusal, isFalse);
+      expect(
+        () => DwRepository.processApiResponse<bool>(
+          response,
+          updateListeners: false,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('a save the server refused', () {
+    test('reaches the caller as a DwRefusal, in the rule\'s words', () async {
+      transport.answerSave = (_) async =>
+          const DwApiResponse<DwModelWrapper>.refusal(_refusalText);
+
+      await expectLater(
+        const DwRepo().saveModel(const _Note(id: 7)),
+        throwsA(
+          isA<DwRefusal>().having((e) => e.message, 'message', _refusalText),
+        ),
+      );
+    });
+  });
+
+  group('the framework error policy', () {
+    test('does not alert a refusal', () {
+      core.handleError(const DwRefusal(_refusalText), StackTrace.current);
+
+      expect(alerts, isEmpty, reason: 'a rule saying no is not an incident');
+    });
+
+    test('still alerts everything else', () {
+      core.handleError(StateError('boom'), StackTrace.current);
+
+      expect(alerts, hasLength(1));
+      expect(alerts.single, contains('boom'));
+    });
+  });
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.11.0
+
+**A refusal now says on the wire that it is one.** A rule saying no and a server breaking both
+travel in `DwApiResponse.error`, so the client could tell them apart only by comparing the message
+against strings it hoped the server still used. It did not, and every ordinary refusal reached the
+app's error policy looking like an incident.
+
+- **New: `DwApiResponse.isRefusal`**, and `DwApiResponse.refusal(message)` to build one. Written to
+  the JSON only when true, so nothing changes for the responses that are the overwhelming majority
+  and an older client — which reads the missing key as "not a refusal" — is right about them.
+- Marked as refusals: every rejection by a rule (`validateSave`, `beforeSaveTransaction`,
+  `afterSaveTransaction`, `afterSaveTransform`, `validateAction`, `DwActionRejection`),
+  `forbidden()` from `allowSave`/`allowDelete`, a delete refused because other rows still reference
+  the model, and a save of a row that is already gone.
+- **Not** marked: a `DatabaseException`, anything the endpoint's guard caught, `notConfigured` (no
+  rule decided anything — the operation does not exist on this server) and `notAuthenticated` (an
+  answer, but its text carries a source written for the logs; sending the user to the login screen
+  needs a channel of its own).
+- `DwDeleteConfig`'s foreign-key refusal now answers with `value: null` rather than `false`. The
+  error was always what callers read.
+
+See `dartway_serverpod_core_flutter` for what the other side does with the flag.
+
 ## 0.10.0
 
 **A CRUD call that fails now says which model it was about.** `getAll` and `getCount` had no error

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_api_response.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/api/dw_api_response.dart
@@ -23,39 +23,86 @@ class DwApiResponse<T> implements SerializableModel, ProtocolSerialization {
     this.warning,
     this.error,
     this.updatedModels,
+    this.isRefusal = false,
   });
 
+  /// A rule said no, and this is what it said.
+  ///
+  /// The one answer a client is meant to show as it arrived: [message] is the
+  /// text whoever wrote the rule wrote — "this message was already deleted",
+  /// "you have no access to this track" — and it travels to the screen
+  /// unedited. Marked with [isRefusal] so the other side can tell it from the
+  /// failures that share the `error` field, and act on the difference instead
+  /// of matching strings.
+  const DwApiResponse.refusal(String message)
+    : isOk = false,
+      value = null,
+      error = message,
+      warning = null,
+      updatedModels = null,
+      isRefusal = true;
+
+  /// The server has no config for this call. **Not a refusal**: no rule
+  /// decided anything, the operation simply does not exist on this server, and
+  /// a client that meets it has found a hole in the deployment rather than the
+  /// answer to a question. It stays an error the app reports.
   const DwApiResponse.notConfigured({required String? source})
     : isOk = false,
       value = null,
       error =
           'Action not configured on server ${source != null ? ' ($source)' : ''}',
       warning = null,
-      updatedModels = null;
+      updatedModels = null,
+      isRefusal = false;
 
+  /// The rule that guards this operation said no — `allowSave`, `allowDelete`,
+  /// an `accessFilter` that let nothing through. A refusal: the caller is
+  /// known, the answer is about them, and nobody needs to be paged for it.
   const DwApiResponse.forbidden()
     : isOk = false,
       value = null,
       error = 'Not enough permissions',
       warning = null,
-      updatedModels = null;
+      updatedModels = null,
+      isRefusal = true;
 
   /// The caller is not signed in and the config did not opt into anonymous
   /// access. Distinct from [DwApiResponse.forbidden]: there the caller is
   /// known and lacks permission, here there is no caller at all — the client
   /// can act on that by sending the user to the login screen.
+  ///
+  /// Deliberately **not** marked as a refusal, though it is an answer rather
+  /// than an accident. Its text carries a `source` written for whoever reads
+  /// the logs, so a client showing it as it arrived would show the user
+  /// `Authentication required (getOne for ClubService)`. Sending them to the
+  /// login screen instead is the right response, and it needs a channel of its
+  /// own rather than this flag.
   const DwApiResponse.notAuthenticated({String? source})
     : isOk = false,
       value = null,
       error = 'Authentication required${source != null ? ' ($source)' : ''}',
       warning = null,
-      updatedModels = null;
+      updatedModels = null,
+      isRefusal = false;
 
   final bool isOk;
   final T? value;
   final String? warning;
   final String? error;
   final List<DwModelWrapper>? updatedModels;
+
+  /// Whether [error] is a rule saying no rather than something breaking.
+  ///
+  /// Both travel in the same field, and until this flag existed the client had
+  /// no way to tell them apart except by comparing the message to strings it
+  /// hoped the server still used. So a refusal reached the app's error policy
+  /// looking like an incident, and the alert channel filled up with rules
+  /// working exactly as intended.
+  ///
+  /// Set by [DwApiResponse.refusal] and [DwApiResponse.forbidden]; false for
+  /// everything a caller cannot answer — a `DatabaseException`, an exception
+  /// caught by the endpoint's guard, a call the server has no config for.
+  final bool isRefusal;
 
   factory DwApiResponse.fromJson(Map<String, dynamic> jsonSerialization) {
     return DwApiResponse(
@@ -68,6 +115,7 @@ class DwApiResponse<T> implements SerializableModel, ProtocolSerialization {
           : (jsonSerialization['updatedModels'] as List)
                 .map((e) => _protocol.deserialize<DwModelWrapper>(e))
                 .toList(),
+      isRefusal: jsonSerialization['isRefusal'] as bool? ?? false,
     );
   }
 
@@ -85,6 +133,9 @@ class DwApiResponse<T> implements SerializableModel, ProtocolSerialization {
       'value': _serializeValue(value, forProtocol: forProtocol),
       if (warning != null) 'warning': warning,
       if (error != null) 'error': error,
+      // Written only when true: an older client reads the key it does not know
+      // as absent, which is what it already assumed about every error.
+      if (isRefusal) 'isRefusal': true,
       if (updatedModels != null)
         'updatedModels': [
           for (final model in updatedModels!)

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/dto_configs/dw_dto_action_config.dart
@@ -176,7 +176,7 @@ class DwDtoActionConfig<DTO extends SerializableModel> with DwCrudEntity<DTO> {
   /// at the operator as an incident. `notConfigured` and `notAuthenticated`
   /// take the same route out.
   DwApiResponse<DwModelWrapper> _rejectedResponse(String message) =>
-      DwApiResponse(isOk: false, value: null, error: message);
+      DwApiResponse.refusal(message);
 
   /// Runs [afterSaveSideEffects] with nobody waiting for it, and makes sure a
   /// failure still lands somewhere — unawaited, it would otherwise go to the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_delete_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_delete_config.dart
@@ -70,10 +70,10 @@ class DwDeleteConfig<T extends TableRow> {
     try {
       await session.db.deleteRow(model);
     } on DatabaseException {
-      return DwApiResponse(
-        isOk: false,
-        value: false,
-        error: 'Cannot delete model because other entities reference it',
+      // A refusal, not a failure: the row is still referenced, which is an
+      // answer about the data and one the user can act on.
+      return DwApiResponse.refusal(
+        'Cannot delete model because other entities reference it',
       );
     }
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
@@ -235,9 +235,7 @@ class DwSaveConfig<T extends TableRow> {
     // --- validateSave ---
     if (validateSave != null) {
       final error = await validateSave!(session, saveContext);
-      if (error != null) {
-        return DwApiResponse(isOk: false, value: null, error: error);
-      }
+      if (error != null) return DwApiResponse.refusal(error);
     }
 
     // --- transaction block ---
@@ -248,8 +246,9 @@ class DwSaveConfig<T extends TableRow> {
       });
     } on _DwSaveRejection catch (rejection) {
       // A rule said no. The transaction is rolled back; this is an answer to
-      // the caller, not a failure — no alert.
-      return DwApiResponse(isOk: false, value: null, error: rejection.message);
+      // the caller, not a failure — no alert, and the client is told it is an
+      // answer, so it does not report one either.
+      return DwApiResponse.refusal(rejection.message);
     } on DatabaseException catch (e, stackTrace) {
       return _databaseErrorResponse(e, stackTrace);
     }
@@ -300,11 +299,7 @@ class DwSaveConfig<T extends TableRow> {
         if (validateSave != null) {
           final error = await validateSave!(session, context);
           if (error != null) {
-            earlyResponse = DwApiResponse(
-              isOk: false,
-              value: null,
-              error: error,
-            );
+            earlyResponse = DwApiResponse.refusal(error);
             return;
           }
         }
@@ -312,7 +307,7 @@ class DwSaveConfig<T extends TableRow> {
         await _writeInsideTransaction(session, context, transaction);
       });
     } on _DwSaveRejection catch (rejection) {
-      return DwApiResponse(isOk: false, value: null, error: rejection.message);
+      return DwApiResponse.refusal(rejection.message);
     } on DatabaseException catch (e, stackTrace) {
       return _databaseErrorResponse(e, stackTrace);
     }
@@ -439,9 +434,7 @@ class DwSaveConfig<T extends TableRow> {
     // response says no. See [afterSaveTransform].
     if (afterSaveTransform != null) {
       final error = await afterSaveTransform!(session, saveContext);
-      if (error != null) {
-        return DwApiResponse(isOk: false, value: null, error: error);
-      }
+      if (error != null) return DwApiResponse.refusal(error);
     }
 
     // --- afterSideEffects (outside the transaction, non-blocking) ---
@@ -499,11 +492,13 @@ class DwSaveConfig<T extends TableRow> {
     }
   }
 
-  DwApiResponse<DwModelWrapper> _notFoundResponse(int id) => DwApiResponse(
-    isOk: false,
-    value: null,
-    error: 'Model with id $id not found (possibly deleted earlier)',
-  );
+  /// A refusal rather than a failure: the row being gone is an answer about
+  /// the data, usually because somebody else removed it a moment ago, and the
+  /// caller is meant to read it rather than have it reported for them.
+  DwApiResponse<DwModelWrapper> _notFoundResponse(int id) =>
+      DwApiResponse.refusal(
+        'Model with id $id not found (possibly deleted earlier)',
+      );
 
   DwApiResponse<DwModelWrapper> _databaseErrorResponse(
     DatabaseException exception,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.10.0
+version: 0.11.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -14,8 +14,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_shared: ^0.10.0
-
+  dartway_serverpod_core_shared: ^0.11.0
   collection: ^1.19.1
   crypto: ^3.0.6
   bcrypt: ^1.1.3

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/api/dw_api_response_refusal_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/api/dw_api_response_refusal_test.dart
@@ -1,0 +1,81 @@
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:test/test.dart';
+
+/// A rule saying no and a server breaking share the `error` field, so the only
+/// thing separating them on the wire is [DwApiResponse.isRefusal]. Both halves
+/// of that agreement are pinned here: what carries the flag, and what the JSON
+/// looks like — the client's twin of this class reads exactly these keys.
+void main() {
+  group('what is a refusal', () {
+    test('a rule refusing, with its own text', () {
+      const response = DwApiResponse<bool>.refusal('This booking is gone');
+
+      expect(response.isOk, isFalse);
+      expect(response.isRefusal, isTrue);
+      expect(response.error, 'This booking is gone');
+    });
+
+    test('a permission rule refusing', () {
+      expect(const DwApiResponse<bool>.forbidden().isRefusal, isTrue);
+    });
+  });
+
+  group('what is not', () {
+    test('an operation the server has no config for', () {
+      // Nobody decided anything: the call does not exist on this server, which
+      // is a hole in the deployment and worth reporting as one.
+      expect(
+        const DwApiResponse<bool>.notConfigured(source: 'getOne').isRefusal,
+        isFalse,
+      );
+    });
+
+    test('an absent session', () {
+      // An answer, but not one to show as it stands — its text carries a
+      // source written for the logs. See the constructor's own note.
+      expect(
+        const DwApiResponse<bool>.notAuthenticated(source: 'getOne').isRefusal,
+        isFalse,
+      );
+    });
+
+    test('a plain failure built by hand', () {
+      const response = DwApiResponse<bool>(
+        isOk: false,
+        value: null,
+        error: 'Database error during save',
+      );
+
+      expect(response.isRefusal, isFalse);
+    });
+  });
+
+  group('on the wire', () {
+    test('a refusal is marked', () {
+      final json = const DwApiResponse<bool>.refusal(
+        'This booking is gone',
+      ).toJsonForProtocol();
+
+      expect(json['isRefusal'], isTrue);
+      expect(json['error'], 'This booking is gone');
+    });
+
+    test('everything else carries no key at all', () {
+      // Absent rather than `false`, so nothing grows for the responses that
+      // are the overwhelming majority — and so an older client, which reads a
+      // missing key as "not a refusal", is right about them.
+      final failure = const DwApiResponse<bool>(
+        isOk: false,
+        value: null,
+        error: 'Unexpected error while handling the getAll request',
+      ).toJsonForProtocol();
+      final success = const DwApiResponse<bool>(
+        isOk: true,
+        value: true,
+      ).toJsonForProtocol();
+
+      expect(failure.containsKey('isRefusal'), isFalse);
+      expect(success.containsKey('isRefusal'), isFalse);
+    });
+  });
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/crud/dw_dto_action_config_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/crud/dw_dto_action_config_test.dart
@@ -199,6 +199,12 @@ void main() {
       expect(reports, isEmpty, reason: 'a refusal is an answer, not an error');
     });
 
+    test('is marked as a refusal, so the client can tell too', () async {
+      final response = await saveModel(TrackAction());
+
+      expect(response.isRefusal, isTrue);
+    });
+
     test('stops the action before it runs', () async {
       await saveModel(TrackAction());
 
@@ -221,6 +227,12 @@ void main() {
       await saveModel(RejectingAction());
 
       expect(reports, isEmpty);
+    });
+
+    test('is marked as a refusal, so the client can tell too', () async {
+      final response = await saveModel(RejectingAction());
+
+      expect(response.isRefusal, isTrue);
     });
 
     test('does not fire the side effects', () async {
@@ -248,6 +260,12 @@ void main() {
       expect(reports, hasLength(1));
       expect(reports.single, contains('BrokenAction'));
       expect(reports.single, contains('relation'));
+    });
+
+    test('is not marked as a refusal — nobody refused anything', () async {
+      final response = await saveModel(BrokenAction());
+
+      expect(response.isRefusal, isFalse);
     });
   });
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.0
+
+Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.11.0 is the
+refusal reaching the client as an answer rather than an exception — `DwApiResponse.isRefusal` on the
+wire, `DwRefusal` on the Flutter side. See the changelog of `dartway_serverpod_core_flutter`.
+
 ## 0.10.0
 
 Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.10.0 is the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.10.0
+version: 0.11.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_shared_preferences/pubspec.yaml
+++ b/packages/dartway_shared_preferences/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.6.0
+  dartway_flutter: ^0.7.0
   flutter_riverpod: ^3.0.0
   shared_preferences: ^2.3.0
 

--- a/packages/dartway_studio_binding/pubspec.yaml
+++ b/packages/dartway_studio_binding/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
   # The passports the binding reports come from mounted DwFeature widgets.
-  dartway_flutter: ^0.6.0
+  dartway_flutter: ^0.7.0
   # The screen identity Studio binds to is the route's declared name, which is
   # a DwRouter concept — the reason this is a package of its own rather than a
   # corner of core_flutter, where the dependency would reach apps that never
@@ -25,7 +25,7 @@ dependencies:
   dartway_router: ^1.1.1
   # The persona switch runs the core's own OTP flow, so the binding sits above
   # the core rather than inside it.
-  dartway_serverpod_core_flutter: ^0.10.0
+  dartway_serverpod_core_flutter: ^0.11.0
   # The wire. Both this package and Studio depend on it; its version means the
   # protocol, which is why host-side changes do not belong there.
   dartway_studio_bridge: ^0.8.0

--- a/packages/dartway_telegram/pubspec.yaml
+++ b/packages/dartway_telegram/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.6.0
+  dartway_flutter: ^0.7.0
   telegram_web_app: ^0.3.3
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -828,10 +828,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -844,10 +844,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1385,26 +1385,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:

--- a/template/dartway_starter_client/pubspec.yaml
+++ b/template/dartway_starter_client/pubspec.yaml
@@ -7,8 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.10.0
-
+  dartway_serverpod_core_client: ^0.11.0
 # Inside the monorepo — a local build. `dartway create` removes this block.
 dependency_overrides:
   dartway_serverpod_core_client:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -270,7 +270,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -291,21 +291,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_starter_client:
     dependency: "direct main"
     description:
@@ -453,10 +453,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_native_splash
-      sha256: "9db4b80b044e9af17cc4b1272137fc7ace0054d879ef8210a76adc34aaf4cdff"
+      sha256: "4fb9f4113350d3a80841ce05ebf1976a36de622af7d19aca0ca9a9911c7ff002"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.8"
+    version: "2.4.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -615,10 +615,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+19"
+    version: "0.8.13+17"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -751,10 +751,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -767,10 +767,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -999,10 +999,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.27"
+    version: "2.4.23"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1164,26 +1164,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:
@@ -1321,5 +1321,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -38,12 +38,10 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.6.0
-
+  dartway_flutter: ^0.7.0
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.10.0
-
+  dartway_serverpod_core_flutter: ^0.11.0
   dartway_studio_bridge: ^0.8.0
 
   dartway_studio_binding: ^0.1.0

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -9,8 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.10.0
-
+  dartway_serverpod_core_server: ^0.11.0
   http: ^1.5.0
 
 

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -408,7 +408,7 @@ Order: `validateAction` → **the transaction opens:** `actionProcessing` → ou
 - `validateAction` → `Future<String?>` — the error text or null, exactly like `validateSave`. Runs **before** the transaction, so the action never starts.
 - `DwActionRejection` — thrown from inside `actionProcessing`, where there is nothing to return the text in and where throwing is the only thing that rolls a Serverpod transaction back. The transaction rolls back, and the caller gets the message verbatim.
 
-Both are **answers**: nothing is reported to `DwAlerts`, and the text reaches the client word for word.
+Both are **answers**: nothing is reported to `DwAlerts`, and the text reaches the client word for word — marked `isRefusal`, so the Flutter side shows it to the user and keeps it out of the alert channel (`DwRefusal`, see `dartway-data-layer` §4). Refusing the documented way is what sets the mark; no config sets it by hand.
 
 **`throw Exception('Not enough rights to delete this message')` is not a refusal — it is a crash**, and the framework treats it as one. The endpoint's error boundary replaces the text with `Unexpected error while handling the saveModel request for X` and alerts the operator. The user reads "Application error" instead of the reason, and the alert channel fills up with rules working as intended.
 

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -9,7 +9,8 @@ description: >-
   an entity and everything hanging off it read in ONE request (include on the server, DwRelationUpdatesConfig
   for live child updates — a parent that leaves the server without its include silently blanks the
   nested lists on every client),
-  actions from the UI via dw.action (unified error/loading handling), notifications via dw.notify.* (not SnackBar),
+  actions from the UI via dw.action (unified error/loading handling, and a server refusal shown to
+  the user as DwRefusal rather than reported as a crash), notifications via dw.notify.* (not SnackBar),
   the profile via ref.watchUserProfile/readUserProfile (getters, not CRUD), sign-out via
   sessionProvider.notifier.signOut(), local screen state that survives a restart via
   dw.plugins.prefs (providerFamily/mappedProviderFamily when the value belongs to an entity).
@@ -343,6 +344,37 @@ final deleteAction = dw.action<bool>(
 
 > The real name is **`DwUiAction`** (46+ usages). There is no `DwCallback` in the project.
 > Declining the confirm dialog cancels the action entirely (no notifications, no follow-up). A custom dialog is `DwConfig.confirmDialogBuilder`. Action errors automatically reach alerting with context (route, screen features, `label`) — see the framework's error-reporting doc.
+
+### A server refusal shows itself, and does not page anybody
+
+A rule on the server that said no — `validateSave` returning its text, an action throwing
+`DwActionRejection`, `allowSave` refusing — comes back marked, and `dw.repo` raises it as a
+**`DwRefusal`** carrying the rule's own text. `dw.action` shows that text instead of its
+`onErrorNotification`, and the framework's alerting steps over it: a rule doing its job is not an
+incident.
+
+```dart
+// The server answered "This booking is already cancelled".
+// The user reads exactly that — not "Could not cancel", and nobody is paged.
+dw.action(
+  (_) => dw.repo.saveModel(booking.copyWith(status: BookingStatus.cancelled)),
+  onErrorNotification: 'Could not cancel', // still used for real failures
+);
+```
+
+**What this means for your code:** write nothing. Do not catch `DwRefusal` to re-show it, do not
+add an `onErrorNotification` for the refusal case, and if the app has a custom
+`DwConfig.onErrorReport`, filter refusals there by type — `if (report.error is DwRefusal) return;` —
+never by matching the message text.
+
+A rule of your own that lives on the client throws the same type:
+
+```dart
+if (file.lengthSync() > maxUpload) throw const DwRefusal('This file is larger than 10 MB');
+```
+
+**The message reaches the screen unedited**, so write it for a user: no ids, no class names, no
+underlying error attached.
 
 **`dw.action` says what to write an action with; where it lives is `dartway-clean-code` §1.9b —
 in the widget that owns the button.** Not a callback handed down from a parent, and not a screen-wide


### PR DESCRIPTION
## The problem

`DwActionRejection` and `validateAction` (#135) made a refusal an answer **on the server**: no alert, and the rule's text carried verbatim in `DwApiResponse.error`. The client undid it. `DwRepository.processApiResponse` turned every `error` into `throw Exception(...)`, so:

- an app's `DwConfig.onErrorReport` could tell a refused rule from a broken server only by comparing message strings;
- the framework's own policy alerted both, and the user read the action's generic "Could not delete" instead of "This message was already deleted".

## On the wire

`DwApiResponse` gains **`isRefusal`** and `DwApiResponse.refusal(message)`, written to the JSON **only when true** — an older client reads the missing key as "not a refusal", which is what it already assumed about every error, and nothing grows for the responses that are the overwhelming majority.

**Marked:** every rejection by a rule (`validateSave`, `beforeSaveTransaction`, `afterSaveTransaction`, `afterSaveTransform`, `validateAction`, `DwActionRejection`), `forbidden()` from `allowSave`/`allowDelete`, a delete other rows still reference, a save of a row already gone.

**Not marked, and each is a decision:**

- a `DatabaseException` and anything the endpoint's guard caught — accidents;
- `notConfigured` — no rule decided anything; the operation does not exist on this server, which is a hole in the deployment and worth reporting as one;
- `notAuthenticated` — an answer, but its text carries a `source` written for the logs (`Authentication required (getOne for ClubService)`), so it must not reach a screen as it stands. Sending the user to the login screen deserves a channel of its own, and this PR does not open it.

## On the client

**`DwRefusal(message)`**, in `dartway_flutter` rather than in the core: `dw.action` sits a layer below the core and could not otherwise see the type. The type came out general as a result — an app throws one for a local rule (`throw const DwRefusal('This file is larger than 10 MB')`) and gets the same treatment.

- `processApiResponse` answers a refusal with `DwRefusal` and everything else with the `Exception` it already threw;
- `dw.action` shows the refusal's message **instead of** its `onErrorNotification` — that text was written once for every way the action can fail, this one for this case;
- `DwCore.dispatchReport` stops alerting refusals, the way it already steps over connection blips. A custom `onErrorReport` **still receives them** and sorts them out with one type check: `if (report.error is DwRefusal) return;`.

## Tests

19 new. The wire contract on the server (what carries the mark, what does not, and that the key is absent otherwise), the mark pinned in the DTO-action tests, `processApiResponse` in both directions plus an older server that marks nothing, a refused `dw.repo.saveModel`, `dw.action` (the rule's text wins, an ordinary failure still shows the action's text, the report arrives typed), and the built-in policy alerting a `StateError` but not a refusal.

Green: 78 (core_server) / 122 (core_flutter) / 41 (dartway_flutter). `analyze` clean everywhere except the pre-existing `dead_code` in generated `dw_updates_transport.dart`; `example/` and `template/` analyze with zero errors.

## Synchronisation

`framework-finish` reports no drift.

- **Versions:** `master` and `stable` had converged, so this cycle moves the four `dartway_serverpod_core_*` packages `0.10.0 → 0.11.0` (lockstep) and `dartway_flutter` `0.6.0 → 0.7.0`. Carets follow in 22 places — `example/`, `template/` and every sibling package; siblings are not themselves bumped, as in the `0.5.1 → 0.6.0` cycle.
- **Docs:** a new section in `2-core/error-reporting.md`, the refusal contract in `2-core/crud-configs.md`, and the note in `3-flutter/actions.md`.
- **Skills:** `dartway-data-layer` §4 gains the client half (including "write nothing" and "never match the message text"), `dartway-crud-config` says the mark is set by refusing the documented way.
- **Changelogs:** all five bumped packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)