### PR TITLE
fix(deploy): bridge a bare docker compose to the project override

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -328,15 +328,36 @@ rather than an error, because only the build block reintroduces the duplicate.
 The override is **never copied to the server**. Every Compose call the CLI issues names it explicitly
 — `docker compose -f docker-compose.yml -f deploy/compose.override.yml …` — so the file being merged
 is the one in the checkout, which `git reset --hard` refreshes on every deploy. It used to be copied
-to `docker-compose.override.yml` beside the rendered file, the name Compose loads on its own, on the
-grounds that nothing then has to remember the flag; but there is nobody to forget it, since every
-invocation is built in one place, and the price was a second copy that a deploy silently preferred
-over the committed one for as long as `setup` was not re-run. A server carrying that copy has it
-moved to `docker-compose.override.yml.retired` on the next `setup` or `run` — renamed rather than
-deleted, in case somebody edited it on the box while debugging.
+to `docker-compose.override.yml` beside the rendered file, and the price was a second copy that a
+deploy silently preferred over the committed one for as long as `setup` was not re-run.
 
-`run` retires that copy, updates the checkout, rebuilds, applies migrations and restarts, then polls
-every public URL. It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders
+**A two-line bridge is written under that name instead.** Naming the override on every call is
+airtight inside the CLI and nowhere else: `docker compose up -d` — the command in every runbook and
+every habit — applies a strictly smaller stack in a directory that holds only the rendered file, and
+exits 0, because from Compose's point of view nothing is missing. A staging stand lost its `minio`
+that way and stayed down for eleven hours. So the deploy writes
+
+```yaml
+# dartway-bridge: written by dartway deploy. Do not edit.
+include:
+  - deploy/compose.override.yml
+```
+
+which Compose loads on its own and which holds no content to go stale. The CLI's own calls are
+untouched: explicit `-f` flags replace the default file selection outright, so this file is read
+only by the command a person types.
+
+A file already sitting under that name and **not** carrying the marker — a stale copy, or a hand
+edit made while debugging — is moved to `docker-compose.override.yml.retired` rather than deleted.
+And where `deploy/compose.override.yml` is absent from the checkout there is nothing to bridge to:
+the deploy **refuses**, because that file may be the only place its services are declared and
+removing it would be pure subtraction. A bridge left pointing at an override the project has since
+deleted holds nothing and is removed.
+
+`run` updates the checkout, writes the bridge, rebuilds, applies migrations and restarts, then polls
+every public URL. The bridge is written **after** the checkout update: it judges the revision this
+deploy is applying, and a deploy that itself introduces the override must not be refused on a tree
+that does not have it yet. It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders
 infrastructure on every push turns a routine change into an infrastructure one.
 
 **The migration step prints what the container said, and fails on it.** It used to print its title

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## 0.9.0
 
+- **A bare `docker compose` in the checkout now means the same stack the deploy applies.**
+
+  Naming `deploy/compose.override.yml` on every call is airtight inside the CLI and nowhere else.
+  In a directory holding only the rendered `docker-compose.yml`, the command in every runbook —
+  `docker compose up -d` — brings the stack up **without a single service the override declares**,
+  and exits 0, because from Compose's point of view nothing is missing. A staging stand lost its
+  `minio` that way and stayed down for eleven hours; the deploy that caused it reported success.
+
+  `setup` and `run` now write a two-line bridge under `docker-compose.override.yml`, the name
+  Compose loads on its own, which `include`s the committed override rather than copying it. It
+  holds no content, so it cannot go stale — which was the whole reason the old copy was retired.
+  The CLI's own calls are unaffected: explicit `-f` flags replace the default file selection, so
+  the bridge is read only by the command a person types.
+
+  A file already under that name and not carrying the marker — a stale copy, or a hand edit made
+  while debugging — is still moved aside to `.retired` rather than deleted. Where the checkout has
+  no `deploy/compose.override.yml` at all, the deploy **refuses**: that file may be the only place
+  its services are declared, and removing it would be pure subtraction. The step moved after
+  `update-checkout`, so a deploy that itself introduces the override is not refused on a tree that
+  does not have it yet.
+
 - **`doctor` checks the two prerequisites that used to let a machine through and then stop it dead:
   the route to the pub host, and a git identity.**
 

