### PR TITLE
feat(template): ship the shared package wired, and correct what it may depend on

### DIFF
--- a/docs/1-getting-started/project-layout.md
+++ b/docs/1-getting-started/project-layout.md
@@ -4,7 +4,7 @@
 dartway create my_app
 ```
 
-Three Dart packages side by side, an agent toolkit, and a git repository with an initial commit.
+Four Dart packages side by side, an agent toolkit, and a git repository with an initial commit.
 The source is `template/` in the DartWay monorepo — a skeleton with auth, roles, navigation, an
 admin panel and a UI kit, and zero domain models.
 
@@ -13,6 +13,7 @@ my_app/
   my_app_server/     Serverpod backend — models, CRUD configs, business logic
   my_app_client/     generated protocol + API client — never edited by hand
   my_app_flutter/    the app — features, UI kit, navigation
+  my_app_shared/     rules both sides must apply identically — pure Dart, no dependencies
   .claude/           the agent toolkit (installed, then committed)
   .vscode/           Server / Flutter (web) launch configs
   .github/           a Claude PR-review workflow (delete it to turn review off)
@@ -31,16 +32,23 @@ An ADR exists for the one thing that cannot live beside code — the *rejected* 
 have no file to sit next to. The rules for writing one (and for never editing it) are in the agent
 toolkit's `CLAUDE.md`; `dartway-plan` reads the folder before proposing an approach.
 
-## Why three packages
+## Why four packages
 
 `server` and `flutter` cannot depend on each other — one imports `dart:io` and Serverpod, the other
-imports Flutter. `client` is the package both halves *can* see, which is why the protocol lives
-there and why it is generated rather than written.
+imports Flutter. `client` holds the generated protocol, and `flutter` depends on it. **The server
+does not:** it carries its own copy of the same models under `lib/src/generated`, which is why the
+protocol is generated on both sides rather than shared through one package — and why a shared
+package must not route through the client, see below.
 
-A project may add a fourth, `my_app_shared`: pure Dart for code that has to behave **identically**
-on both sides — format validation, shared enums, computation over fields with no IO. The skeleton
-ships none, because until such code exists the package is a folder with a pubspec in it. The CLI
-recognises it by the `*_shared` directory suffix if you add it.
+The fourth, `my_app_shared`, is pure Dart for code that has to behave **identically** on both sides
+— format validation, shared enums, computation over fields with no IO. The skeleton ships it wired
+into both halves, holding one worked example; it used to be a package each project assembled by
+hand, and the guidance for doing so was wrong about the one thing that matters.
+
+**It depends on nothing, and that constraint is its design.** It may not depend on the client
+package: the server does not depend on that package either — it carries its own copy of the
+generated models — so a shared package reaching for the protocol would serve exactly one of the two
+sides. Plain values in, plain values out; each side unpacks its own models at the call site.
 
 ## `my_app_server` — where the rules live
 

--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -163,7 +163,8 @@ Installs or updates `.claude/` in the current project: the methodology `CLAUDE.m
 
 It finds the project root through `git rev-parse --show-toplevel` (falling back to the current
 directory), then detects the package layout by directory suffix: `*_server`, `*_client`,
-`*_flutter` are required, `*_shared` is optional. Two packages with the same suffix, or none, and
+`*_flutter` are required, `*_shared` is optional — the skeleton ships one, and a project that
+deletes it is still a valid layout. Two packages with the same suffix, or none, and
 the command stops with a layout error rather than guessing. The detected names are substituted
 into the installed markdown, so the skills speak your package names, not placeholders.
 

