### PR TITLE
feat(cli): doctor checks the pub host and a git identity

### DIFF
--- a/docs/1-getting-started/quick-start.md
+++ b/docs/1-getting-started/quick-start.md
@@ -9,6 +9,9 @@ and 2 for you — [start with an agent](start-with-an-agent.md).
 ## Prerequisites
 
 - Dart SDK `>=3.11` and Flutter `>=3.41` (FVM works; the template carries a `.fvmrc`)
+- git, with `user.name` and `user.email` set — `create` commits the project it makes for you
+- Network access to pub.dev (or a mirror in `PUB_HOSTED_URL`). `pub get` has no deadline of its
+  own: where the route is filtered or throttled it does not fail, it hangs
 - Docker — the project brings up its own Postgres
 - The Serverpod CLI, **pinned to the version the template depends on**:
 
@@ -20,8 +23,8 @@ and 2 for you — [start with an agent](start-with-an-agent.md).
   version, and a CLI newer than the `serverpod` in your pubspec produces a generated protocol that
   compiles and then misbehaves at runtime.
 
-`dartway doctor` checks all four and prints the fix for whatever is missing — run it instead of
-checking by hand.
+`dartway doctor` checks all of these and prints the fix for whatever is missing — run it instead
+of checking by hand.
 
 ## 1. Create the project
 

--- a/docs/1-getting-started/start-with-an-agent.md
+++ b/docs/1-getting-started/start-with-an-agent.md
@@ -32,6 +32,12 @@ The assistant will run `dartway doctor` first, which reports each of these and p
 whatever is missing:
 
 - **Dart `>=3.11` and Flutter `>=3.41`**
+- **git, with an identity.** `create` commits the project it makes for you; without
+  `user.name` and `user.email` that commit is the one step that does not happen.
+- **A pub host that answers.** Every step of the setup begins with `pub get`, and pub sets no
+  deadline on a connection that opens and then goes quiet — where the route to pub.dev is
+  filtered or throttled you get no error, just a resolve step that hangs. Doctor rules it out in
+  one request; a mirror in `PUB_HOSTED_URL` is checked instead when you have one.
 - **Docker, running.** The database comes from it and there is no second path. This is the one an
   assistant cannot solve for you: Docker Desktop does not install unattended, so if doctor says the
   daemon is not responding, start it.

