### PR TITLE
fix(deploy): refuse to restart nginx onto an upstream nothing declares

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -354,8 +354,29 @@ the deploy **refuses**, because that file may be the only place its services are
 removing it would be pure subtraction. A bridge left pointing at an override the project has since
 deleted holds nothing and is removed.
 
-`run` updates the checkout, writes the bridge, rebuilds, applies migrations and restarts, then polls
-every public URL. The bridge is written **after** the checkout update: it judges the revision this
+**An upstream no service answers to stops the deploy before the restart does.** A snippet under
+`deploy/nginx.d/` names Compose services as backends — `proxy_pass http://minio:9000` — and nothing
+used to check that those services are in the stack. Nginx resolves an upstream **once, when it
+starts**, so the mismatch is not felt at the deploy that introduced it: the proxy keeps running on
+addresses resolved long ago, and the configuration it has not read yet sits there as deferred
+failure. What cashes it in is `restart-proxy`, the deploy's own last step, at the moment an operator
+is looking at an unrelated change. On the u90 stand the nginx container had been up for ten days and
+had never once parsed the snippet written on day five.
+
+The invariant is checked in two places, because they answer different questions. `deploy check`
+reads the working copy — the rendered stack plus `deploy/compose.override.yml` — and fails on a
+snippet naming anything else; that is cheap and catches it before anyone travels. The `check-upstreams`
+step then asks the **server**, between `up` and `restart-proxy`, using `docker compose config
+--services` on the stack that was really applied: the checkout can be right while the invocation was
+not, which is exactly what happened. Nothing is restarted when they disagree, and the message names
+the service.
+
+Addresses, fully qualified names, `localhost`, nginx variables and aliases the file defines through
+its own `upstream` block are not services and are not reported — a check that flagged them would be
+switched off within a week.
+
+`run` updates the checkout, writes the bridge, rebuilds, applies migrations, checks the upstreams and
+restarts, then polls every public URL. The bridge is written **after** the checkout update: it judges the revision this
 deploy is applying, and a deploy that itself introduces the override must not be refused on a tree
 that does not have it yet. It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders
 infrastructure on every push turns a routine change into an infrastructure one.

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## 0.9.0
 
+- **An Nginx upstream that no service answers to now stops the deploy, instead of the proxy.**
+
+  A snippet under `deploy/nginx.d/` names Compose services as backends, and nothing checked that
+  those services are in the stack. Nginx resolves an upstream once, when it starts, so the mismatch
+  is not felt at the deploy that introduced it — the proxy runs on addresses resolved long ago and
+  the unread configuration sits there as deferred failure. What cashes it in is `restart-proxy`, the
+  deploy's own last step: on the u90 stand nginx had been up for ten days, had never parsed the
+  snippet written on day five, read it at an unrelated deploy and refused to start. A healthy stand
+  became a dead one as a direct result of the deploy's recovery step, with the cause ten days
+  upstream.
+
+  Checked in two places, because they answer different questions. `deploy check` reads the working
+  copy — the rendered stack plus `deploy/compose.override.yml` — and fails on a snippet naming
+  anything else. The new `check-upstreams` step asks the server, between `up` and `restart-proxy`,
+  against the stack that was really applied: the checkout can be right while the invocation was not,
+  which is what actually happened. Nothing is restarted when they disagree.
+
+  Addresses, fully qualified names, `localhost`, nginx variables and aliases defined by the file's
+  own `upstream` block are not services and are not reported.
+
 - **A bare `docker compose` in the checkout now means the same stack the deploy applies.**
 
   Naming `deploy/compose.override.yml` on every call is airtight inside the CLI and nowhere else.

--- a/packages/dartway_cli/lib/src/deploy/deploy_check.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_check.dart
@@ -506,15 +506,6 @@ Future<DwDeployVerdict> _checkEntrypointForm(DwDeployContext context) async {
   );
 }
 