--- a/packages/dartway_cli/test/template_build_context_test.dart
+++ b/packages/dartway_cli/test/template_build_context_test.dart
@@ -1,0 +1,132 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+/// Every path dependency of a template package is copied by the image that
+/// builds it.
+///
+/// The images are built from the project root and name package directories one
+/// by one. A directory that is never named does not enter the build context,
+/// so `pub get` inside the image fails on a dependency whose folder is not
+/// there — as exit code 66, three layers from the cause, pointing at neither
+/// the Dockerfile nor the package.
+///
+/// **Nothing else can catch it.** Repository checks compile the server and
+/// build the app *inside the checkout*, where the path resolves; the images are
+/// built only by `dartway deploy`, on the server. A project stays green and
+/// cannot ship, and the two facts do not meet until somebody deploys. That is
+/// what happened when a shared package was added by hand to a real project.
+void main() {
+  /// The repository's `template/`, found by walking up rather than by a fixed
+  /// number of `..`: this suite is run both from the package directory and from
+  /// the workspace root, and a hard-coded depth is right in exactly one of them.
+  final template = () {
+    var dir = Directory.current.absolute;
+    while (true) {
+      final candidate = Directory(
+        p.join(dir.path, 'template', 'dartway_starter_server'),
+      );
+      if (candidate.existsSync()) {
+        return Directory(p.join(dir.path, 'template'));
+      }
+      final up = dir.parent;
+      if (up.path == dir.path) {
+        throw StateError('no template/ above ${Directory.current.path}');
+      }
+      dir = up;
+    }
+  }();
+
+  /// Package directories a Dockerfile copies into its context.
+  Set<String> copiedBy(File dockerfile) => {
+    for (final line in dockerfile.readAsLinesSync())
+      if (RegExp(r'^\s*COPY\s+([a-z0-9_]+)/\s').firstMatch(line)
+          case final match?)
+        match.group(1)!,
+  };
+
+  /// Sibling packages [pubspec] depends on by path.
+  Set<String> pathDepsOf(File pubspec) {
+    final document = loadYaml(pubspec.readAsStringSync());
+    final dependencies = document is YamlMap ? document['dependencies'] : null;
+    if (dependencies is! YamlMap) {
+      return const {};
+    }
+    return {
+      for (final entry in dependencies.entries)
+        if (entry.value is YamlMap && (entry.value as YamlMap)['path'] != null)
+          entry.key.toString(),
+    };
+  }
+
+  for (final package in const ['dartway_starter_server', 'dartway_starter_flutter']) {
+    test('$package: the image copies every package it depends on', () {
+      final dockerfile = File(p.join(template.path, package, 'Dockerfile'));
+      final pubspec = File(p.join(template.path, package, 'pubspec.yaml'));
+      expect(dockerfile.existsSync(), isTrue, reason: dockerfile.path);
+
+      final copied = copiedBy(dockerfile);
+      expect(
+        copied,
+        contains(package),
+        reason: 'the image does not copy the package it builds',
+      );
+
+      // Transitive: the client is a path dependency of flutter, and whatever
+      // the client itself pulls in by path has to be in the context too.
+      final pending = <String>{...pathDepsOf(pubspec)};
+      final needed = <String>{};
+      while (pending.isNotEmpty) {
+        final name = pending.first;
+        pending.remove(name);
+        if (!needed.add(name)) {
+          continue;
+        }
+        final nested = File(p.join(template.path, name, 'pubspec.yaml'));
+        if (nested.existsSync()) {
+          pending.addAll(pathDepsOf(nested));
+        }
+      }
+
+      expect(
+        needed.difference(copied),
+        isEmpty,
+        reason:
+            'path dependencies missing from the build context of $package. '
+            'Add a COPY line for each, or pub inside the image fails on a '
+            'directory that is not there.',
+      );
+    });
+  }
+
+  test('the shared package is wired into both halves', () {
+    // The skeleton ships it deliberately: the guidance used to describe a
+    // package a project had to assemble by hand, and the one hint it gave
+    // about that package was wrong.
+    for (final package in const [
+      'dartway_starter_server',
+      'dartway_starter_flutter',
+    ]) {
+      expect(
+        pathDepsOf(File(p.join(template.path, package, 'pubspec.yaml'))),
+        contains('dartway_starter_shared'),
+        reason: package,
+      );
+    }
+  });
+
+  test('the shared package depends on nothing', () {
+    // The constraint is the whole design. The server does not depend on the
+    // client package — it carries its own generated copy — so a shared package
+    // that reached for the protocol would serve exactly one of the two sides.
+    final document = loadYaml(
+      File(
+        p.join(template.path, 'dartway_starter_shared', 'pubspec.yaml'),
+      ).readAsStringSync(),
+    );
+    final dependencies = (document as YamlMap)['dependencies'];
+    expect(dependencies, anyOf(isNull, isEmpty));
+  });
+}