--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -73,12 +73,14 @@ friendlier version to drift from it.
 dartway doctor
 ```
 
-Checks the five things that break a first run, and prints the exact fix for each:
+Checks the seven things that break a first run, and prints the exact fix for each:
 
 | Check | Why it is here |
 |---|---|
 | Dart `>=3.11` | The SDK running the CLI is the one that will run the project |
 | Flutter `>=3.41` | |
+| git, and a configured `user.name`/`user.email` | `create` clones the template with git and then commits the result. A missing binary is a failure; an unset identity is a warning — the project is complete either way, but its repository has no initial commit, and git says so in its own text in the machine's locale, in the middle of successful output |
+| A pub host that answers | `pub get` sets no deadline on a connection that opens and then goes quiet, so a filtered or throttled route to pub.dev surfaces as a resolve step that prints one line and hangs with no error and no exit. The probe asks for bytes rather than for a socket — a TCP connect succeeds even when the handshake after it is filtered — and honours `PUB_HOSTED_URL`, so it tests whatever pub itself would talk to |
 | A responding Docker daemon | Postgres comes from it, and there is no second path. Installed-but-stopped is reported separately from missing |
 | `serverpod_cli` matching the project's pin | The generator writes code for its own version; a drifted CLI produces a protocol that compiles and then misbehaves at runtime. Inside a project the expected version is read from the server package rather than assumed |
 | The pub global bin directory on PATH | The cause of `dartway: command not found` right after a successful install. A warning, not a failure — the fallback is `dart pub global run dartway_cli:dartway` |

--- a/example/README.md
+++ b/example/README.md
@@ -41,8 +41,8 @@ flutter run
 Sign in as **79990000003** (a client), **79990000002** (a coach) or **79990000001** (the admin).
 There are no passwords: the one-time code is printed in the server console.
 
-`dartway doctor` says whether this machine has what any of it needs — Dart, Flutter, a responding
-Docker daemon, a `serverpod_cli` matching the pin.
+`dartway doctor` says whether this machine has what any of it needs — Dart, Flutter, git, a pub
+host that answers, a responding Docker daemon, a `serverpod_cli` matching the pin.
 
 ## Tests
 

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dev_dependencies:
     sdk: flutter
 
 
-  dartway_cli: ^0.8.0
+  dartway_cli: ^0.9.0
 
   # The UI-kit law is enforced here, not just written down: raw Color/TextStyle/
   # BorderRadius and direct theme access outside `ui_kit/` are lints. Needs

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.9.0
+
+- **`doctor` checks the two prerequisites that used to let a machine through and then stop it dead:
+  the route to the pub host, and a git identity.**
+
+  Doctor's promise is that a machine can create and run a project. It was possible for it to report
+  one problem, have that fixed, and then hand over to a `dart pub get` that hung for an hour: pub
+  sets no deadline on a connection that opens and then goes quiet, so a filtered or throttled route
+  to pub.dev surfaces as a resolve step printing one line and nothing after it, with no error, no
+  progress and no exit. That is the worst shape a prerequisite failure can take, and it is one
+  request to rule out. The check asks the pub host for bytes rather than for a socket — a TCP
+  connect succeeds even when the handshake after it is being filtered — honours `PUB_HOSTED_URL` so
+  it probes whatever pub itself would talk to, gives up after ten seconds and fails, since a machine
+  that cannot fetch packages cannot create or run anything.
+
+  The git half is a warning, not a failure. `create` clones the template with git and then commits
+  the result, and with no `user.name`/`user.email` that commit fails: the project is complete and
+  usable, but its repository has no initial commit, and the reason arrives as a wall of git's own
+  text in the machine's locale in the middle of otherwise successful output. Doctor now names the
+  two config commands up front. A missing git binary is a failure — the clone needs it.
+
 ## 0.8.0
 
 - **The two git-ignored journals are retired; the project's own findings become `docs/dev_notes/`,

--- a/packages/dartway_cli/lib/src/commands/doctor_command.dart
+++ b/packages/dartway_cli/lib/src/commands/doctor_command.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 
 import '../project_layout.dart';
+import '../pub_host.dart';
 import '../version_check.dart';
 
 /// Checks that this machine can actually create and run a DartWay project.
@@ -14,6 +16,12 @@ import '../version_check.dart';
 /// those surfaces much later — as a connection refused during migrations, as
 /// generated code that compiles and then misbehaves, as `dartway: not found` —
 /// and each is trivially detectable up front.
+///
+/// Two of the checks below are here because doctor once passed a machine that
+/// could not get past the first command of the setup brief. A route to the pub
+/// host that opens and then goes quiet makes `dart pub get` hang forever with
+/// no output at all, and git without an identity leaves `dartway create` unable
+/// to make the initial commit it just promised.
 ///
 /// Every failure prints the command that fixes it. An agent runs this first and
 /// relays what is missing; nothing below it works until this passes.
@@ -27,6 +35,10 @@ class DoctorCommand extends Command<int> {
   /// Inside a project the pin is read from the server package instead — the
   /// generator must match the runtime, and only the project knows its runtime.
   static const _defaultServerpodCli = '3.4.11';
+
+  /// Long enough for a slow but working link, short enough that doctor stays a
+  /// command you run without planning for it.
+  static const _networkTimeout = Duration(seconds: 10);
 
   @override
   String get name => 'doctor';
@@ -44,6 +56,8 @@ class DoctorCommand extends Command<int> {
     final checks = [
       _checkDart(),
       _checkFlutter(),
+      _checkGit(),
+      await _checkPubHost(),
       _checkDocker(),
       _checkServerpodCli(expectedServerpodCli),
       _checkPubGlobalBinOnPath(),
@@ -117,6 +131,101 @@ class DoctorCommand extends Command<int> {
             fix: 'flutter upgrade',
           );
   }
+
+  /// git is not optional here: `dartway create` clones the framework template
+  /// with it and then commits the result. The identity half is only a warning —
+  /// the project it produces is complete either way — but an unset identity
+  /// fails the commit, and the reason arrives as a wall of git's own text in
+  /// the machine's locale, in the middle of otherwise successful output.
+  _Check _checkGit() {
+    if (_run('git', ['--version']) == null) {
+      return _Check.fail(
+        'git',
+        'not found on PATH',
+        fix:
+            'Install git — https://git-scm.com/downloads '
+            '(`dartway create` clones the template with it)',
+      );
+    }
+    final missing = [
+      if (_gitConfig('user.name') == null) 'user.name',
+      if (_gitConfig('user.email') == null) 'user.email',
+    ];
+    if (missing.isEmpty) {
+      return _Check.ok('git', 'installed, identity configured');
+    }
+    return _Check.warn(
+      'git',
+      'installed, but ${missing.join(' and ')} '
+          '${missing.length == 1 ? 'is' : 'are'} not set',
+      fix:
+          'git config --global user.name "Your Name" && '
+          'git config --global user.email "you@example.com"  '
+          '(without an identity `dartway create` leaves the new project '
+          'without its initial commit)',
+    );
+  }
+
+  String? _gitConfig(String key) {
+    final result = _run('git', ['config', '--get', key]);
+    if (result == null || result.exitCode != 0) return null;
+    final value = (result.stdout as String).trim();
+    return value.isEmpty ? null : value;
+  }
+
+  /// The one prerequisite whose absence does not announce itself.
+  ///
+  /// `dart pub get` sets no deadline on a connection that opens and then goes
+  /// quiet, so a filtered or throttled route to the pub host shows up as a
+  /// resolve step that hangs forever having printed a single line — and every
+  /// step after this one begins with `pub get`. Reported as a failure rather
+  /// than a warning for that reason: a machine that cannot fetch packages
+  /// cannot create or run a project, whatever else is in place.
+  Future<_Check> _checkPubHost() async {
+    final uri = pubHostProbeUri(Platform.environment['PUB_HOSTED_URL']);
+    final host = uri.host;
+    final client = HttpClient()..connectionTimeout = _networkTimeout;
+    try {
+      // `getUrl` completes once the socket *and* the TLS session are up, which
+      // is the step that hangs when traffic is filtered mid-handshake. A bare
+      // TCP connect succeeds in that case and proves nothing, so this asks for
+      // bytes back rather than for a socket.
+      final request = await client.getUrl(uri).timeout(_networkTimeout);
+      request.headers.set(
+        HttpHeaders.acceptHeader,
+        'application/vnd.pub.v2+json',
+      );
+      final response = await request.close().timeout(_networkTimeout);
+      await response.drain<void>().timeout(_networkTimeout);
+      if (response.statusCode >= 400) {
+        return _Check.warn(
+          'pub host',
+          '$host answered ${response.statusCode}',
+          fix: 'Check that $host serves the pub package API',
+        );
+      }
+      return _Check.ok('pub host', '$host answers');
+    } on TimeoutException {
+      return _Check.fail(
+        'pub host',
+        'no answer from $host within ${_networkTimeout.inSeconds}s',
+        fix: _pubHostFix(host),
+      );
+    } on IOException catch (error) {
+      return _Check.fail(
+        'pub host',
+        'cannot reach $host — $error',
+        fix: _pubHostFix(host),
+      );
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  String _pubHostFix(String host) =>
+      'Restore network access to $host, or point PUB_HOSTED_URL at a mirror '
+      'you trust — `dart pub get` has no deadline of its own and will hang '
+      'on this without printing anything';
 
   _Check _checkDocker() {
     final result = _run('docker', ['ps']);

--- a/packages/dartway_cli/lib/src/pub_host.dart
+++ b/packages/dartway_cli/lib/src/pub_host.dart
@@ -1,0 +1,22 @@
+/// The pub host a `dart pub get` in this environment would actually talk to,
+/// and a URL on it that answers cheaply.
+///
+/// Its own file because the obvious one-liner is wrong for the case that makes
+/// the check worth having. A mirror may be served from a path
+/// (`https://mirror.example/pub/`), and resolving a relative segment against
+/// such a base drops its last segment — the probe would then report a host that
+/// is reachable while the mirror behind it is not, which is worse than not
+/// probing at all.
+///
+/// `PUB_HOSTED_URL` is the same variable pub itself reads, so whatever it names
+/// is what the resolve step will hang on.
+Uri pubHostProbeUri(String? pubHostedUrl) {
+  final configured = pubHostedUrl?.trim() ?? '';
+  var base = configured.isEmpty ? 'https://pub.dev' : configured;
+  while (base.endsWith('/')) {
+    base = base.substring(0, base.length - 1);
+  }
+  // Every pub host serves the package metadata API; asking about the CLI's own
+  // package keeps the response small and needs no knowledge of the project.
+  return Uri.parse('$base/api/packages/dartway_cli');
+}

