### PR TITLE
feat(alerts): a proxy and a deadline for the Telegram sink

### DIFF
--- a/docs/2-core/error-reporting.md
+++ b/docs/2-core/error-reporting.md
@@ -54,6 +54,49 @@ Features come for free: any widget implementing `DwFeature` (see the example
 app) is picked up by `DwFeature.scanMounted()` at the moment of the error — the
 alert names the features of the screen where it happened.
 
+## Sending them to Telegram
+
+The sink is configured once, where `DwCore.init` is called on the server:
+
+```dart
+dwAlerts: DwAlerts.init(
+  telegramConfig: DwTelegramAlertsConfig.fromEnv(env: passwords),
+  httpClient: DwProxyHttpClient.fromEnv(env: passwords),
+),
+```
+
+Both read `config/passwords.yaml`, and both return `null` when their keys are
+absent — a project with no bot token logs its alerts instead of failing to
+boot.
+
+```yaml
+production:
+  dwTelegramAlertsToken: '123456:ABC-DEF...'
+  dwTelegramAlertsChatId: '-1001234567890'
+  dwTelegramAlertsMessageThreadId: '42'   # optional, a topic in the group
+  dwTelegramAlertsProxyUrl: 'http://user:pass@10.0.0.5:3128'  # optional
+```
+
+`DwTelegramAlertsKeys` names all four in code, so a typo is a compile error
+rather than a `null` discovered in production.
+
+### When the server cannot reach Telegram
+
+`dwTelegramAlertsProxyUrl` is for hosts whose outbound access to
+`api.telegram.org` is blocked — which is the normal state of a Russian
+production host, and of plenty of corporate networks. `DwProxyHttpClient.fromEnv`
+turns the URL into the client every alert is then sent through; credentials are
+optional, and a value that is not a proxy URL is logged and ignored rather than
+taken down with the boot.
+
+The failure it prevents is worth naming, because it does not look like a
+network failure. A firewall that **drops** packets instead of refusing them
+leaves the connection hanging rather than failing it, so every alert holds a
+socket open until the platform gives up minutes later. A server reporting errors
+in bursts — which is exactly when it is reporting errors — runs out of sockets,
+and the symptom shows up somewhere else entirely. Alerts carry their own
+deadline for that reason (10 seconds), proxy or no proxy.
+
 ## A refusal is not an error
 
 A rule on the server saying no — `validateSave` returning its text, an action