--- a/template/README.md
+++ b/template/README.md
@@ -5,6 +5,7 @@ A fullstack app built with [DartWay](https://dartway.dev) (Flutter + Serverpod):
 - `dartway_starter_server` — Serverpod backend (models, CRUD configs, logic)
 - `dartway_starter_flutter` — Flutter app (features, UI kit, navigation)
 - `dartway_starter_client` — generated API client (**do not edit by hand**)
+- `dartway_starter_shared` — rules that must hold identically on both sides; pure Dart, no dependencies
 
 ## Getting started
 

--- a/template/dartway_starter_flutter/Dockerfile
+++ b/template/dartway_starter_flutter/Dockerfile
@@ -5,7 +5,10 @@
 FROM ghcr.io/cirruslabs/flutter:3.44.0 AS build
 
 WORKDIR /workspace
+# Every path dependency by name. One that is missing from the context fails
+# inside `flutter pub get`, three layers from the cause.
 COPY dartway_starter_client/ dartway_starter_client/
+COPY dartway_starter_shared/ dartway_starter_shared/
 COPY dartway_starter_flutter/ dartway_starter_flutter/
 
 WORKDIR /workspace/dartway_starter_flutter

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -263,7 +263,7 @@ packages:
       path: "../../packages/dartway_cli"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_flutter:
     dependency: "direct main"
     description:
@@ -310,6 +310,13 @@ packages:
     dependency: "direct main"
     description:
       path: "../dartway_starter_client"
+      relative: true
+    source: path
+    version: "0.0.0"
+  dartway_starter_shared:
+    dependency: "direct main"
+    description:
+      path: "../dartway_starter_shared"
       relative: true
     source: path
     version: "0.0.0"

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -30,6 +30,10 @@ dependencies:
   serverpod_flutter: 3.4.11
   dartway_starter_client:
     path: ../dartway_starter_client
+  # The same rules the server enforces, so the app can refuse before sending.
+  # A path dependency: the web image copies this directory too.
+  dartway_starter_shared:
+    path: ../dartway_starter_shared
 
   flutter_hooks: ^0.21.2
   hooks_riverpod: ^3.0.0

--- a/template/dartway_starter_server/Dockerfile
+++ b/template/dartway_starter_server/Dockerfile
@@ -5,6 +5,10 @@
 FROM dart:3.12.0 AS build
 
 WORKDIR /workspace
+# Both packages, and both by name: a path dependency whose directory never
+# enters the build context fails inside `dart pub get` as exit code 66, three
+# layers from the cause and pointing at neither the Dockerfile nor the package.
+COPY dartway_starter_shared/ dartway_starter_shared/
 COPY dartway_starter_server/ dartway_starter_server/
 
 WORKDIR /workspace/dartway_starter_server

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -12,6 +12,12 @@ dependencies:
   dartway_serverpod_core_server: ^0.11.0
   http: ^1.5.0
 
+  # Rules that must hold identically here and in the app. A path dependency,
+  # so both Dockerfiles have to copy this directory too — an image that does
+  # not is unbuildable, and pub says so three layers from the cause.
+  dartway_starter_shared:
+    path: ../dartway_starter_shared
+
 
 
 dev_dependencies:

--- a/template/dartway_starter_shared/README.md
+++ b/template/dartway_starter_shared/README.md
@@ -1,0 +1,29 @@
+# dartway_starter_shared
+
+Pure Dart, no dependencies. Code that has to behave **identically** on the
+server and in the app: format validation, shared enums, computation over
+fields with no IO.
+
+The package exists so a rule both sides enforce is written once. Without it the
+same rule is written twice — once in `_server`, once in `_flutter` — and the
+two copies drift silently, because each side is internally consistent and
+nothing compares them.
+
+## What may not go in here
+
+**No dependency on the client package.** The server does not depend on it
+either: it carries its own copy of the generated models under
+`lib/src/generated`. A shared package that reached for the protocol would be
+usable by exactly one of the two sides.
+
+So: plain values in, plain values out. Each side unpacks its own models at the
+call site.
+
+No Flutter, no Serverpod, no `Session`, no IO, no database.
+
+## Adding to it
+
+The public surface is `lib/dartway_starter_shared.dart`; the implementation
+goes under `lib/src/`. Both `_server` and `_flutter` already depend on this
+package, and both Dockerfiles already copy it — a package the images do not
+copy makes them unbuildable with an error three layers from its cause.

--- a/template/dartway_starter_shared/analysis_options.yaml
+++ b/template/dartway_starter_shared/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    unawaited_futures: true
+    avoid_print: true

--- a/template/dartway_starter_shared/lib/dartway_starter_shared.dart
+++ b/template/dartway_starter_shared/lib/dartway_starter_shared.dart
@@ -1,0 +1,4 @@
+/// Rules that must hold identically on the server and in the app.
+library;
+
+export 'src/starter_handle.dart';

--- a/template/dartway_starter_shared/lib/src/starter_handle.dart
+++ b/template/dartway_starter_shared/lib/src/starter_handle.dart
@@ -1,0 +1,48 @@
+/// A user-visible handle, and the one rule that decides whether it is valid.
+///
+/// A worked example rather than a feature: it is here to show the shape a
+/// shared rule takes, and it is meant to be replaced by a real one.
+///
+/// The shape is the point. Both sides need this answer — the app to refuse
+/// before sending, the server to refuse whatever reaches it — and neither may
+/// be the one that decides. Written twice, the two copies pass their own tests
+/// and disagree in production about a value on the boundary; and the side that
+/// gives way is whichever was edited last.
+///
+/// Note what it does not take: not a model, not a DTO, not a row. Plain values
+/// in, plain values out, so the server can call it on its own generated class
+/// and the app on its own.
+class StarterHandle {
+  const StarterHandle._();
+
+  static const int minLength = 3;
+  static const int maxLength = 30;
+
+  static final RegExp _allowed = RegExp(r'^[a-z0-9_]+$');
+
+  /// The form a handle is stored and compared in.
+  ///
+  /// Comparison happens on this form on both sides, so `Ann` and `ann` cannot
+  /// become two accounts.
+  static String normalise(String raw) => raw.trim().toLowerCase();
+
+  /// Why [raw] is not a usable handle, or null when it is.
+  ///
+  /// A reason rather than a bool: the app has to show something, and a message
+  /// invented separately on each side is two messages for one rule.
+  static String? reasonInvalid(String raw) {
+    final handle = normalise(raw);
+    if (handle.length < minLength) {
+      return 'A handle needs at least $minLength characters.';
+    }
+    if (handle.length > maxLength) {
+      return 'A handle may be at most $maxLength characters.';
+    }
+    if (!_allowed.hasMatch(handle)) {
+      return 'A handle may hold lowercase letters, digits and underscores only.';
+    }
+    return null;
+  }
+
+  static bool isValid(String raw) => reasonInvalid(raw) == null;
+}

--- a/template/dartway_starter_shared/pubspec.lock
+++ b/template/dartway_starter_shared/pubspec.lock
@@ -9,14 +9,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "105.0.0"
-  amazon_cognito_identity_dart_2:
-    dependency: transitive
-    description:
-      name: amazon_cognito_identity_dart_2
-      sha256: "81ad6c8e746cf34819a0d157863cbb7df6f1feb6d8e4da25a97cb22ee0051ca3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   analyzer:
     dependency: transitive
     description:
@@ -41,14 +33,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
-  bcrypt:
-    dependency: transitive
-    description:
-      name: bcrypt
-      sha256: "6073a700cbbc59f1d4ab27cd532755e3de5e676c4941f535f351374df849270b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -57,22 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  buffer:
-    dependency: transitive
-    description:
-      name: buffer
-      sha256: "389da2ec2c16283c8787e0adaede82b1842102f8c8aae2f49003a766c5c6b3d1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.3"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   cli_config:
     dependency: transitive
     description:
@@ -81,14 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -114,42 +74,13 @@ packages:
     source: hosted
     version: "1.15.1"
   crypto:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
-  dartway_serverpod_core_server:
-    dependency: "direct main"
-    description:
-      path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
-      relative: true
-    source: path
-    version: "0.11.0"
-  dartway_serverpod_core_shared:
-    dependency: "direct overridden"
-    description:
-      path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
-      relative: true
-    source: path
-    version: "0.11.0"
-  dartway_starter_shared:
-    dependency: "direct main"
-    description:
-      path: "../dartway_starter_shared"
-      relative: true
-    source: path
-    version: "0.0.0"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -158,22 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  fixnum:
-    dependency: transitive
-    description:
-      name: fixnum
-      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.1"
-  flutter_lints:
-    dependency: transitive
-    description:
-      name: flutter_lints
-      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -190,14 +105,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  http:
-    dependency: "direct main"
-    description:
-      name: http
-      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -214,14 +121,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -230,14 +129,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   lints:
     dependency: "direct dev"
     description:
@@ -278,22 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  minio:
-    dependency: transitive
-    description:
-      name: minio
-      sha256: ee2ce47766e46c7d164f960f2f5ed6a9a82844d877f6b82574f6876ec50c56d1
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.5.8"
-  mustache_template:
-    dependency: transitive
-    description:
-      name: mustache_template
-      sha256: c689b4d59176f8c7a2860aab765d205916aa5b06cfafff7613bfcc42fa996143
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.5"
   node_preamble:
     dependency: transitive
     description:
@@ -318,14 +193,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.2"
   pool:
     dependency: transitive
     description:
@@ -334,14 +201,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
-  postgres:
-    dependency: transitive
-    description:
-      name: postgres
-      sha256: "123de5cbadc56a7e8d9fa485c780b6b56940b4081f4c74f3a5578682757c299b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.5.12"
   pub_semver:
     dependency: transitive
     description:
@@ -350,86 +209,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  redis:
-    dependency: transitive
-    description:
-      name: redis
-      sha256: d7c7f18a374936baa786baf5f0e747aa5510bb289aad44b30ec41e3b703233b4
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.0"
-  relic:
-    dependency: transitive
-    description:
-      name: relic
-      sha256: d917b188dd1b6838c630d1904a1e26b040e6647406f2aab01b10fdf0ca051c12
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
-  relic_core:
-    dependency: transitive
-    description:
-      name: relic_core
-      sha256: c2f7638d56fdf144a035d17eb8e93fb30fe53bd105fd81c31393f8be4f43ecdc
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
-  relic_io:
-    dependency: transitive
-    description:
-      name: relic_io
-      sha256: d64a9f309943200ec7a45b2a127cbc5abf4dd6603159a179396d66b932a15f1f
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
-  retry:
-    dependency: transitive
-    description:
-      name: retry
-      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.2"
-  serverpod:
-    dependency: "direct main"
-    description:
-      name: serverpod
-      sha256: b8bc1110191ddecf4e58b0b97d84802e11eb82612acc6d2c7085636f65b8bb6d
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.11"
-  serverpod_lints:
-    dependency: transitive
-    description:
-      name: serverpod_lints
-      sha256: bc4f763b57e9b82ce9c35c752c962726d593526af4aee5605ac63c50938e5b20
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.11"
-  serverpod_serialization:
-    dependency: transitive
-    description:
-      name: serverpod_serialization
-      sha256: e159f298e9b980bfea720fbb91d66d5ad00ff6510f2fcd851932e9942ca0673d
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.11"
-  serverpod_shared:
-    dependency: transitive
-    description:
-      name: serverpod_shared
-      sha256: "515f5cf12cd68dc0a3934ab8d6478cbf0f011c700764a8c4c5d3ae9e967c79d0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.11"
-  serverpod_test:
-    dependency: "direct dev"
-    description:
-      name: serverpod_test
-      sha256: "32d5432d30cb34eb19979790334f7c073a5626c3dbf89f69ae3db8c06e1b49f5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.11"
   shelf:
     dependency: transitive
     description:
@@ -474,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      sha256: "14c2945847669b44089bb1222f66873d7ff7103c58911917f2a63c5a62327898"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.13"
+    version: "0.10.14"
   source_span:
     dependency: transitive
     description:
@@ -510,30 +289,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  super_string:
-    dependency: transitive
-    description:
-      name: super_string
-      sha256: ba41acf9fbb318b3fc0d57c9235779100394d85d83f45ab533615df1f3146ea7
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.0+1"
-  system_resources_2:
-    dependency: transitive
-    description:
-      name: system_resources_2
-      sha256: "3f1d7da26ece139d03e8679ca5d99faceadfdbb4edc108244aa4cc362b9181ef"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.2"
   term_glyph:
     dependency: transitive
     description:
@@ -574,22 +329,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  uuid:
-    dependency: transitive
-    description:
-      name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.5.3"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   watcher:
     dependency: transitive
     description:
@@ -630,14 +377,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/template/dartway_starter_shared/pubspec.yaml
+++ b/template/dartway_starter_shared/pubspec.yaml
@@ -1,0 +1,20 @@
+name: dartway_starter_shared
+description: Rules that must hold identically on the server and in the app.
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.11.0 <4.0.0'
+
+# Deliberately empty, and this is the whole design of the package.
+#
+# It cannot depend on the client package: the server does not depend on it
+# either — it carries its own copy of the generated models under
+# lib/src/generated. A shared package that reached for the protocol would be
+# usable by exactly one of the two sides, which is the opposite of the point.
+# Plain values in, plain values out; each side unpacks its own models at the
+# call site.
+dependencies:
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.24.2

--- a/template/dartway_starter_shared/test/starter_handle_test.dart
+++ b/template/dartway_starter_shared/test/starter_handle_test.dart
@@ -1,0 +1,29 @@
+import 'package:dartway_starter_shared/dartway_starter_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('normalising', () {
+    test('case and surrounding space do not make a second identity', () {
+      expect(StarterHandle.normalise('  Ann_Lee '), 'ann_lee');
+    });
+  });
+
+  group('validity', () {
+    test('a usable handle has no reason against it', () {
+      expect(StarterHandle.reasonInvalid('ann_lee'), isNull);
+      expect(StarterHandle.isValid('ann_lee'), isTrue);
+    });
+
+    test('too short, too long, and the wrong alphabet each say which', () {
+      expect(StarterHandle.reasonInvalid('an'), contains('at least'));
+      expect(StarterHandle.reasonInvalid('a' * 31), contains('at most'));
+      expect(StarterHandle.reasonInvalid('ann lee'), contains('underscores'));
+    });
+
+    test('the rule is applied to the normalised form', () {
+      // Otherwise the app validates what the user typed and the server
+      // validates what it stored, and the two disagree on the boundary.
+      expect(StarterHandle.isValid(' ANN_LEE '), isTrue);
+    });
+  });
+}

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -18,7 +18,7 @@ Dart packages (the role is determined by the name suffix):
 | `__CLIENT_PKG__` | client | The generated Serverpod protocol. **Never edit by hand** |
 | `__FLUTTER_PKG__` | flutter | The Flutter app: features, UI Kit, navigation, data layer |
 