--- a/packages/dartway_cli/lib/src/quickstart_brief.dart
+++ b/packages/dartway_cli/lib/src/quickstart_brief.dart
@@ -26,11 +26,17 @@ If `dartway` is not on PATH, every command below also works as:
 
     dartway doctor
 
-It reports Dart, Flutter, a running Docker daemon and the Serverpod CLI pin, and prints
-the exact fix for whatever is missing. Ask the human to install or start what it names.
+It reports Dart, Flutter, git, a reachable pub host, a running Docker daemon and the
+Serverpod CLI pin, and prints the exact fix for whatever is missing. Ask the human to
+install or start what it names.
 
 **Do not work around a stopped Docker** — the database comes from it, and there is no
 second path. Docker Desktop cannot be installed unattended; that one is the human's job.
+
+**A failing pub host check is also the human's job**, and it stops everything: every step
+below begins with `pub get`, and pub sets no deadline on a connection that opens and then
+goes quiet. If you skip past this one you will not get an error — you will get a resolve
+step that prints one line and hangs until your session is killed.
 
 ## 2. Create the project
 

--- a/packages/dartway_cli/pubspec.yaml
+++ b/packages/dartway_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_cli
 description: "DartWay command-line tool: print the agent setup brief, check prerequisites, create projects from the canonical template, install the AI toolkit, run convention checks."
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_cli/test/pub_host_test.dart
+++ b/packages/dartway_cli/test/pub_host_test.dart
@@ -1,0 +1,47 @@
+import 'package:dartway_cli/src/pub_host.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('pubHostProbeUri', () {
+    test('falls back to pub.dev when nothing is configured', () {
+      expect(pubHostProbeUri(null).host, 'pub.dev');
+      expect(pubHostProbeUri('').host, 'pub.dev');
+      expect(pubHostProbeUri('   ').host, 'pub.dev');
+    });
+
+    test('asks pub.dev for the package metadata API', () {
+      expect(
+        pubHostProbeUri(null).toString(),
+        'https://pub.dev/api/packages/dartway_cli',
+      );
+    });
+
+    test('probes the mirror PUB_HOSTED_URL names', () {
+      expect(
+        pubHostProbeUri('https://mirror.example').toString(),
+        'https://mirror.example/api/packages/dartway_cli',
+      );
+    });
+
+    test('keeps a mirror served from a path', () {
+      // The case the helper exists for: resolving a relative segment against
+      // this base would drop `/pub` and probe a host that may well answer while
+      // the mirror behind it does not.
+      expect(
+        pubHostProbeUri('https://mirror.example/pub/').toString(),
+        'https://mirror.example/pub/api/packages/dartway_cli',
+      );
+      expect(
+        pubHostProbeUri('https://mirror.example/pub').toString(),
+        'https://mirror.example/pub/api/packages/dartway_cli',
+      );
+    });
+
+    test('tolerates surrounding whitespace and repeated slashes', () {
+      expect(
+        pubHostProbeUri('  https://mirror.example//  ').toString(),
+        'https://mirror.example/api/packages/dartway_cli',
+      );
+    });
+  });
+}

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -62,7 +62,7 @@ dev_dependencies:
     sdk: flutter
 
 