-/// The deploy renders the `web` service itself, build argument included: the
-/// API address comes from `publicHost`, which is what keeps the domain written
-/// down once. An override that builds `web` states it a second time, and
-/// nothing compares the two copies — the image keeps building successfully
-/// against yesterday's API, which is a failure with no error message.
-///
-/// A warning rather than an error: overriding `web` for something that is not
-/// the build (a label, a limit, a volume) is legitimate, and only the build
-/// block reintroduces the second copy.
 /// Compose service names declared by a Compose document.
 Set<String> _servicesIn(String yaml) {
   final Object? document;
@@ -572,6 +563,15 @@ Future<DwDeployVerdict> _checkNginxUpstreams(DwDeployContext context) async {
   );
 }
 
+/// The deploy renders the `web` service itself, build argument included: the
+/// API address comes from `publicHost`, which is what keeps the domain written
+/// down once. An override that builds `web` states it a second time, and
+/// nothing compares the two copies — the image keeps building successfully
+/// against yesterday's API, which is a failure with no error message.
+///
+/// A warning rather than an error: overriding `web` for something that is not
+/// the build (a label, a limit, a volume) is legitimate, and only the build
+/// block reintroduces the second copy.
 Future<DwDeployVerdict> _checkOverrideWebBuild(DwDeployContext context) async {
   final file = File(
     p.join(context.projectRoot.path, 'deploy', 'compose.override.yml'),

--- a/packages/dartway_cli/lib/src/deploy/deploy_check.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_check.dart
@@ -5,6 +5,8 @@ import 'package:yaml/yaml.dart';
 
 import '../checker/dw_check_type.dart';
 import 'deploy_target.dart';
+import 'nginx_upstreams.dart';
+import 'renderer.dart';
 import 'serverpod_config.dart';
 import 'ssh_runner.dart';
 import 'web_cache.dart';
@@ -221,6 +223,13 @@ const List<DwDeployCheck> dwLocalDeployChecks = [
     // "web-cache-headers", which is the one that errors.
     severity: DwCheckSeverity.warning,
     evaluate: _checkWebCachePolicy,
+  ),
+  DwDeployCheck(
+    id: 'nginx-upstreams',
+    title: 'Every Nginx upstream is a service the stack declares',
+    stage: DwDeployCheckStage.local,
+    severity: DwCheckSeverity.error,
+    evaluate: _checkNginxUpstreams,
   ),
   DwDeployCheck(
     id: 'override-web-build',
@@ -506,6 +515,63 @@ Future<DwDeployVerdict> _checkEntrypointForm(DwDeployContext context) async {
 /// A warning rather than an error: overriding `web` for something that is not
 /// the build (a label, a limit, a volume) is legitimate, and only the build
 /// block reintroduces the second copy.
+/// Compose service names declared by a Compose document.
+Set<String> _servicesIn(String yaml) {
+  final Object? document;
+  try {
+    document = loadYaml(yaml);
+  } on YamlException {
+    return const {};
+  }
+  final services = document is YamlMap ? document['services'] : null;
+  if (services is! YamlMap) {
+    return const {};
+  }
+  return services.keys.map((key) => key.toString()).toSet();
+}
+
+Future<DwDeployVerdict> _checkNginxUpstreams(DwDeployContext context) async {
+  final renderer = DwInfraRenderer(
+    projectRoot: context.projectRoot,
+    target: context.target,
+    serverpod: context.serverpod,
+    serverPackage: context.serverPackage,
+    flutterPackage: context.flutterPackage,
+  );
+  final snippets = renderer.nginxSnippets;
+  if (snippets.isEmpty) {
+    return const DwDeployVerdict.skip('no deploy/nginx.d snippets');
+  }
+
+  final services = {
+    ..._servicesIn(renderer.composeFile),
+    if (renderer.composeOverride case final override?)
+      ..._servicesIn(override.readAsStringSync()),
+  };
+
+  final missing = DwNginxUpstreams.missing(
+    snippets: {
+      for (final entry in snippets.entries)
+        entry.key: entry.value.readAsStringSync(),
+    },
+    services: services,
+  );
+  if (missing.isEmpty) {
+    return DwDeployVerdict.pass(
+      '${snippets.length} snippet(s) against ${services.length} service(s)',
+    );
+  }
+  return DwDeployVerdict.fail(
+    missing.join(', '),
+    fix:
+        'Nginx resolves an upstream once, when it starts, so a name no service '
+        'answers to does not fail at the deploy that introduced it — it fails '
+        'at whatever restarts the proxy next, which is the deploy\'s own last '
+        'step and may be days later. Declare the service in '
+        'deploy/compose.override.yml, or drop the snippet that names it.',
+  );
+}
+
 Future<DwDeployVerdict> _checkOverrideWebBuild(DwDeployContext context) async {
   final file = File(
     p.join(context.projectRoot.path, 'deploy', 'compose.override.yml'),

--- a/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'compose_files.dart';
 import 'deploy_target.dart';
 import 'migration_report.dart';
+import 'nginx_upstreams.dart';
 import 'serverpod_config.dart';
 import 'ssh_runner.dart';
 
@@ -73,6 +74,49 @@ class DwDeployRunner {
   /// without saying so. See [DwComposeFiles.bridgeIn].
   Future<DwSshResult> bridgeOverride() =>
       ssh.runAs(target.deployUser, DwComposeFiles.bridgeIn(_appDir));
+
+  /// Marks the boundary between the two answers [checkUpstreams] collects.
+  static const String _upstreamMarker = '--dw-nginx-d--';
+
+  /// Asks the server what the stack actually holds and what nginx expects.
+  ///
+  /// On the server, not against the working copy: the checkout can be right
+  /// while the invocation was not, and that is exactly the case that took a
+  /// stand down — `deploy/compose.override.yml` was committed and present at
+  /// the deployed revision, and the container stamps show it was never
+  /// applied. The local check answers a different question and both are worth
+  /// asking.
+  Future<DwSshResult> checkUpstreams() => ssh.runAs(
+    target.deployUser,
+    "cd '$_appDir' && ${DwComposeFiles.selectFiles} && "
+    '${DwComposeFiles.invoke} config --services && '
+    "echo '$_upstreamMarker' && "
+    "{ find nginx.d -name '*.conf' -exec cat {} + 2>/dev/null || true; }",
+  );
+
+  /// Why a stack that came up is still not fit to have its proxy restarted.
+  ///
+  /// Null when it is. Separate from [checkUpstreams] because the command
+  /// exits 0 either way: it asks two questions, and the disagreement between
+  /// the answers is the finding.
+  static String? upstreamVerdict(DwSshResult result) {
+    final parts = result.stdout.split(_upstreamMarker);
+    if (parts.length < 2) {
+      return null;
+    }
+    final missing = DwNginxUpstreams.missing(
+      snippets: {'nginx.d': parts[1]},
+      services: DwNginxUpstreams.servicesInListing(parts.first),
+    );
+    if (missing.isEmpty) {
+      return null;
+    }
+    final names = missing.map((line) => line.split(': ').last).join(', ');
+    return 'Nginx is configured to proxy to $names, and the applied stack has '
+        'no such service. Restarting nginx now would make it read that '
+        'configuration for the first time and refuse to start, taking the whole '
+        'stand down. Nothing has been restarted.';
+  }
 
   /// Brings the checkout to the tip of the deployment branch.
   ///
@@ -158,6 +202,15 @@ class DwDeployRunner {
           DwMigrationReport.read('${result.stdout}\n${result.stderr}').failure,
     ),
     DwDeployStep(id: 'up', title: 'Start services', run: up),
+    // Between `up` and the restart, and it has to be exactly here: the stack
+    // is now the one nginx will be pointed at, and the proxy has not been
+    // touched yet. A step later this is a post-mortem.
+    DwDeployStep(
+      id: 'check-upstreams',
+      title: 'Check nginx upstreams against the applied stack',
+      run: checkUpstreams,
+      verdict: upstreamVerdict,
+    ),
     DwDeployStep(
       id: 'restart-proxy',
       title: 'Restart nginx',

--- a/packages/dartway_cli/lib/src/deploy/nginx_upstreams.dart
+++ b/packages/dartway_cli/lib/src/deploy/nginx_upstreams.dart
@@ -1,0 +1,98 @@
+/// The hosts an Nginx snippet sends traffic to, and which of them a Compose
+/// stack has to declare.
+///
+/// A snippet under `deploy/nginx.d/` names Compose services as upstreams —
+/// `proxy_pass http://minio:9000` — and nothing used to check that those
+/// services are in the stack that was actually applied. Nginx resolves an
+/// upstream once, at start, so the mismatch is not felt until something
+/// restarts the proxy, which is the deploy's own last step. A staging stand
+/// held a config naming a service it did not have for ten days, healthy the
+/// whole time, and died at a deploy that had nothing to do with it.
+///
+/// One reading serves both sides of the guard: the local check reads the files
+/// in the working copy, the deploy reads what is on the server. The rule must
+/// be the same rule, or the two answers can differ for no reason anybody can
+/// see.
+class DwNginxUpstreams {
+  const DwNginxUpstreams._();
+
+  /// `proxy_pass http://host:8080;` and its siblings — the directives that
+  /// name a backend by host.
+  static final RegExp _pass = RegExp(
+    r'\b(?:proxy_pass|grpc_pass|uwsgi_pass|fastcgi_pass)\s+'
+    r'(?:[a-zA-Z0-9+.-]+://)?([^;\s/]+)',
+  );
+
+  /// `upstream name {` — an alias defined in the file itself, not a service.
+  static final RegExp _upstreamBlock = RegExp(r'\bupstream\s+([^\s{]+)\s*\{');
+
+  /// `server host:9000;` inside an upstream block.
+  static final RegExp _server = RegExp(r'\bserver\s+([^;\s]+)');
+
+  static final RegExp _comment = RegExp(r'#[^\n]*');
+
+  /// Service names [conf] expects the stack to provide.
+  ///
+  /// Left out, because none of them is a Compose service and a check that
+  /// reports them would be turned off within a week: anything holding a dot
+  /// (an address or a fully qualified name), an nginx variable, a unix socket,
+  /// `localhost`, and an alias the file defines through its own `upstream`
+  /// block — for that one the servers inside the block are read instead.
+  static Set<String> namesIn(String conf) {
+    final text = conf.replaceAll(_comment, '');
+    final aliases = _upstreamBlock
+        .allMatches(text)
+        .map((m) => m.group(1)!)
+        .toSet();
+
+    final referenced = <String>{
+      for (final m in _pass.allMatches(text)) m.group(1)!,
+      for (final m in _server.allMatches(text)) m.group(1)!,
+    };
+
+    return {
+      for (final raw in referenced)
+        if (!aliases.contains(raw))
+          if (_serviceName(raw) case final name?) name,
+    };
+  }
+
+  /// Everything [snippets] reference and [services] does not declare, as
+  /// `<file>: <host>` lines. Empty when they agree.
+  static List<String> missing({
+    required Map<String, String> snippets,
+    required Set<String> services,
+  }) {
+    final out = <String>[];
+    for (final entry in snippets.entries) {
+      for (final name in namesIn(entry.value)) {
+        if (!services.contains(name)) {
+          out.add('${entry.key}: $name');
+        }
+      }
+    }
+    out.sort();
+    return out;
+  }
+
+  /// Service names declared by a Compose document, read as text.
+  ///
+  /// Text rather than a YAML parse: on the server the answer comes from
+  /// `docker compose config --services`, which is one name per line, and on
+  /// this side the question is only ever asked about the rendered file plus
+  /// the override.
+  static Set<String> servicesInListing(String listing) => {
+    for (final line in listing.split('\n'))
+      if (line.trim().isNotEmpty && !line.startsWith(' ')) line.trim(),
+  };
+
+  static String? _serviceName(String raw) {
+    final host = raw.split(':').first;
+    if (host.isEmpty) return null;
+    if (host.contains(r'$')) return null;
+    if (host.contains('.')) return null;
+    if (host.startsWith('unix')) return null;
+    if (host == 'localhost') return null;
+    return host;
+  }
+}

--- a/packages/dartway_cli/test/deploy_compose_files_test.dart
+++ b/packages/dartway_cli/test/deploy_compose_files_test.dart
@@ -245,6 +245,127 @@ void main() {
     });
   });
 
+  group('the local upstream check reads the working copy', () {
+    late Directory root;
+
+    setUp(() {
+      root = Directory.systemTemp.createTempSync('dw_upstreams_');
+    });
+    tearDown(() => root.deleteSync(recursive: true));
+
+    Future<DwDeployVerdict> run() {
+      final check = dwLocalDeployChecks.firstWhere(
+        (c) => c.id == 'nginx-upstreams',
+      );
+      return check.evaluate(
+        DwDeployContext(
+          projectRoot: root,
+          serverPackage: 'shop_server',
+          flutterPackage: 'shop_flutter',
+          target: _target(),
+          serverpod: _serverpod(),
+        ),
+      );
+    }
+
+    void snippet(String relative, String body) =>
+        File(p.join(root.path, 'deploy', 'nginx.d', relative))
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(body);
+
+    test('a project with no snippets has nothing to disagree about', () async {
+      expect((await run()).skipped, isTrue);
+    });
+
+    test('a service the rendered stack provides passes', () async {
+      snippet('api/extra.conf', 'proxy_pass http://backend:8080;\n');
+      final verdict = await run();
+      expect(verdict.passed, isTrue, reason: verdict.detail);
+    });
+
+    test('a service only the override declares passes', () async {
+      // This is the shape the guard must not punish: minio is not in the
+      // rendered file and never will be — it is exactly what an override is
+      // for.
+      snippet('app/storage.conf', 'proxy_pass http://minio:9000;\n');
+      File(p.join(root.path, 'deploy', 'compose.override.yml'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync('services:\n  minio:\n    image: minio\n');
+
+      final verdict = await run();
+      expect(verdict.passed, isTrue, reason: verdict.detail);
+    });
+
+    test('a service nothing declares fails and names it', () async {
+      snippet('app/storage.conf', 'proxy_pass http://minio:9000;\n');
+
+      final verdict = await run();
+      expect(verdict.passed, isFalse);
+      expect(verdict.detail, contains('app/storage.conf: minio'));
+      expect(verdict.fix, contains('restarts the proxy'));
+    });
+  });
+
+  group('the upstream guard the deploy runs before restarting nginx', () {
+    DwDeployRunner runner() => DwDeployRunner(
+      ssh: _ScriptedSsh(const []),
+      target: _target(),
+      serverpod: _serverpod(),
+      stdout: stdout,
+    );
+
+    test('stands between starting the stack and restarting the proxy', () {
+      // The position is the whole point: the stack is the one nginx is about
+      // to be pointed at, and the proxy has not been touched yet. A step later
+      // and this is a post-mortem.
+      final steps = runner()
+          .steps(skipGitUpdate: true)
+          .map((s) => s.id)
+          .toList();
+
+      expect(steps.indexOf('check-upstreams'), greaterThan(steps.indexOf('up')));
+      expect(
+        steps.indexOf('check-upstreams'),
+        lessThan(steps.indexOf('restart-proxy')),
+      );
+    });
+
+    test('asks the server for the applied stack, not the working copy', () {
+      final ssh = _ScriptedSsh(const []);
+      DwDeployRunner(
+        ssh: ssh,
+        target: _target(),
+        serverpod: _serverpod(),
+        stdout: stdout,
+      ).checkUpstreams();
+
+      expect(ssh.issued.single, contains('config --services'));
+      expect(ssh.issued.single, contains('-f ${DwComposeFiles.projectOverride}'));
+      expect(ssh.issued.single, contains('nginx.d'));
+    });
+
+    test('a stack that answers every upstream is not a finding', () {
+      expect(
+        DwDeployRunner.upstreamVerdict(
+          _ok('backend\nweb\nnginx\n--dw-nginx-d--\nproxy_pass http://backend:8080;'),
+        ),
+        isNull,
+      );
+    });
+
+    test('an upstream nothing declares stops the restart and says why', () {
+      // The command exits 0 either way — it asked two questions. The
+      // disagreement between the answers is the finding.
+      final verdict = DwDeployRunner.upstreamVerdict(
+        _ok('backend\nweb\nnginx\n--dw-nginx-d--\nproxy_pass http://minio:9000;'),
+      );
+
+      expect(verdict, isNotNull);
+      expect(verdict, contains('minio'));
+      expect(verdict, contains('Nothing has been restarted'));
+    });
+  });
+
   group('requires.files becomes a mount', () {
     String render({List<String> files = const []}) => DwInfraRenderer(
       projectRoot: Directory.systemTemp,

--- a/packages/dartway_cli/test/deploy_nginx_upstreams_test.dart
+++ b/packages/dartway_cli/test/deploy_nginx_upstreams_test.dart
@@ -1,0 +1,97 @@
+import 'package:dartway_cli/src/deploy/nginx_upstreams.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('what a snippet expects the stack to provide', () {
+    test('a service named by proxy_pass is an upstream', () {
+      expect(
+        DwNginxUpstreams.namesIn('''
+location /files/ {
+  proxy_pass http://minio:9000;
+}
+'''),
+        {'minio'},
+      );
+    });
+
+    test('an address or a domain is not a service, and neither is a variable', () {
+      // Each of these is a legitimate proxy target that no Compose stack
+      // declares. A check that reported them would be switched off in a week.
+      expect(
+        DwNginxUpstreams.namesIn('''
+proxy_pass http://127.0.0.1:8080;
+proxy_pass https://files.example.com;
+proxy_pass http://localhost:3000;
+proxy_pass http://\$upstream_from_map;
+proxy_pass unix:/var/run/app.sock;
+'''),
+        isEmpty,
+      );
+    });
+
+    test('an alias the file defines is read through its own servers', () {
+      // `storage` is not a service — it is a name this file invents. What has
+      // to exist is what the block points at.
+      expect(
+        DwNginxUpstreams.namesIn('''
+upstream storage {
+  server minio:9000;
+  server minio_backup:9000;
+}
+location / {
+  proxy_pass http://storage;
+}
+'''),
+        {'minio', 'minio_backup'},
+      );
+    });
+
+    test('a commented-out directive is not a requirement', () {
+      expect(
+        DwNginxUpstreams.namesIn('# proxy_pass http://minio:9000;\n'),
+        isEmpty,
+      );
+    });
+
+    test('grpc and fastcgi name backends the same way', () {
+      expect(
+        DwNginxUpstreams.namesIn(
+          'grpc_pass grpc://backend:50051;\nfastcgi_pass php:9000;\n',
+        ),
+        {'backend', 'php'},
+      );
+    });
+  });
+
+  group('snippets against a stack', () {
+    test('names the file and the service that is missing', () {
+      expect(
+        DwNginxUpstreams.missing(
+          snippets: {
+            'app/storage.conf': 'proxy_pass http://minio:9000;',
+            'api/extra.conf': 'proxy_pass http://backend:8080;',
+          },
+          services: {'backend', 'web', 'nginx'},
+        ),
+        ['app/storage.conf: minio'],
+      );
+    });
+
+    test('agreement is empty, not a message', () {
+      expect(
+        DwNginxUpstreams.missing(
+          snippets: {'api/extra.conf': 'proxy_pass http://backend:8080;'},
+          services: {'backend'},
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  test('a compose --services listing is one name per line', () {
+    expect(
+      DwNginxUpstreams.servicesInListing('backend\nminio\nnginx\n\n'),
+      {'backend', 'minio', 'nginx'},
+    );
+  });
+}

--- a/template/deploy/README.md
+++ b/template/deploy/README.md
@@ -23,7 +23,7 @@ dartway deploy secret --help                # runtime secrets on the server
 | `../dartway_starter_flutter/Dockerfile` | the web image; the deploy passes it `DW_BACKEND_URL` |
 | `../dartway_starter_flutter/nginx.conf` | how that image serves the build, and above all **what a browser may keep** — see "Caching" |
 | `compose.override.yml` | anything this project adds to a standard deployment — create it when that happens. Read from the checkout on every deploy, so a committed change to it takes effect on the next `run` |
-| `nginx.d/{http,api,app}/*.conf` | extra Nginx directives, if any are ever needed |
+| `nginx.d/{http,api,app}/*.conf` | extra Nginx directives, if any are ever needed. A `proxy_pass` here that names a Compose service must name one the stack declares — `deploy check` and the deploy both refuse otherwise, because nginx resolves upstreams once at start and would only fail at the next restart |
 
 A domain appears in exactly one of the first two, and `dartway deploy check`
 fails when they disagree. One thing does not belong in the override: a `build`


### PR DESCRIPTION
Closes #154. Sibling of #153, which removed one way the stack could lose a service; this is the guard that catches it whatever the cause was.

## The defect

A snippet under `deploy/nginx.d/` names Compose services as backends — `proxy_pass http://minio:9000` — and nothing checked that those services are in the stack.

Nginx resolves an upstream **once, when it starts**. So the mismatch is not felt at the deploy that introduced it: the proxy keeps running on addresses resolved long ago, and the configuration it has not read yet sits there as deferred failure. What cashes it in is `restart-proxy`, the deploy's own last step, at the moment an operator is looking at an unrelated change.

The u90 stand's own numbers: the nginx container dated from 12.08 and had never been recreated; `storage.conf`, naming `minio`, was written on 17.08. It stayed up and healthy for ten days holding a config it had not parsed. The 27.08 deploy recreated `backend`, restarted nginx to refresh that one address — and nginx read `storage.conf` for the first time, could not resolve `minio`, and refused to start.

## The change

The invariant, stated once: **upstream hostnames in `nginx.d/**/*.conf` ⊆ the services of the applied stack.**

Checked in two places, because they answer different questions:

| where | against what | why it is not enough on its own |
|---|---|---|
| `deploy check`, local, error | the rendered stack + `deploy/compose.override.yml` | cheap, catches it before anyone travels — but it reads the checkout |
| `check-upstreams`, between `up` and `restart-proxy` | `docker compose config --services` on the server | the checkout can be right while the invocation was not — which is exactly what happened |

The step's position is the point: the stack is the one nginx is about to be pointed at, and the proxy has not been touched yet. It exits 0 either way and its `verdict` judges the text, since the finding is a disagreement between two answers rather than a failed command. When they disagree **nothing is restarted**, and the message names the service.

`DwNginxUpstreams` holds the reading so both sides use the same rule — two answers differing for reasons nobody can see would be worse than one. Not reported, because none of them is a Compose service and a check that flagged them would be switched off within a week: addresses, fully qualified names, `localhost`, nginx variables, unix sockets, and aliases the file defines through its own `upstream` block — for those the servers inside the block are read instead.

## How it is demonstrated

`deploy_nginx_upstreams_test.dart` pins the reading, including every exclusion above and the `upstream { server … }` indirection. In `deploy_compose_files_test.dart`: the local check passes on a service only the override declares (the shape the guard must not punish), fails naming `app/storage.conf: minio` when nothing declares it, and skips a project with no snippets; the step sits between `up` and `restart-proxy`, asks the server rather than the working copy, and the verdict is null on agreement and names the service on disagreement.

`dart analyze` clean, 211 tests green.