-A project may add a fourth one, `*_shared` — pure Dart for code that has to behave identically on the server and in Flutter (see "Shared" below). The skeleton has none: until such code shows up, the package is not needed.
+A fourth one, `*_shared` — pure Dart for code that has to behave identically on the server and in Flutter (see "Shared" below). The skeleton ships it wired, with one worked example in it.
 
 ## Cross-stack laws (they hold everywhere)
 
@@ -401,9 +401,13 @@ Not to be confused with `lib/shared/` in the Flutter package: that one holds bui
 with no story of their own. This is a separate Dart **package**, for code that must behave identically
 on the server and in Flutter.
 
-**The skeleton does not include this package** — create it once code appears that has to behave **identically** on the backend and the frontend (format validation, shared enums, computations over fields without IO). Until such code exists there is nothing to duplicate and the package is not needed.
+**The skeleton ships this package**, wired and holding one worked example — a handle rule both sides enforce. Put your own rules beside it: format validation, shared enums, computations over fields without IO. It used to be something a project assembled by hand the day it needed one, and assembling it by hand is where projects lost a day each time.
 
-✅ Allowed: pure Dart, a dependency on the client package. ❌ Not allowed: Flutter, server APIs, `Session`, IO, the DB. The public API goes in `lib/<package_name>.dart`, the implementation in `lib/src/`.
+✅ Allowed: pure Dart, and nothing else. ❌ Not allowed: **a dependency on the client package**, Flutter, server APIs, `Session`, IO, the DB. The public API goes in `lib/<package_name>.dart`, the implementation in `lib/src/`.
+
+**Why not the client package.** The server does not depend on it either — it carries its own copy of the generated models under `lib/src/generated`. A shared package that reached for the protocol would be usable by exactly one of the two sides, which is the opposite of what it is for, and the failure shows up as a duplicate model class rather than as anything naming the mistake. So: plain values in, plain values out; each side unpacks its own models at the call site.
+
+**Adding a path dependency means adding it to both Dockerfiles.** The images are built from the project root and copy package directories by name; one that is never named does not enter the build context, and `pub get` inside the image fails as exit code 66, three layers from the cause. Nothing in a checkout can tell — repository checks resolve the path fine, and the images are built only by `dartway deploy`.
 
 ## Client (`__CLIENT_PKG__`)
 