-  dartway_cli: ^0.8.0
+  dartway_cli: ^0.9.0
 
   # The UI-kit law is enforced here, not just written down: raw Color/TextStyle/
   # BorderRadius and direct theme access outside `ui_kit/` are lints. Needs

--- a/toolkit/skills/dartway-run/SKILL.md
+++ b/toolkit/skills/dartway-run/SKILL.md
@@ -30,11 +30,15 @@ Project packages: `__SERVER_PKG__` (backend), `__FLUTTER_PKG__` (app),
 dartway doctor
 ```
 
-It reports Dart, Flutter, a running Docker daemon, whether `serverpod_cli` matches this
-project's pin, and whether globally activated executables are on PATH — with the exact fix
-for each. Exit code 1 means something below will fail; relay what it names and ask the human
-rather than working around it. Half the failure table further down is a problem doctor names
-in a second.
+It reports Dart, Flutter, git and its identity, whether the pub host answers, a running
+Docker daemon, whether `serverpod_cli` matches this project's pin, and whether globally
+activated executables are on PATH — with the exact fix for each. Exit code 1 means something
+below will fail; relay what it names and ask the human rather than working around it. Half
+the failure table further down is a problem doctor names in a second.
+
+Take the pub host check seriously in particular: `pub get` has no deadline of its own, so an
+unreachable host is not an error you can wait out — it is a command that prints one line and
+never returns.
 
 ## The order (it is not arbitrary)
 


### PR DESCRIPTION
`dartway doctor` promises that a machine can create and run a project. It was possible for it to report one problem, have that fixed, and then hand over to a `dart pub get` that never returned — which is what happened to somebody bringing a demo project up from an empty folder.

Pub sets no deadline on a connection that opens and then goes quiet. Where the route to pub.dev is filtered or throttled, the resolve step prints one line and hangs: no error, no progress, no exit. Every step of the setup brief begins with `pub get`, so nothing after it can happen, and the failure gives the operator nothing to act on. Doctor now rules it out in one request.

## The two checks

**`pub host`** — a failure, since a machine that cannot fetch packages cannot create or run anything.

- Asks the host for bytes rather than for a socket. A TCP connect succeeds even when the handshake after it is being filtered, so a reachability check built on connect alone waves the machine straight through — that is exactly what the case behind this PR looked like: TCP up 3/3, TLS hanging.
- Honours `PUB_HOSTED_URL`, so it probes whatever pub itself would talk to.
- Ten seconds, then it gives up and prints the two ways out: restore access, or point `PUB_HOSTED_URL` at a mirror.

**`git`** — a missing binary is a failure (`create` clones the template with it); an unset `user.name`/`user.email` is a warning. The project `create` produces is complete either way, but that commit fails, so its repository has no initial commit — and the reason arrives as a wall of git's own text in the machine's locale, in the middle of otherwise successful output.

## Why `pubHostProbeUri` is its own file

A mirror may be served from a path (`https://mirror.example/pub/`), and resolving a relative segment against such a base drops its last one. The probe would then report a reachable host in front of an unreachable mirror — worse than not probing at all. Five tests hold it.

## Synchronisation

`dartway_cli` was 0.8.0 on both `master` and `stable`, so this change moves it: 0.9.0, with the carets on it in `example/` and `template/` raised to match.

Updated everywhere the checks were enumerated: the quickstart brief (the text an agent actually follows), `toolkit/skills/dartway-run`, `docs/5-tooling/cli.md`, `quick-start.md`, `start-with-an-agent.md`, `example/README.md`, the CHANGELOG. `template/README.md` and `what-is-dartway.md` do not enumerate them.

`dart analyze` clean, 193 tests green, the workspace resolves, and both failure paths were exercised by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