--- a/packages/dartway_cli/lib/src/commands/deploy_run.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_run.dart
@@ -140,9 +140,9 @@ Future<int> runDeploy(Command<int> command, ArgResults results) async {
         stdout.writeln('  now at ${revision.firstLine}');
       }
     }
-    // Says nothing on a server that has nothing to retire, which is every
-    // server after the first deploy that did.
-    if (step.id == 'retire-override-copy' && result.stdout.trim().isNotEmpty) {
+    // Says nothing on a server whose bridge is already in place, which is
+    // every server after the first deploy that wrote one.
+    if (step.id == 'bridge-override' && result.stdout.trim().isNotEmpty) {
       stdout.writeln('  ${result.stdout.trim()}');
     }
   }

--- a/packages/dartway_cli/lib/src/commands/deploy_setup.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_setup.dart
@@ -294,16 +294,14 @@ chmod 600 '${target.appDir}/.env'
     return 1;
   }
 
-  // The project's override is not copied anywhere. Every Compose call names
-  // deploy/compose.override.yml inside the checkout, which the deploy's
-  // `git reset --hard` refreshes. A copy taken here would freeze the file as
-  // it was on the day setup last ran — and Compose would prefer it.
+  // The project's override is never copied. What is written here names it —
+  // two lines that Compose loads on its own, so a bare `docker compose` in the
+  // checkout applies the same stack the deploy does. A copy taken here would
+  // freeze the file as it was on the day setup last ran, and Compose would
+  // prefer the frozen one.
   if (!await step(
-    'Retire the setup-time compose override copy',
-    () => ssh.runAs(
-      target.deployUser,
-      DwComposeFiles.retireLegacyCopyIn(target.appDir),
-    ),
+    'Bridge a bare docker compose to the project override',
+    () => ssh.runAs(target.deployUser, DwComposeFiles.bridgeIn(target.appDir)),
   )) {
     return 1;
   }

--- a/packages/dartway_cli/lib/src/deploy/compose_files.dart
+++ b/packages/dartway_cli/lib/src/deploy/compose_files.dart
@@ -10,7 +10,8 @@
 /// the checkout to do.
 ///
 /// Nobody has to remember the flag: every `docker compose` the CLI issues is