### PR DESCRIPTION
Closes #139

## The defect

The skeleton described an optional fourth package and left every project to assemble it by hand the day it needed one. Two things made that expensive.

**The one hint the guidance gave was wrong.** `toolkit/CLAUDE.md` said a `*_shared` package may depend on the client package. On a Serverpod project it may not: the server does not depend on the client package either — it carries its own copy of the generated models under `lib/src/generated`. Confirmed in this tree: `template/dartway_starter_server/pubspec.yaml` has no dependency on `dartway_starter_client`. A shared package that reaches for the protocol is therefore usable by exactly one of the two sides, which is the opposite of the point, and the failure shows up as a duplicate model class rather than as anything naming the mistake.

**And the hand-assembly list was missing the item that stops a release.** Both Dockerfiles have to copy the package. The images are built from the project root and name package directories one by one; a directory that is never named does not enter the build context, so `pub get` inside the image fails as exit code 66 — three layers from the cause, pointing at neither the Dockerfile nor the package. It is silent for a structural reason: repository checks resolve the path *inside the checkout*, and the images are built only by `dartway deploy`, on the server. A project stays green and cannot ship, and the two facts do not meet until somebody deploys.

## The change

**`template/dartway_starter_shared/`** — pure Dart, `dependencies:` deliberately empty, an export surface over `lib/src/`, a README stating what may not go in it, and one worked example with a test: `StarterHandle`, a rule both halves enforce (the app to refuse before sending, the server to refuse whatever reaches it). An example rather than a feature — it is there to show the shape, taking plain values so each side can call it on its own generated class.