--- a/example/dartway_example_server/lib/src/dartway/dartway_core.dart
+++ b/example/dartway_example_server/lib/src/dartway/dartway_core.dart
@@ -105,7 +105,14 @@ void initDartwayCore({
     // the subscription.
     channelConfigurations: [],
     userProfileConstructor: _buildUserProfile,
-    dwAlerts: DwAlerts.init(),
+    // Telegram when this run mode carries the dwTelegramAlerts* keys, the log
+    // otherwise. `DwProxyHttpClient` is the way out of a host whose outbound
+    // access to api.telegram.org is blocked: set dwTelegramAlertsProxyUrl and
+    // the same alerts travel through a proxy; absent, they go out directly.
+    dwAlerts: DwAlerts.init(
+      telegramConfig: DwTelegramAlertsConfig.fromEnv(env: passwords),
+      httpClient: DwProxyHttpClient.fromEnv(env: passwords),
+    ),
     // Uploads are optional: configured when this run mode carries the
     // dwCloudStorage* keys (development points them at the `minio` service in
     // docker-compose), and simply absent when it does not.

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -134,14 +134,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   ffi:
     dependency: transitive
     description:

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.11.0
 
+**New: `DwProxyHttpClient.fromEnv`** — alerts reach Telegram from a host that cannot reach it
+directly. Reads `dwTelegramAlertsProxyUrl` (`http://user:pass@host:port`, credentials optional)
+from `passwords.yaml` and returns the `http.Client` to hand `DwAlerts.init(httpClient: ...)`. The
+key absent, blank or unparseable returns null — no client, direct access, today's behaviour bit for
+bit — and says so through the optional `logFunction` rather than failing the boot. See the alerts
+entry in `dartway_serverpod_core_shared` for the timeout that ships with it.
+
 **A refusal now says on the wire that it is one.** A rule saying no and a server breaking both
 travel in `DwApiResponse.error`, so the client could tell them apart only by comparing the message
 against strings it hoped the server still used. It did not, and every ordinary refusal reached the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/dartway_serverpod_core_server.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/dartway_serverpod_core_server.dart
@@ -1,5 +1,6 @@
 export 'package:dartway_serverpod_core_shared/dartway_serverpod_core_shared.dart';
 
+export 'src/business/alerts/dw_proxy_http_client.dart';
 export 'src/business/auth/dw_auth_config.dart';
 export 'src/business/auth/dw_authentification_handler.dart';
 export 'src/business/auth/dw_password_hashing.dart';

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/alerts/dw_proxy_http_client.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/alerts/dw_proxy_http_client.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:dartway_serverpod_core_shared/dartway_serverpod_core_shared.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+
+import 'dw_proxy_settings.dart';
+
+/// The outbound HTTP client alerts are sent through when the server cannot
+/// reach `api.telegram.org` itself.
+///
+/// Lives on the server and nowhere else: it is `dart:io` from top to bottom,
+/// and a proxy is a property of the machine the server runs on, not of the
+/// app. The Flutter half of the core never sees it — which is also why
+/// `DwAlerts` takes a plain `http.Client` rather than anything of this shape.
+abstract final class DwProxyHttpClient {
+  /// How long a connection to the proxy itself may take to establish.
+  ///
+  /// The send has its own deadline (`DwTelegramService.sendTimeout`); this one
+  /// covers the leg before it, where a proxy that has gone away leaves the
+  /// connect hanging.
+  static const connectionTimeout = Duration(seconds: 10);
+
+  /// Builds a proxying client from [env] (typically the app's `passwords.yaml`).
+  ///
+  /// Returns null when
+  /// [DwTelegramAlertsKeys.dwTelegramAlertsProxyUrlKey] is absent, blank, or
+  /// not a proxy URL — and null is not a failure, it is the default: it hands
+  /// `DwAlerts` no client, and alerts then go out directly, exactly as they did
+  /// before the key existed.
+  ///
+  /// ```dart
+  /// dwAlerts: DwAlerts.init(
+  ///   telegramConfig: DwTelegramAlertsConfig.fromEnv(env: passwords),
+  ///   httpClient: DwProxyHttpClient.fromEnv(env: passwords),
+  /// ),
+  /// ```
+  ///
+  /// The client is meant to live as long as the process — `DwAlerts` keeps it
+  /// and reuses it for every alert. Nothing closes it, deliberately: the sink
+  /// outlives every send that goes through it.
+  static http.Client? fromEnv({
+    required Map<String, String> env,
+    void Function(String message)? logFunction,
+  }) {
+    final settings = DwProxySettings.parse(
+      env[DwTelegramAlertsKeys.dwTelegramAlertsProxyUrlKey],
+      logFunction: logFunction,
+    );
+
+    if (settings == null) return null;
+
+    logFunction?.call(
+      'DwProxyHttpClient: alerts go through ${settings.host}:${settings.port}'
+      '${settings.hasCredentials ? ' (authenticated)' : ''}.',
+    );
+
+    return IOClient(_buildHttpClient(settings));
+  }
+
+  static HttpClient _buildHttpClient(DwProxySettings settings) {
+    final client = HttpClient()
+      ..connectionTimeout = connectionTimeout
+      ..findProxy = (_) => settings.proxyConfiguration;
+
+    if (settings.hasCredentials) {
+      // The empty realm is not a placeholder: `dart:io` matches proxy
+      // credentials by host and port, and consults the realm only for the
+      // challenge a proxy sends back.
+      client.addProxyCredentials(
+        settings.host,
+        settings.port,
+        '',
+        HttpClientBasicCredentials(settings.username!, settings.password!),
+      );
+    }
+
+    return client;
+  }
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/alerts/dw_proxy_settings.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/alerts/dw_proxy_settings.dart
@@ -1,0 +1,120 @@
+/// One outbound proxy, parsed out of a `passwords.yaml` value.
+///
+/// Internal to the package: apps never build one, they set the key and get a
+/// client back from `DwProxyHttpClient.fromEnv`. It is a type of its own so
+/// that the parsing — the part that quietly goes wrong in production, on a
+/// machine nobody can attach a debugger to — is testable without opening a
+/// socket.
+class DwProxySettings {
+  final String host;
+  final int port;
+
+  /// Proxy credentials, both null when the URL carried none.
+  final String? username;
+  final String? password;
+
+  const DwProxySettings({
+    required this.host,
+    required this.port,
+    this.username,
+    this.password,
+  });
+
+  bool get hasCredentials => username != null && password != null;
+
+  /// The proxy configuration string `HttpClient.findProxy` answers with.
+  String get proxyConfiguration => 'PROXY $host:$port';
+
+  /// Parses `http://user:pass@host:port` (credentials and port optional).
+  ///
+  /// Returns null for anything else — a missing value, a blank one, a bare
+  /// `host:port` with no scheme, junk — rather than guessing. A proxy is used
+  /// where the direct route is blocked, so a half-understood value would not
+  /// degrade to something slower, it would degrade to alerts that never arrive
+  /// while the config says they should. [logFunction] is how that becomes
+  /// audible; the library never writes to stdout on its own.
+  static DwProxySettings? parse(
+    String? raw, {
+    void Function(String message)? logFunction,
+  }) {
+    final value = raw?.trim();
+    if (value == null || value.isEmpty) return null;
+
+    void reject(String reason) => logFunction?.call(
+      'DwProxySettings.parse: $reason — expected '
+      'http://user:pass@host:port (credentials optional). Proxy stays off.',
+    );
+
+    final uri = Uri.tryParse(value);
+    if (uri == null) {
+      reject('not a URL');
+      return null;
+    }
+
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
+      reject(
+        uri.scheme.isEmpty
+            ? 'no scheme'
+            : 'unsupported scheme "${uri.scheme}"',
+      );
+      return null;
+    }
+
+    if (uri.host.isEmpty) {
+      reject('no host');
+      return null;
+    }
+
+    // `uri.port` falls back to the scheme default (80/443) when the URL states
+    // none, so a proxy written without a port still resolves to something.
+    final port = uri.port;
+    if (port <= 0 || port > 65535) {
+      reject('port $port is out of range');
+      return null;
+    }
+
+    if (uri.userInfo.isEmpty) {
+      return DwProxySettings(host: uri.host, port: port);
+    }
+
+    final separator = uri.userInfo.indexOf(':');
+    final rawUsername = separator == -1
+        ? uri.userInfo
+        : uri.userInfo.substring(0, separator);
+    final rawPassword = separator == -1
+        ? ''
+        : uri.userInfo.substring(separator + 1);
+
+    final String username;
+    final String password;
+    try {
+      // `Uri.userInfo` hands back the escapes as written — a password with a
+      // `@`, a `:` or a `/` in it has to arrive percent-encoded, and would
+      // otherwise be sent to the proxy literally as `%40`.
+      username = Uri.decodeComponent(rawUsername);
+      password = Uri.decodeComponent(rawPassword);
+    } on FormatException {
+      // `Uri.parse` repairs a lone `%` on its own (it becomes `%25`), so what
+      // reaches here is a well-formed escape of something that is not UTF-8.
+      reject('credentials are not valid percent-encoded UTF-8');
+      return null;
+    }
+
+    if (username.isEmpty) {
+      reject('credentials with an empty user name');
+      return null;
+    }
+
+    return DwProxySettings(
+      host: uri.host,
+      port: port,
+      username: username,
+      password: password,
+    );
+  }
+
+  @override
+  String toString() =>
+      'DwProxySettings($host:$port, '
+      '${hasCredentials ? 'authenticated' : 'anonymous'})';
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   dartway_serverpod_core_shared: ^0.11.0
   collection: ^1.19.1
   crypto: ^3.0.6
+  http: ^1.5.0
   bcrypt: ^1.1.3
   minio: ^3.5.8
   mime: ^2.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/alerts/dw_proxy_settings_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/alerts/dw_proxy_settings_test.dart
@@ -1,0 +1,144 @@
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:dartway_serverpod_core_server/src/business/alerts/dw_proxy_settings.dart';
+import 'package:test/test.dart';
+
+/// The proxy URL is read once, at boot, on a production machine nobody attaches
+/// a debugger to — and what it produces decides whether alerts arrive at all.
+/// These are the four shapes that reach it.
+void main() {
+  group('DwProxySettings.parse', () {
+    test('reads host, port and credentials', () {
+      final settings = DwProxySettings.parse('http://bob:s3cret@10.0.0.5:3128');
+
+      expect(settings, isNotNull);
+      expect(settings!.host, '10.0.0.5');
+      expect(settings.port, 3128);
+      expect(settings.username, 'bob');
+      expect(settings.password, 's3cret');
+      expect(settings.hasCredentials, isTrue);
+      expect(settings.proxyConfiguration, 'PROXY 10.0.0.5:3128');
+    });
+
+    test('percent-encoded credentials arrive decoded', () {
+      // A password with a `@` or a `:` has to be encoded to survive the URL —
+      // sent on literally, the proxy would refuse every alert.
+      final settings = DwProxySettings.parse(
+        'http://bob%40corp:p%40ss%3Aword@proxy.example.com:8080',
+      );
+
+      expect(settings!.username, 'bob@corp');
+      expect(settings.password, 'p@ss:word');
+    });
+
+    test('reads a proxy without credentials', () {
+      final settings = DwProxySettings.parse('http://proxy.example.com:8080');
+
+      expect(settings, isNotNull);
+      expect(settings!.host, 'proxy.example.com');
+      expect(settings.port, 8080);
+      expect(settings.username, isNull);
+      expect(settings.password, isNull);
+      expect(settings.hasCredentials, isFalse);
+    });
+
+    test('falls back to the scheme port when none is stated', () {
+      expect(DwProxySettings.parse('http://proxy.example.com')?.port, 80);
+      expect(DwProxySettings.parse('https://proxy.example.com')?.port, 443);
+    });
+
+    test('a blank or missing value is no proxy, and says nothing', () {
+      final complaints = <String>[];
+
+      expect(DwProxySettings.parse(null, logFunction: complaints.add), isNull);
+      expect(DwProxySettings.parse('', logFunction: complaints.add), isNull);
+      expect(DwProxySettings.parse('   ', logFunction: complaints.add), isNull);
+
+      // Not configuring a proxy is the normal case, not a misconfiguration.
+      expect(complaints, isEmpty);
+    });
+
+    test('junk is refused audibly rather than guessed at', () {
+      for (final junk in [
+        'proxy.example.com:3128', // no scheme — the commonest typo
+        'socks5://proxy.example.com:1080', // not an HTTP proxy
+        'http://', // no host
+        'not a url at all',
+        'http://bob:secret@', // credentials, nothing to connect to
+        'http://:secret@proxy.example.com:3128', // no user name
+      ]) {
+        final complaints = <String>[];
+
+        expect(
+          DwProxySettings.parse(junk, logFunction: complaints.add),
+          isNull,
+          reason: 'expected "$junk" to be refused',
+        );
+        expect(complaints, hasLength(1), reason: 'silent about "$junk"');
+      }
+    });
+
+    test('an undecodable escape is junk, not a crash at boot', () {
+      final complaints = <String>[];
+
+      expect(
+        DwProxySettings.parse(
+          'http://bob:%C3%28@proxy.example.com:3128',
+          logFunction: complaints.add,
+        ),
+        isNull,
+      );
+      expect(complaints, hasLength(1));
+    });
+
+    test('a lone percent sign is taken literally, the way a URL reads it', () {
+      // `Uri.parse` escapes it to `%25` before we ever see it, so `50%` is a
+      // password of three characters rather than a refused config.
+      expect(
+        DwProxySettings.parse('http://bob:50%@proxy.example.com:3128')?.password,
+        '50%',
+      );
+    });
+  });
+
+  group('DwProxyHttpClient.fromEnv', () {
+    test('no key at all means direct access, exactly as before', () {
+      expect(DwProxyHttpClient.fromEnv(env: const {}), isNull);
+    });
+
+    test('a blank key means direct access', () {
+      expect(
+        DwProxyHttpClient.fromEnv(
+          env: const {DwTelegramAlertsKeys.dwTelegramAlertsProxyUrlKey: '  '},
+        ),
+        isNull,
+      );
+    });
+
+    test('junk degrades to direct access instead of failing the boot', () {
+      final complaints = <String>[];
+
+      expect(
+        DwProxyHttpClient.fromEnv(
+          env: const {
+            DwTelegramAlertsKeys.dwTelegramAlertsProxyUrlKey: 'nonsense',
+          },
+          logFunction: complaints.add,
+        ),
+        isNull,
+      );
+      expect(complaints, hasLength(1));
+    });
+
+    test('a proxy URL builds a client', () {
+      final client = DwProxyHttpClient.fromEnv(
+        env: const {
+          DwTelegramAlertsKeys.dwTelegramAlertsProxyUrlKey:
+              'http://bob:s3cret@10.0.0.5:3128',
+        },
+      );
+
+      expect(client, isNotNull);
+      client!.close();
+    });
+  });
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 ## 0.11.0
 
-Version bump only. The four `dartway_serverpod_core_*` packages move in lockstep, and 0.11.0 is the
-refusal reaching the client as an answer rather than an exception — `DwApiResponse.isRefusal` on the
-wire, `DwRefusal` on the Flutter side. See the changelog of `dartway_serverpod_core_flutter`.
+**An alert now has a deadline and a way through a proxy.** Both are about the same production
+symptom: a host that cannot reach `api.telegram.org`.
+
+- **New: `DwAlerts.init(httpClient: ...)`** — the transport every alert is sent through. Left null,
+  each send builds and closes a plain client of its own and goes out directly, exactly as before.
+  On the server, `DwProxyHttpClient.fromEnv` builds a proxying one from `passwords.yaml` (see
+  `dartway_serverpod_core_server`).
+- `DwTelegramService.sendMessage` takes the same `client`, one level down — the seam `DwAlerts`
+  passes it through.
+- **New: a 10-second timeout on the send.** There was none. A firewall that *drops* packets rather
+  than refusing them leaves the connection hanging instead of failing it, so every alert held a
+  socket open until the platform default gave up minutes later — and a server reports errors in
+  bursts, which is precisely when it cannot afford to.
+- **New: `DwTelegramAlertsKeys.dwTelegramAlertsProxyUrlKey`** (`dwTelegramAlertsProxyUrl`), read on
+  the server. It sits with the other alert keys so the name cannot drift from `passwords.yaml`.
+
+Also in 0.11.0, from the other packages moving in lockstep: the refusal reaching the client as an
+answer rather than an exception — `DwApiResponse.isRefusal` on the wire, `DwRefusal` on the Flutter
+side. See the changelog of `dartway_serverpod_core_flutter`.
 
 ## 0.10.0
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/alerts/configs/dw_telegram_alerts_keys.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/alerts/configs/dw_telegram_alerts_keys.dart
@@ -1,5 +1,4 @@
-/// Keys `DwTelegramAlertsConfig.fromEnv` reads from the server's
-/// `passwords.yaml`.
+/// Keys the Telegram alerts sink reads from the server's `passwords.yaml`.
 ///
 /// The values are the literal key names an app writes in that file — renaming
 /// one breaks every deployment that already has it.
@@ -8,4 +7,13 @@ class DwTelegramAlertsKeys {
   static const dwTelegramAlertsTokenKey = 'dwTelegramAlertsToken';
   static const dwTelegramAlertsMessageThreadIdKey =
       'dwTelegramAlertsMessageThreadId';
+
+  /// The outbound proxy alerts are sent through, as
+  /// `http://user:pass@host:port` (credentials optional).
+  ///
+  /// Read by `DwProxyHttpClient.fromEnv` on the server. Absent — the normal
+  /// case — alerts go to Telegram directly. It lives here, beside the keys the
+  /// config itself reads, because the proxy is part of the same `passwords.yaml`
+  /// block and the two drift apart the moment they are named in two places.
+  static const dwTelegramAlertsProxyUrlKey = 'dwTelegramAlertsProxyUrl';
 }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/alerts/dw_alerts.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/alerts/dw_alerts.dart
@@ -1,3 +1,5 @@
+import 'package:http/http.dart' as http;
+
 import '../services/dw_telegram_service.dart';
 import 'configs/dw_telegram_alerts_config.dart';
 import 'dw_alert_context.dart';
@@ -5,6 +7,7 @@ import 'dw_alert_formatter.dart';
 
 class DwAlerts {
   final DwTelegramAlertsConfig? _telegramConfig;
+  final http.Client? _httpClient;
   final Function(String message)? _logFunction;
   final bool _logMessages;
   final bool _logErrors;
@@ -18,14 +21,24 @@ class DwAlerts {
     return _instance!;
   }
 
+  /// Builds the process-wide sink.
+  ///
+  /// [httpClient] is the transport alerts are sent through. Left null — the
+  /// usual case — each send builds and closes a plain client of its own, which
+  /// reaches Telegram directly. Where outbound access to `api.telegram.org` is
+  /// blocked, the server passes a proxying client built by
+  /// `DwProxyHttpClient.fromEnv`; it is kept for the lifetime of the process,
+  /// so pass one that is safe to reuse.
   static DwAlerts init({
     DwTelegramAlertsConfig? telegramConfig,
+    http.Client? httpClient,
     Function(String message) logFunction = print,
     bool logMessages = false,
     bool logErrors = true,
   }) {
     _instance = DwAlerts._(
       telegramConfig: telegramConfig,
+      httpClient: httpClient,
       logFunction: logFunction,
       logMessages: logMessages,
       logErrors: logErrors,
@@ -36,10 +49,12 @@ class DwAlerts {
 
   DwAlerts._({
     DwTelegramAlertsConfig? telegramConfig,
+    http.Client? httpClient,
     Function(String message)? logFunction,
     required bool logMessages,
     required bool logErrors,
   }) : _telegramConfig = telegramConfig,
+       _httpClient = httpClient,
        _logFunction = logFunction,
        _logMessages = logMessages,
        _logErrors = logErrors;
@@ -90,6 +105,7 @@ class DwAlerts {
         // template markup alive) — escaping them again would kill the markup.
         escapeMessage: !isPreformatted,
         reportErrorFunction: suppressErrors ? (_) {} : _sendAlertingError,
+        client: _httpClient,
       );
     }
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/services/dw_telegram_service.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/lib/src/services/dw_telegram_service.dart
@@ -8,10 +8,27 @@ import '../alerts/dw_alerts.dart';
 class DwTelegramService {
   static const _telegramLimit = 4096;
 
+  /// How long one send is allowed to take before it is given up on.
+  ///
+  /// Alerts are a side channel — nothing waits on them — which is exactly why
+  /// a missing deadline is dangerous rather than harmless: where the route to
+  /// `api.telegram.org` is blocked by a firewall that drops packets instead of
+  /// refusing them, the connection does not fail, it hangs. Every alert then
+  /// parks a socket for the platform default (minutes), and a server that
+  /// reports errors in bursts runs out of them.
+  static const sendTimeout = Duration(seconds: 10);
+
   /// Sends a message to Telegram (MarkdownV2). With [escapeMessage] the whole
   /// text is escaped and truncated (plain-text callers); pass `false` for
   /// messages that are already valid MarkdownV2 (e.g. built by
   /// [DwAlertFormatter]) — they only get the safety truncation.
+  ///
+  /// [client] is the transport to send through. Omitted, a plain client is
+  /// built for the call and closed after it — direct access, which is what
+  /// every deployment that can reach Telegram wants. A deployment that cannot
+  /// passes one that goes through a proxy; on the server
+  /// `DwProxyHttpClient.fromEnv` builds it. The client is never closed here
+  /// when the caller supplied it: it is theirs, and it is reused across alerts.
   static Future<void> sendMessage({
     required String message,
     required String chatId,
@@ -19,7 +36,10 @@ class DwTelegramService {
     String? messageThreadId,
     bool escapeMessage = true,
     Function(String message)? reportErrorFunction,
+    http.Client? client,
   }) async {
+    final httpClient = client ?? http.Client();
+
     try {
       final safeMessage = escapeMessage
           ? _prepareMessage(message)
@@ -34,11 +54,13 @@ class DwTelegramService {
         if (messageThreadId != null) "message_thread_id": messageThreadId,
       };
 
-      final res = await http.post(
-        url,
-        headers: {"Content-Type": "application/json"},
-        body: jsonEncode(body),
-      );
+      final res = await httpClient
+          .post(
+            url,
+            headers: {"Content-Type": "application/json"},
+            body: jsonEncode(body),
+          )
+          .timeout(sendTimeout);
 
       if (res.statusCode != 200) {
         (reportErrorFunction ?? DwAlerts.instance.sendMessage)(
@@ -49,6 +71,8 @@ class DwTelegramService {
       (reportErrorFunction ?? DwAlerts.instance.sendError)(
         "⚠️ DwTelegramService: Exception while sending message: $e",
       );
+    } finally {
+      if (client == null) httpClient.close();
     }
   }
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/test/dw_telegram_service_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/test/dw_telegram_service_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dartway_serverpod_core_shared/src/services/dw_telegram_service.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+/// A client that answers from [handler] and remembers whether anyone closed it.
+class _RecordingClient extends http.BaseClient {
+  _RecordingClient(this.handler);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+  handler;
+
+  final List<http.BaseRequest> requests = [];
+  bool closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    requests.add(request);
+    return handler(request);
+  }
+
+  @override
+  void close() => closed = true;
+}
+
+http.StreamedResponse _response(int statusCode, [String body = '{"ok":true}']) =>
+    http.StreamedResponse(Stream.value(utf8.encode(body)), statusCode);
+
+void main() {
+  group('DwTelegramService.sendMessage', () {
+    test('sends through the injected client', () async {
+      final client = _RecordingClient((_) async => _response(200));
+
+      await DwTelegramService.sendMessage(
+        message: 'Deploy finished',
+        chatId: '-100500',
+        token: 'bot-token',
+        messageThreadId: '7',
+        client: client,
+        reportErrorFunction: (message) => fail('unexpected report: $message'),
+      );
+
+      expect(client.requests, hasLength(1));
+      final request = client.requests.single as http.Request;
+      expect(
+        request.url.toString(),
+        'https://api.telegram.org/botbot-token/sendMessage',
+      );
+
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+      expect(body['chat_id'], '-100500');
+      expect(body['message_thread_id'], '7');
+      expect(body['text'], 'Deploy finished');
+    });
+
+    test('leaves the injected client open — the sink reuses it', () async {
+      final client = _RecordingClient((_) async => _response(200));
+
+      await DwTelegramService.sendMessage(
+        message: 'hello',
+        chatId: 'chat',
+        token: 'token',
+        client: client,
+      );
+
+      expect(client.closed, isFalse);
+    });
+
+    test('reports a refusal from Telegram instead of throwing', () async {
+      final reports = <String>[];
+      final client = _RecordingClient(
+        (_) async => _response(400, '{"description":"chat not found"}'),
+      );
+
+      await DwTelegramService.sendMessage(
+        message: 'hello',
+        chatId: 'chat',
+        token: 'token',
+        client: client,
+        reportErrorFunction: reports.add,
+      );
+
+      expect(reports, hasLength(1));
+      expect(reports.single, contains('400'));
+      expect(reports.single, contains('chat not found'));
+    });
+
+    test('a send that runs out of time is reported, not left hanging', () async {
+      // The real deadline is `sendTimeout`; a test cannot wait it out, so the
+      // transport raises what the deadline would have raised. What is under
+      // test is the handling: reported through the alert sink, and the future
+      // completes rather than never returning.
+      final reports = <String>[];
+      final client = _RecordingClient(
+        (_) => Future.error(TimeoutException('no answer', DwTelegramService.sendTimeout)),
+      );
+
+      await DwTelegramService.sendMessage(
+        message: 'hello',
+        chatId: 'chat',
+        token: 'token',
+        client: client,
+        reportErrorFunction: reports.add,
+      );
+
+      expect(reports, hasLength(1));
+      expect(reports.single, contains('TimeoutException'));
+    });
+
+    test('the deadline is short enough to keep sockets from piling up', () {
+      expect(DwTelegramService.sendTimeout, lessThanOrEqualTo(const Duration(seconds: 15)));
+    });
+  });
+}

--- a/template/dartway_starter_server/config/passwords.yaml.example
+++ b/template/dartway_starter_server/config/passwords.yaml.example
@@ -55,3 +55,8 @@ test:
 #   dwVerificationCodeSalt:
 #   bootstrapAdminIdentifier:
 #   redis:
+#   # Runtime error reports to Telegram — optional, and the log is the fallback.
+#   # The proxy is for a host that cannot reach api.telegram.org directly.
+#   dwTelegramAlertsToken:
+#   dwTelegramAlertsChatId:
+#   dwTelegramAlertsProxyUrl:

--- a/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
+++ b/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
@@ -53,7 +53,14 @@ void initDartwayCore({
     //   ),
     channelConfigurations: [],
     userProfileConstructor: _buildUserProfile,
-    dwAlerts: DwAlerts.init(),
+    // Telegram when this run mode carries the dwTelegramAlerts* keys, the log
+    // otherwise. `DwProxyHttpClient` is the way out of a host whose outbound
+    // access to api.telegram.org is blocked: set dwTelegramAlertsProxyUrl and
+    // the same alerts travel through a proxy; absent, they go out directly.
+    dwAlerts: DwAlerts.init(
+      telegramConfig: DwTelegramAlertsConfig.fromEnv(env: passwords),
+      httpClient: DwProxyHttpClient.fromEnv(env: passwords),
+    ),
     // Uploads are optional: configured when this run mode carries the
     // dwCloudStorage* keys (development points them at the `minio` service in
     // docker-compose), and simply absent when it does not — rather than a boot


### PR DESCRIPTION
Two halves of one production symptom: a server whose outbound route to `api.telegram.org` is blocked.

## What changes

**`dartway_serverpod_core_shared` — the seam**

- `DwAlerts.init(httpClient:)` and `DwTelegramService.sendMessage(client:)` take the transport alerts travel on. Left null, each send builds and closes a plain client of its own and goes out directly — today's behaviour bit for bit. A supplied client is never closed here: it is the caller's, and the sink reuses it for the life of the process.
- **A 10-second deadline on the send.** There was none. A firewall that *drops* packets rather than refusing them leaves the connection hanging instead of failing it, so every alert held a socket open until the platform default gave up minutes later — and a server reports errors in bursts, which is exactly when it cannot afford to.
- No `dart:io` reaches this package; the web build is untouched.

**`dartway_serverpod_core_server` — the client**

- `DwProxyHttpClient.fromEnv({env, logFunction})` → `http.Client?`, built from `dwTelegramAlertsProxyUrl` (`http://user:pass@host:port`, credentials optional) in `passwords.yaml`. Inside: `HttpClient()..connectionTimeout = 10s ..findProxy = (_) => 'PROXY host:port'`, plus `addProxyCredentials` when the URL carries them.
- The key absent, blank or unparseable returns `null` — no client, direct access, unchanged behaviour — and says so through the optional `logFunction` rather than failing the boot.
- The key name sits in `DwTelegramAlertsKeys`, with the keys the config already reads, so it cannot drift from the file it is written in.

The empty realm passed to `addProxyCredentials` is not a placeholder: `dart:io` matches proxy credentials by host and port and consults the realm only for the challenge a proxy sends back.

## Tests

17 new ones. Parsing is the part that quietly goes wrong on a production host nobody can attach a debugger to, so it lives in an internal `DwProxySettings.parse` and is tested without opening a socket: credentials, percent-encoded credentials, no credentials, the scheme's default port, blank/missing (silent — not configuring a proxy is normal), and six shapes of junk including a scheme-less `host:port` and `socks5://`, each refused with exactly one line in the log. Plus `fromEnv` over an empty env, a blank key, junk, and a real URL; and on the shared side, that the injected client is used and left open, that a non-200 and a timeout are reported instead of thrown.

## Synchronisation law

- `example/` and `template/` now wire the sink the documented way — `DwTelegramAlertsConfig.fromEnv` + `DwProxyHttpClient.fromEnv`. With no keys in `passwords.yaml` both return null and alerts still go to the log, so nothing changes for a fresh project; without it the new option would be dead code in the skeleton.
- `template/config/passwords.yaml.example` names the keys in the deployed-environment block.
- `docs/2-core/error-reporting.md` gains "Sending them to Telegram", including why the deadline exists.
- `CHANGELOG.md` of both packages, under the pending 0.11.0.
- No version moves: master is already at 0.11.0 against 0.10.0 on `stable`, and this is additive. Carets in `example/` and `template/` checked and satisfied.
- No toolkit skill teaches this API, so nothing there went stale. The Studio bridge is untouched.

`analyze` clean in shared, server, flutter, example and template; shared, server and flutter test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)