-/// built here.
+/// built here. What nobody controls is the command a person types by hand, and
+/// that command is the reason [bridgeIn] exists.
 class DwComposeFiles {
   const DwComposeFiles._();
 
@@ -21,14 +22,21 @@ class DwComposeFiles {
   /// which is where Compose runs.
   static const String projectOverride = 'deploy/compose.override.yml';
 
-  /// The copy `setup` used to write next to [rendered]. Compose loads a file
-  /// under this name automatically, so a leftover from an older CLI keeps
-  /// being merged into every deploy — see [retireLegacyCopyIn].
-  static const String legacyCopy = 'docker-compose.override.yml';
+  /// The name Compose loads on its own, with no `-f` at all.
+  ///
+  /// An older CLI wrote a full copy of the project override here, and nothing
+  /// refreshed it. Today [bridgeIn] writes a two-line bridge instead: it names
+  /// [projectOverride] rather than duplicating it, so it cannot go stale.
+  static const String autoLoaded = 'docker-compose.override.yml';
 
-  /// Where [legacyCopy] is moved to. Any name Compose does not load on its own
-  /// would do; this one says what happened.
+  /// Where a file found under [autoLoaded] that is not ours is moved to. Any
+  /// name Compose does not load on its own would do; this one says what
+  /// happened.
   static const String retiredCopy = 'docker-compose.override.yml.retired';
+
+  /// Marks [autoLoaded] as written by us, so a rerun can tell its own file
+  /// from a stale copy or a hand edit and leave the latter alone.
+  static const String bridgeMarker = 'dartway-bridge';
 
   /// Shell variable holding the `-f` flags.
   static const String _variable = 'dw_compose_files';
@@ -51,18 +59,56 @@ class DwComposeFiles {
   static String commandIn(String appDir, String arguments) =>
       "cd '$appDir' && $selectFiles && $invoke $arguments";
 
-  /// Removes the automatically loaded copy an older CLI left in [appDir].
+  /// Makes a bare `docker compose` in [appDir] mean the same stack the deploy
+  /// applies, by writing [autoLoaded] as an `include` of [projectOverride].
   ///
-  /// Renamed rather than deleted: the file is normally a stale copy of a
-  /// committed one and worth nothing, but a server may carry a hand edit made
-  /// while debugging, and losing that silently would be its own bug. Idempotent
-  /// — a server that never had the copy, or that has already been through this,
-  /// finds nothing to move and says nothing.
-  static String retireLegacyCopyIn(String appDir) =>
+  /// **Why a file has to be there at all.** Naming the override on every call
+  /// is airtight inside the CLI and nowhere else. Every runbook, every habit
+  /// and every agent that has ever opened a shell on the box types
+  /// `docker compose up -d`, and in a directory holding only [rendered] that
+  /// command applies a strictly smaller stack — Compose exits 0, because from
+  /// its point of view nothing is missing. A staging stand lost its `minio`
+  /// that way and stayed down for eleven hours.
+  ///
+  /// **Why a bridge and not a copy.** The copy an older CLI wrote was the
+  /// original bug: it froze the override as it stood the day `setup` last ran.
+  /// A file that only names the committed one holds no content to go stale,
+  /// and `git reset --hard` refreshes what it points at.
+  ///
+  /// The CLI's own calls are unaffected: explicit `-f` flags replace the
+  /// default file selection outright, so Compose never auto-loads this file
+  /// while the deploy is running, and the two routes cannot merge twice.
+  ///
+  /// **Without [projectOverride] there is nothing to bridge to,** and this
+  /// refuses rather than tidies: a file under [autoLoaded] that is not ours may
+  /// be the only place those services are declared, and removing it would be
+  /// pure subtraction. Our own bridge, left pointing at an override the project
+  /// has since deleted, is removed — it holds nothing.
+  ///
+  /// Idempotent, and silent on a rerun that finds its own file already in place.
+  static String bridgeIn(String appDir) =>
       "cd '$appDir' && "
-      "if [ -f '$legacyCopy' ]; then "
-      "mv -f '$legacyCopy' '$retiredCopy' && "
-      "echo 'Retired $legacyCopy (now $retiredCopy): the deploy reads "
-      "$projectOverride from the checkout instead.'; "
+      "if [ -f '$projectOverride' ]; then "
+      "if [ ! -f '$autoLoaded' ] || ! grep -q '$bridgeMarker' '$autoLoaded'; then "
+      "if [ -f '$autoLoaded' ]; then "
+      "mv -f '$autoLoaded' '$retiredCopy' && "
+      "echo 'Kept the previous $autoLoaded as $retiredCopy.'; "
+      'fi && '
+      "printf '%s\n' "
+      "'# $bridgeMarker: written by dartway deploy. Do not edit.' "
+      "'# Keeps a bare docker compose in this directory equal to the deploy.' "
+      "'include:' '  - $projectOverride' > '$autoLoaded' && "
+      "echo 'Bridged $autoLoaded to $projectOverride.'; "
+      'fi; '
+      "elif [ -f '$autoLoaded' ]; then "
+      "if grep -q '$bridgeMarker' '$autoLoaded'; then "
+      "rm -f '$autoLoaded' && "
+      "echo 'Removed $autoLoaded: $projectOverride is no longer in the checkout.'; "
+      'else '
+      "echo 'ERROR: $autoLoaded is here and $projectOverride is not. That file "
+      "may be the only place its services are declared, so this deploy will not "
+      "touch it. Commit $projectOverride, or remove $autoLoaded deliberately.' >&2 && "
+      'exit 1; '
+      'fi; '
       'fi';
 }

--- a/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
@@ -65,13 +65,14 @@ class DwDeployRunner {
   String _compose(String arguments) =>
       DwComposeFiles.commandIn(_appDir, arguments);
 
-  /// Moves aside the automatically loaded override copy older CLIs wrote.
+  /// Keeps a hand-typed `docker compose` in the checkout honest.
   ///
-  /// A server that has one merges it into every deploy, silently and forever,
-  /// while the committed override it was copied from goes on being ignored.
-  /// Idempotent, and a no-op on a server that never had the copy.
-  Future<DwSshResult> retireOverrideCopy() =>
-      ssh.runAs(target.deployUser, DwComposeFiles.retireLegacyCopyIn(_appDir));
+  /// The CLI names the project override on every call of its own; nothing
+  /// makes the command a person types do the same, and in a directory holding
+  /// only the rendered file that command applies a strictly smaller stack
+  /// without saying so. See [DwComposeFiles.bridgeIn].
+  Future<DwSshResult> bridgeOverride() =>
+      ssh.runAs(target.deployUser, DwComposeFiles.bridgeIn(_appDir));
 
   /// Brings the checkout to the tip of the deployment branch.
   ///
@@ -128,17 +129,21 @@ class DwDeployRunner {
   );
 
   List<DwDeployStep> steps({required bool skipGitUpdate}) => [
-    DwDeployStep(
-      id: 'retire-override-copy',
-      title: 'Retire the setup-time compose override copy',
-      run: retireOverrideCopy,
-    ),
     if (!skipGitUpdate)
       DwDeployStep(
         id: 'update-checkout',
         title: 'Update the checkout to origin/${target.branch}',
         run: updateCheckout,
       ),
+    // After the checkout and before anything reads the stack: the bridge names
+    // a file in the working copy, so it has to judge the revision this deploy
+    // is applying. Judged before the update, a deploy that itself introduces
+    // deploy/compose.override.yml would see a tree without it.
+    DwDeployStep(
+      id: 'bridge-override',
+      title: 'Bridge a bare docker compose to the project override',
+      run: bridgeOverride,
+    ),
     DwDeployStep(id: 'build', title: 'Build images', run: build),
     DwDeployStep(
       id: 'migrate',

--- a/packages/dartway_cli/test/deploy_compose_files_test.dart
+++ b/packages/dartway_cli/test/deploy_compose_files_test.dart
@@ -137,21 +137,29 @@ void main() {
     });
   });
 
-  group('retiring the copy an older setup left behind', () {
-    test('a deployment always offers to move it aside', () {
+  group('bridging a bare docker compose to the project override', () {
+    test('runs after the checkout update, not before it', () {
+      // The bridge names a file in the working copy, so it has to judge the
+      // revision this deploy is applying. Before the update it would judge
+      // yesterday's — and a deploy that itself introduces the override would
+      // refuse on a tree that does not have it yet.
       final steps = DwDeployRunner(
         ssh: _ScriptedSsh(const []),
         target: _target(),
         serverpod: _serverpod(),
         stdout: stdout,
-      ).steps(skipGitUpdate: true);
+      ).steps(skipGitUpdate: false).map((s) => s.id).toList();
 
-      expect(steps.first.id, 'retire-override-copy');
+      expect(
+        steps.indexOf('bridge-override'),
+        greaterThan(steps.indexOf('update-checkout')),
+      );
+      expect(steps.indexOf('bridge-override'), lessThan(steps.indexOf('build')));
     });
 
-    test('is idempotent, and a no-op where the copy never existed', () async {
+    test('writes the bridge, keeps a foreign file, and is idempotent', () async {
       // Shell is the only place this can be judged: the whole point is what
-      // happens on a server that has the file, and on one that never did.
+      // happens to files on a server.
       try {
         Process.runSync('sh', ['-c', 'true']);
       } on ProcessException {
@@ -162,34 +170,78 @@ void main() {
       final root = Directory.systemTemp.createTempSync('dw_override_');
       addTearDown(() => root.deleteSync(recursive: true));
       final dir = root.path.replaceAll(r'\', '/');
-      final script = DwComposeFiles.retireLegacyCopyIn(dir);
+      final script = DwComposeFiles.bridgeIn(dir);
+      final autoLoaded = File(p.join(root.path, DwComposeFiles.autoLoaded));
 
-      // A server that never had the copy.
-      final clean = Process.runSync('sh', ['-c', script]);
-      expect(clean.exitCode, 0);
-      expect(clean.stdout.toString().trim(), isEmpty);
-
-      // A server that has one, twice over.
-      File(
-        p.join(root.path, DwComposeFiles.legacyCopy),
-      ).writeAsStringSync('services:\n  backend:\n    restart: always\n');
+      // A checkout that carries the override, and a stale copy left by an
+      // older CLI. The copy is kept — it may hold a hand edit made while
+      // debugging, and losing that silently would be its own bug.
+      File(p.join(root.path, DwComposeFiles.projectOverride))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync('services:\n  minio:\n    image: minio\n');
+      autoLoaded.writeAsStringSync('services:\n  backend:\n    restart: always\n');
 
       final first = Process.runSync('sh', ['-c', script]);
       expect(first.exitCode, 0);
-      expect(first.stdout.toString(), contains('Retired'));
-
-      final second = Process.runSync('sh', ['-c', script]);
-      expect(second.exitCode, 0);
-      expect(second.stdout.toString().trim(), isEmpty);
-
-      expect(
-        File(p.join(root.path, DwComposeFiles.legacyCopy)).existsSync(),
-        isFalse,
-      );
+      expect(first.stdout.toString(), contains('Bridged'));
       expect(
         File(p.join(root.path, DwComposeFiles.retiredCopy)).readAsStringSync(),
         contains('restart: always'),
       );
+      expect(autoLoaded.readAsStringSync(), contains(DwComposeFiles.projectOverride));
+      expect(autoLoaded.readAsStringSync(), contains(DwComposeFiles.bridgeMarker));
+
+      // A rerun recognises its own file and says nothing.
+      final second = Process.runSync('sh', ['-c', script]);
+      expect(second.exitCode, 0);
+      expect(second.stdout.toString().trim(), isEmpty);
+    });
+
+    test('refuses when the override is gone and the file is not ours', () async {
+      try {
+        Process.runSync('sh', ['-c', 'true']);
+      } on ProcessException {
+        markTestSkipped('no POSIX shell on this machine');
+        return;
+      }
+
+      final root = Directory.systemTemp.createTempSync('dw_override_');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final dir = root.path.replaceAll(r'\', '/');
+      final autoLoaded = File(p.join(root.path, DwComposeFiles.autoLoaded))
+        ..writeAsStringSync('services:\n  minio:\n    image: minio\n');
+
+      // Nothing else declares those services. Removing the file would be pure
+      // subtraction, and that is how a stand loses a service for eleven hours.
+      final refused = Process.runSync('sh', ['-c', DwComposeFiles.bridgeIn(dir)]);
+      expect(refused.exitCode, isNot(0));
+      expect(refused.stderr.toString(), contains(DwComposeFiles.projectOverride));
+      expect(autoLoaded.existsSync(), isTrue);
+
+      // Our own bridge, left pointing at an override the project has deleted,
+      // holds nothing and goes.
+      autoLoaded.writeAsStringSync('# ${DwComposeFiles.bridgeMarker}\ninclude:\n');
+      final cleaned = Process.runSync('sh', ['-c', DwComposeFiles.bridgeIn(dir)]);
+      expect(cleaned.exitCode, 0);
+      expect(autoLoaded.existsSync(), isFalse);
+    });
+
+    test('a checkout with neither file is left alone', () async {
+      try {
+        Process.runSync('sh', ['-c', 'true']);
+      } on ProcessException {
+        markTestSkipped('no POSIX shell on this machine');
+        return;
+      }
+
+      final root = Directory.systemTemp.createTempSync('dw_override_');
+      addTearDown(() => root.deleteSync(recursive: true));
+      final clean = Process.runSync(
+        'sh',
+        ['-c', DwComposeFiles.bridgeIn(root.path.replaceAll(r'\', '/'))],
+      );
+      expect(clean.exitCode, 0);
+      expect(clean.stdout.toString().trim(), isEmpty);
     });
   });
 

--- a/template/deploy/README.md
+++ b/template/deploy/README.md
@@ -37,6 +37,15 @@ every push turns a routine change into an infrastructure one. `compose.override.
 is the opposite: it is never copied to the server, only named on every Compose
 call, so the file the deploy merges is the committed one.
 
+Because the CLI names it and nothing else does, the deploy also writes a
+`docker-compose.override.yml` beside the rendered file — two lines, marked
+`dartway-bridge`, that `include` this one. Compose loads that name on its own, so
+a hand-typed `docker compose up -d` on the server applies the same stack the
+deploy does instead of a silently smaller one. **Do not edit it and do not commit
+one of your own**: a file under that name which is not the bridge is treated as
+possibly the only declaration of its services, and the deploy stops rather than
+touch it.
+
 ## Migrations — what "migrate" in that one-liner actually promises
 
 The migration step prints everything the container said and fails when the text


### PR DESCRIPTION
Closes #153

## The defect

Naming `deploy/compose.override.yml` on every Compose call is airtight inside the CLI and nowhere else. In a directory holding only the rendered `docker-compose.yml`, the command in every runbook — `docker compose up -d` — brings the stack up **without a single service the override declares**, and exits 0: from Compose's point of view nothing is missing.

The u90 staging stand lost its `minio` that way. It was down for eleven hours, and the deploy that caused it reported success.

## The change

`setup` and `run` write a two-line bridge under `docker-compose.override.yml` — the name Compose loads on its own — which `include`s the committed override rather than copying it:

```yaml
# dartway-bridge: written by dartway deploy. Do not edit.
include:
  - deploy/compose.override.yml
```

It holds no content, so it cannot go stale — which was the whole reason the old copy was retired in #106. Verified against Compose v2.40: with the bridge in place a bare `docker compose config --services` lists the full stack; without it, only the rendered half. The CLI's own calls are untouched, because explicit `-f` flags replace the default file selection outright, so the two routes cannot merge twice.

Three cases the script distinguishes:

| in the checkout | what happens |
|---|---|
| override present | bridge written; a file already there without the marker is moved to `.retired`, not deleted — it may hold a hand edit made while debugging |
| override absent, file is our bridge | removed; it points at nothing and holds nothing |
| override absent, file is not ours | **the deploy refuses.** That file may be the only place its services are declared, and removing it would be pure subtraction |

**The step moved after `update-checkout`.** The bridge names a file in the working copy, so it has to judge the revision this deploy is applying; before the update it would judge yesterday's, and a deploy that itself introduces the override would be refused on a tree that does not have it yet. The old retire step did not care about order because it only removed a file.

## How it is demonstrated

`deploy_compose_files_test.dart` runs the script through a real shell against real files: the bridge is written and the foreign file kept; a rerun recognises its own file and says nothing; a missing override with a foreign file exits non-zero and names `deploy/compose.override.yml`; a checkout with neither file is left alone. Plus a step-order test asserting `bridge-override` sits between `update-checkout` and `build`.

`dart analyze` clean, 195 tests green.

## Not in this PR

#154 — the guard that checks rendered nginx upstreams against the applied stack. Different mechanism, independently revertible, so it travels separately.