Wired: a path dependency from `_server` and `_flutter`, and a `COPY` in both Dockerfiles.

**A test walks the path dependencies of each template package against what its Dockerfile copies** (`template_build_context_test.dart`), transitively — the client is a path dependency of `_flutter`, and whatever it pulls in has to be in the context too. Verified by mutation: deleting the `COPY dartway_starter_shared/` line turns it red with *"path dependencies missing from the build context of dartway_starter_server"*, and restoring it green.

**Guidance corrected** in `toolkit/CLAUDE.md` (the client-dependency claim, plus a note that a path dependency means a Dockerfile line), `docs/1-getting-started/project-layout.md` and `docs/5-tooling/cli.md`. While there: the neighbouring sentence *"`client` is the package both halves can see"* is the same misconception one step upstream and is corrected too.

## Verification

`dart analyze` clean on the shared package, on `dartway_cli` and on `template/dartway_starter_server` (one pre-existing `deprecated_member_use` in the Serverpod web widget, identical on `master`); `flutter analyze` clean on `template/dartway_starter_flutter`; 215 CLI tests and the shared package's own 4 green.

`pubspec.lock` in both template halves picks up the new package. It also refreshes stale path-override versions that were already behind on `master` (`dartway_serverpod_core_*` 0.10.0 → 0.11.0, `dartway_cli` 0.8.0 → 0.9.0) — a consequence of running `pub get`, not of this change.

## Not in this PR

The general guard the issue also suggests: teaching `dartway deploy check` to compare a project's path dependencies against what its Dockerfiles copy, for **any** project rather than the skeleton. That is a separate change to the CLI's check set, and it is the one that would catch the next package a project adds by hand. Filed separately.