### PR TITLE
feat(flutter): a failing plugin costs its own feature, not the app start

### DIFF
--- a/docs/3-flutter/plugins.md
+++ b/docs/3-flutter/plugins.md
@@ -93,6 +93,40 @@ DwAppRunner(
 ready before the first frame. A plugin that throws during `init()` surfaces on `DwAppRunner`'s error
 screen rather than half-booting the app.
 
+### What a failing plugin costs — `blocksStartup`
+
+**By default, everything: the app does not start.** `DwPlugin.blocksStartup` is `true` unless a plugin
+says otherwise, because a plugin an app declared is one it expects to have, and an app running
+without it is an app whose features fail one by one, later and further from the cause.
+
+Starting anyway is a decision, and it is made by the plugin that knows whether it is load-bearing:
+
+```dart
+class MyAnalytics extends DwPlugin {
+  // Its absence costs analytics and nothing else.
+  @override
+  bool get blocksStartup => false;
+
+  @override
+  Future<void> init(DwFlutter core) async { ... }
+}
+```
+
+A non-blocking failure is reported once through the error pipeline and the remaining plugins run.
+**Declaration order used to decide this silently:** the list ran bare, so a single `init` that threw
+aborted `dw.init()` and every plugin after it never ran — an optional integration listed first could
+take down an app that would have run perfectly without it. That is not something an app author
+weighs while writing `plugins: [...]`.
+
+Either way the failure now travels as `DwPluginInitException`, naming the plugin and carrying the
+cause, so a report says which plugin failed rather than showing a raw exception from inside a
+third-party package.
+
+Reaching for a plugin that failed says so. `of<T>()` throws a `StateError` naming the plugin and the
+failure — not a `LateInitializationError` from inside the package, which is what a swallowed error
+would have produced, further from the cause than the crash it replaced. `maybeOf<T>()` asks whether
+anybody holds a role, and a plugin that did not survive does not hold it, so it answers `null`.
+
 Declare a plugin and forget it, and the failure is loud and immediate: `dw.plugins.of<T>()` throws a
 `StateError` naming the type that was never registered. It cannot silently return null.
 

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   dartway_router: ^1.1.1
 
   dartway_serverpod_core_flutter: ^0.11.0

--- a/packages/dartway_flutter/CHANGELOG.md
+++ b/packages/dartway_flutter/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.8.0
+
+- **One plugin's failed `init` no longer takes the whole app start with it, and the report says
+  which plugin it was.**
+
+  `DwPlugins.initAll` ran the list bare: a single `init` that threw aborted `dw.init()`, so every
+  plugin declared after it never ran and the application did not start at all. Declaration order
+  silently decided the blast radius — not something an app author weighs while writing
+  `plugins: [...]`. In production this cost a whole app start: the first plugin in the list met a
+  browser with no `localStorage`, and the integrations after it, none of which needed storage,
+  never got their turn. The report was as unhelpful as the outcome — a raw exception out of a
+  third-party package, naming neither the plugin nor initialization.
+
+  What a failure costs is now the plugin's own answer. **`DwPlugin.blocksStartup` defaults to
+  `true`**, so nothing changes for an app that says nothing: a plugin it declared is one it expects
+  to have. An integration that is genuinely optional sets it to `false`, and its failure is
+  reported once through the error pipeline while the app starts without it.
+
+  Either way the failure now travels as `DwPluginInitException`, which names the plugin and carries
+  the cause, so the message says what happened wherever it is caught.
+
+  **Breaking for a class that `implements DwPlugin`** rather than extending it: the new member has a
+  default body, so `extends` inherits it and `implements` must declare it. `DwTelegramWebApp` was
+  such a class and now extends instead — which is what a plugin base wants anyway, so the next
+  member with a default does not break it either.
+
+  Reaching for a plugin that failed no longer leaks a `LateInitializationError` from inside the
+  package — further from the cause than the crash it replaced. `of<T>()` throws a `StateError`
+  naming the plugin and the failure; `maybeOf<T>()`, which asks whether anybody holds a role,
+  answers that nobody does, because a plugin that did not survive does not hold it.
+
 ## 0.7.0
 
 **`DwRefusal`** — the one error that is an answer. It carries a `message` written for the user

--- a/packages/dartway_flutter/example/pubspec.lock
+++ b/packages/dartway_flutter/example/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/dartway_flutter/lib/src/core/logic/dw_plugin.dart
+++ b/packages/dartway_flutter/lib/src/core/logic/dw_plugin.dart
@@ -38,6 +38,44 @@ abstract class DwPlugin {
   /// what `plugins:` being a constructor argument means — so this is the first
   /// moment it may look at anything.
   Future<void> init(DwFlutter core);
+
+  /// Whether a failure in [init] must stop the application from starting.
+  ///
+  /// True by default, and deliberately: a plugin an app declared is one it
+  /// expects to have, and an app running without it is an app whose features
+  /// fail one by one, later and further from the cause. Starting anyway is a
+  /// decision, and it is made here, by the plugin that knows whether it is
+  /// load-bearing.
+  ///
+  /// Set it to false where the integration is genuinely optional — analytics,
+  /// a chat widget, anything whose absence costs its own feature and nothing
+  /// else. The failure is then reported once through the error pipeline,
+  /// naming the plugin, and the app starts without it.
+  ///
+  /// The name says what happens rather than how important the plugin feels:
+  /// "required" invites an argument about importance, and the only question
+  /// that has an answer here is whether the app may start.
+  bool get blocksStartup => true;
+}
+
+/// A plugin's `init` threw, with the plugin named.
+///
+/// The raw exception out of an integration says nothing about plugins: it is a
+/// null check inside a third-party package, and neither the plugin, nor its
+/// position in the list, nor initialization appears anywhere in it. That is
+/// what a whole app start cost once, and the report was as unhelpful as the
+/// outcome.
+class DwPluginInitException implements Exception {
+  const DwPluginInitException(this.plugin, this.cause);
+
+  /// The plugin whose [DwPlugin.init] threw.
+  final Type plugin;
+
+  /// What it threw.
+  final Object cause;
+
+  @override
+  String toString() => '$plugin failed to initialize: $cause';
 }
 
 /// The plugins a project has connected, reached as `dw.plugins`.
@@ -52,6 +90,14 @@ class DwPlugins {
 
   final List<DwPlugin> _plugins;
 
+  /// Plugins whose [DwPlugin.init] threw, by identity, with what it threw.
+  ///
+  /// Kept because a failed plugin is not an absent one, and its `late final`
+  /// fields are unset: reaching for it must say what happened, not die on a
+  /// `LateInitializationError` from inside it — further from the cause than
+  /// the crash it replaced.
+  final Map<DwPlugin, Object> _failures = {};
+
   /// The registered plugin of type [T], or `null` when the app connected none.
   ///
   /// For a *role* the framework can ask about but must not require — a local
@@ -61,10 +107,16 @@ class DwPlugins {
   ///
   /// Two plugins claiming one role is not an ordinary answer, and picking the
   /// first quietly would decide something the app did not: it throws.
+  /// A plugin that failed to start is **not** a claimant here. It was declared,
+  /// it did not survive, and its failure was already reported at init — so the
+  /// framework gets the honest answer that nobody holds the role, and the app
+  /// that allowed the failure ([DwPlugin.blocksStartup] false) gets the
+  /// degradation it asked for rather than a second crash later.
   T? maybeOf<T extends DwPlugin>() {
     T? claimant;
     for (final plugin in _plugins) {
       if (plugin is! T) continue;
+      if (_failures.containsKey(plugin)) continue;
       if (claimant != null) {
         throw StateError(
           'Two plugins claim the $T role: $claimant and $plugin. '
@@ -77,9 +129,24 @@ class DwPlugins {
   }
 
   /// The registered plugin of type [T]. Throws if none is registered.
+  ///
+  /// A plugin that failed to start throws too, naming the plugin and the
+  /// failure. This is an app reaching for its own integration: absence is a
+  /// wiring mistake and a corpse is worse, because its fields are unset and
+  /// the first touch would raise a `LateInitializationError` from inside the
+  /// package, with nothing naming startup.
   T of<T extends DwPlugin>() {
     for (final plugin in _plugins) {
-      if (plugin is T) return plugin;
+      if (plugin is! T) continue;
+      final failure = _failures[plugin];
+      if (failure != null) {
+        throw StateError(
+          '$T failed to initialize: $failure. It declared '
+          'blocksStartup = false, so the app started without it — this '
+          'feature cannot run until the failure is fixed or handled.',
+        );
+      }
+      return plugin;
     }
     throw StateError(
       'No $T is registered. Declare it at startup: '
@@ -89,9 +156,38 @@ class DwPlugins {
 
   /// Initializes every plugin once, in declaration order, handing each the
   /// [core] it was declared on. Called by `dw.init()`, which passes itself.
+  ///
+  /// **One plugin's failure is contained to that plugin.** Before, nothing
+  /// separated them: a single `init` that threw aborted `dw.init()`, so every
+  /// plugin declared after it never ran and the application did not start at
+  /// all. Declaration order silently decided the blast radius, which is not
+  /// something an app author weighs while writing `plugins: [...]`.
+  ///
+  /// What a failure costs is now the plugin's own answer
+  /// ([DwPlugin.blocksStartup]), and either way the report names it: a blocking
+  /// failure travels on as [DwPluginInitException] and is reported once, by
+  /// whoever catches an uncaught error; a non-blocking one goes through the
+  /// error pipeline here and the loop carries on.
   Future<void> initAll(DwFlutter core) async {
     for (final plugin in _plugins) {
-      await plugin.init(core);
+      try {
+        await plugin.init(core);
+      } catch (error, stackTrace) {
+        _failures[plugin] = error;
+        final named = DwPluginInitException(plugin.runtimeType, error);
+        if (plugin.blocksStartup) {
+          // Rethrown rather than reported here: reporting *and* rethrowing
+          // puts the same failure in the log twice, once from us and once
+          // from the zone handler that will see it a moment later.
+          Error.throwWithStackTrace(named, stackTrace);
+        }
+        // Reported with the default source. A dedicated `DwErrorSource`
+        // value would label it better, and it is left out on purpose: the
+        // enum is switched over exhaustively in the core package, so adding
+        // one is a lockstep version move of four packages — a release
+        // decision, not part of this fix.
+        core.handleError(named, stackTrace);
+      }
     }
   }
 }

--- a/packages/dartway_flutter/pubspec.yaml
+++ b/packages/dartway_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_flutter
 description: "The Flutter skeleton of a DartWay app: bootstrap runner, guarded UI actions, the AsyncValue rendering contract, notifications and error reporting. Riverpod-native."
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_flutter/test/dw_plugin_init_test.dart
+++ b/packages/dartway_flutter/test/dw_plugin_init_test.dart
@@ -1,0 +1,126 @@
+import 'package:dartway_flutter/dartway_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A plugin whose `init` throws. [blocksStartup] is the whole variable.
+class _FailingPlugin extends DwPlugin {
+  _FailingPlugin({bool? blocking}) : _blocking = blocking;
+
+  final bool? _blocking;
+
+  /// Unset means the plugin says nothing — the default is what is under test.
+  @override
+  bool get blocksStartup => _blocking ?? super.blocksStartup;
+
+  @override
+  Future<void> init(DwFlutter core) async {
+    throw StateError('no localStorage');
+  }
+}
+
+/// Declared after the failing one. Whether it ran is the blast radius.
+class _LaterPlugin extends DwPlugin {
+  bool initialized = false;
+
+  @override
+  Future<void> init(DwFlutter core) async {
+    initialized = true;
+  }
+}
+
+void main() {
+  final reports = <DwErrorReport>[];
+
+  // One core per process; the registries under test are built separately.
+  final core = DwFlutter(
+    config: DwConfig(onErrorReport: reports.add),
+    plugins: const [],
+  );
+
+  setUp(reports.clear);
+
+  group('a plugin that blocks startup', () {
+    test('is the default, said by nobody', () {
+      expect(_FailingPlugin().blocksStartup, isTrue);
+    });
+
+    test('stops the start and the failure names it', () async {
+      final later = _LaterPlugin();
+
+      await expectLater(
+        DwPlugins([_FailingPlugin(), later]).initAll(core),
+        throwsA(
+          isA<DwPluginInitException>()
+              .having((e) => e.plugin, 'plugin', _FailingPlugin)
+              .having((e) => '$e', 'text', contains('no localStorage')),
+        ),
+      );
+
+      // Unchanged from before the fix, and deliberately: a plugin the app
+      // expects to have is not something to start without.
+      expect(later.initialized, isFalse);
+    });
+
+    test('is reported once, by whoever catches it — not here as well', () async {
+      await DwPlugins([
+        _FailingPlugin(),
+      ]).initAll(core).catchError((Object _) {});
+
+      expect(reports, isEmpty);
+    });
+  });
+
+  group('a plugin that does not block startup', () {
+    test('costs its own feature and nothing else', () async {
+      final later = _LaterPlugin();
+
+      await DwPlugins([
+        _FailingPlugin(blocking: false),
+        later,
+      ]).initAll(core);
+
+      expect(later.initialized, isTrue);
+    });
+
+    test('is reported through the pipeline, naming the plugin', () async {
+      await DwPlugins([_FailingPlugin(blocking: false)]).initAll(core);
+
+      expect(reports, hasLength(1));
+      expect('${reports.single.error}', contains('_FailingPlugin'));
+      expect('${reports.single.error}', contains('no localStorage'));
+    });
+
+    test('reaching for it says what happened, not a late-init error', () async {
+      // The failure mode being replaced: a swallowed init leaves `late final`
+      // fields unset, and the app dies at the first touch on a
+      // LateInitializationError from inside the package — further from the
+      // cause than the crash it replaced.
+      final plugins = DwPlugins([_FailingPlugin(blocking: false)]);
+      await plugins.initAll(core);
+
+      expect(
+        plugins.of<_FailingPlugin>,
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            allOf(
+              contains('_FailingPlugin'),
+              contains('no localStorage'),
+              contains('blocksStartup'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('does not hold its role: maybeOf answers that nobody took it', () async {
+      // The framework asking whether anybody took a job gets the honest
+      // answer. The failure was already reported at init, so this is not a
+      // silence — it is the degradation the app asked for.
+      final plugins = DwPlugins([_FailingPlugin(blocking: false)]);
+      await plugins.initAll(core);
+
+      expect(plugins.maybeOf<_FailingPlugin>(), isNull);
+    });
+  });
+}

--- a/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
+++ b/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
@@ -175,7 +175,7 @@ packages:
       path: "../../../dartway_flutter"
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   dartway_offline_flutter:
     dependency: "direct main"
     description:

--- a/packages/dartway_offline/dartway_offline_flutter/pubspec.yaml
+++ b/packages/dartway_offline/dartway_offline_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   dartway_offline_shared: ^0.1.0
   dartway_serverpod_core_flutter: ^0.11.0
   drift: 2.31.0

--- a/packages/dartway_push/dartway_push_flutter/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   # The device registration request, and the CRUD action that carries it. The
   # app half talks to the server half through the generated protocol, not
   # through an endpoint of its own.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
   serverpod_client: ^3.4.11
 
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   dartway_serverpod_core_client: ^0.11.0
   dartway_serverpod_core_shared: ^0.11.0
   collection: ^1.19.1

--- a/packages/dartway_shared_preferences/pubspec.yaml
+++ b/packages/dartway_shared_preferences/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   flutter_riverpod: ^3.0.0
   shared_preferences: ^2.3.0
 

--- a/packages/dartway_studio_binding/pubspec.yaml
+++ b/packages/dartway_studio_binding/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
   # The passports the binding reports come from mounted DwFeature widgets.
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   # The screen identity Studio binds to is the route's declared name, which is
   # a DwRouter concept — the reason this is a package of its own rather than a
   # corner of core_flutter, where the dependency would reach apps that never

--- a/packages/dartway_telegram/lib/src/dw_telegram_web_app.dart
+++ b/packages/dartway_telegram/lib/src/dw_telegram_web_app.dart
@@ -32,7 +32,7 @@ import 'dw_telegram_web_app_stub.dart'
 /// `dartway_flutter` knows nothing of Telegram: it knows only what a [DwPlugin]
 /// is. The `dw.plugins.telegram` accessor is an extension declared *here*, so it
 /// exists only for apps that chose this package.
-abstract class DwTelegramWebApp implements DwPlugin {
+abstract class DwTelegramWebApp extends DwPlugin {
   const DwTelegramWebApp();
 
   /// The platform implementation: the real bridge on web, an inert stub on

--- a/packages/dartway_telegram/pubspec.yaml
+++ b/packages/dartway_telegram/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   telegram_web_app: ^0.3.3
 
 dev_dependencies:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.7.0
+  dartway_flutter: ^0.8.0
   dartway_router: ^1.1.1
 
   dartway_serverpod_core_flutter: ^0.11.0


### PR DESCRIPTION
Closes #124. Sibling of #123, which is the specific failure that cost an app start; this is the containment that holds whatever the next one turns out to be.

## The defect

`DwPlugins.initAll` ran the list bare — `for (plugin in _plugins) await plugin.init(core)`. A single `init` that threw aborted `dw.init()`, so every plugin declared after it never ran and the application did not start at all.

**Declaration order silently decided the blast radius**, and that is not something an app author weighs while writing `plugins: [...]`. In production it cost a whole app start: the first plugin in the list met a browser with no `localStorage`, and the integrations declared after it — none of which needed storage — never got their turn. The report was as unhelpful as the outcome: a raw exception out of a third-party package, naming neither the plugin, nor its position, nor initialization.

## The change

**`DwPlugin.blocksStartup`, defaulting to `true`.** Nothing changes for an app that says nothing: a plugin it declared is one it expects to have, and starting without it is a decision — made by the plugin that knows whether it is load-bearing. An integration that is genuinely optional sets `false`, its failure is reported once through the error pipeline, and the loop carries on.

The name says what happens rather than how important the plugin feels; "required" invites an argument about importance, and the only question with an answer here is whether the app may start.

**`DwPluginInitException`** carries the plugin type and the cause, so the message names the plugin wherever it is caught. A blocking failure is rethrown rather than reported here — reporting *and* rethrowing puts the same failure in the log twice, once from us and once from the zone handler a moment later.

**Reaching for a failed plugin says so.** Swallowing an error leaves `late final` fields unset, and the app then dies at the first `dw.plugins.x` on a `LateInitializationError` from inside the package — further from the cause than the crash it replaced. `of<T>()` now throws a `StateError` naming the plugin and the failure.

**One deviation from the issue, said out loud.** It proposed that `maybeOf<T>()` throw as well. It returns `null` instead: `maybeOf` is the framework asking whether anybody took a role, the failure was already reported at init, and an app that set `blocksStartup: false` asked for exactly this degradation — throwing there would hand it a second crash for a decision it already made. `of<T>()`, where absence is a wiring mistake, still throws.

## Breaking, and how it surfaces

A class that **`implements DwPlugin`** rather than extending it must now declare the member. `DwTelegramWebApp` was such a class; it extends now, which is what a plugin base wants anyway, so the next member with a default does not break it either. The compiler names every case.

Version: `dartway_flutter` `0.7.0` → `0.8.0`, since `stable` and `master` agree at `0.7.0` and this change is a minor under a `0.x` major. All eight `^0.7.0` carets raised — the two the ritual names (`example/`, `template/`) and the six sibling packages, which would otherwise be uninstallable beside the new minor once `dependency_overrides` are stripped.

## Left out on purpose

A dedicated `DwErrorSource.pluginInit` would label the non-blocking report better than the default `manual`. The enum is switched over exhaustively in `dartway_serverpod_core_flutter`, so adding a value pulls in a lockstep version move of the four core packages — a release decision rather than part of this fix, and not one to make inside a PR that merges on a green review. Reported with the default source for now; the message body names the plugin either way.

## How it is demonstrated

`dw_plugin_init_test.dart`, seven cases: the default is `true` when a plugin says nothing; a blocking failure stops the start, names the plugin, and leaves the plugin after it uninitialised (unchanged from before); it is *not* reported here, so it is logged once; a non-blocking failure lets the later plugin run, is reported once through the pipeline naming the plugin, makes `of<T>()` throw a descriptive `StateError`, and makes `maybeOf<T>()` answer `null`.

`dart analyze` clean across `packages/` (one pre-existing `dead_code` in generated Serverpod transport, identical on `master`); `dartway_flutter` 48 tests, `dartway_telegram` 6, `dartway_serverpod_core_flutter` 122 — all green.