### PR TITLE
feat(server)!: a web route tells the caller only what was written for them

### DIFF
--- a/docs/4-server/web-routes.md
+++ b/docs/4-server/web-routes.md
@@ -1,0 +1,70 @@
+# Web routes: an integration calling in
+
+A Serverpod route that answers an outside system — a payment webhook, a
+delivery callback, a partner's push — is an HTTP handler, not an endpoint. It
+has no session of ours, no authenticated user, and no client library on the
+other side. What it needs is always the same four things: read the body once,
+log the request, decide what the caller is allowed to see when it fails, and
+answer in a shape they can parse.
+
+The framework owns all four. `DwWebServerLog` is a framework table and arrives
+by migration in every project, so "integration requests are logged" is settled
+upstream; `DwWebServerLogger` is what writes into it.
+
+```dart
+Future<bool> handleCall(Session session, HttpRequest request) =>
+    DwWebServerLogger.handleWithExceptions(
+      session,
+      request,
+      handler: 'PaymentCallback',
+      action: (body) async {
+        final payload = jsonDecode(body ?? '{}') as Map<String, dynamic>;
+        final orderId = payload['orderId'];
+        if (orderId == null) {
+          throw const DwPublicWebException('orderId is required');
+        }
+        await _apply(session, orderId as int);
+        return {'applied': true};
+      },
+    );
+```
+
+A successful `action` becomes `{"success": true, "data": …}` with `200`.
+
+## What the caller is told when it fails
+
+**Only a `DwPublicWebException` reaches them.** Its `message` is the response
+body and its `statusCode` the status — `400` unless you say otherwise.
+
+Anything else is answered with `500` and a fixed sentence. That is not caution
+for its own sake: an arbitrary exception carries whatever it carries — a
+database error carries its query, a null check carries a file path, a framework
+failure carries whatever the framework felt like saying — and it was written
+for us, not for a caller we never authenticated. The text is not lost; it goes
+to the alert and into the `DwWebServerLog` row, where it is of use.
+
+So "safe to show the caller" is a **type**, not a convention:
+
+```dart
+throw const DwPublicWebException('unknown signature', statusCode: 401);
+```
+
+A public failure raises no alert. The route refusing on its own terms is not an
+incident, and alerting on every malformed request is how people learn to stop
+reading alerts. It is still recorded in the log row.
+
+## What reaches the log table
+
+Headers and the JSON body are written with sensitive values replaced, walking
+maps **and lists** — a payload keeps its secrets one level inside an array as
+readily as under a key. A body that is not JSON is not logged at all.
+
+`DwWebServerLogger.knownSensitiveKeys` is the maintained list (`authorization`,
+`cookie`, `x-api-key`, `token`, `secret`, …). Pass `sensitiveKeys:` to extend it
+for a route whose partner names things its own way — and add it to the framework
+list instead when the name is not project-specific, because the next project
+will meet the same partner.
+
+The log row records the method, URL, sanitised headers and body, status, status
+code, error text, duration, handler name and caller IP. Writing it never fails
+the request: a failure to log is alerted and swallowed.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.12.0
+
+- **A web route no longer answers the caller with whatever the exception happened to say.**
+
+  `DwWebServerLogger.handleWithExceptions` caught everything and wrote `e.toString()` into the
+  response body. An arbitrary exception carries what it carries — a database error carries its
+  query, a null check carries a file path — and it was written for us, while whoever called a
+  webhook is not somebody we authenticated. The `500` looked ordinary from the outside, so nothing
+  drew attention to what had been sent with it.
+
+  `DwPublicWebException` makes "safe to show the caller" a type instead of a convention: its
+  message and status code go to the caller verbatim, and it raises no alert, because a route
+  refusing on its own terms is not an incident. Everything else answers with a fixed sentence and
+  `500`; the text lives in the alert and in the `DwWebServerLog` row.
+
+  The decision is `DwWebServerLogger.failureFor`, a function rather than two branches inside a
+  `try`, so the security-relevant half can be checked without a server, a session or a socket.
+
+- **A secret inside a list is now hidden in the log row too.** The sanitiser walked nested maps and
+  stopped there, so `{"items":[{"token":"…"}]}` was written into `DwWebServerLog` intact — and
+  nothing failed, which is the whole difficulty with this class of bug.
+
+- Web routes are documented: `docs/4-server/web-routes.md`. Three of the four things every project
+  was rewriting had been in the framework for a while with nothing pointing at them.
+
 ## 0.11.0
 
 **New: `DwProxyHttpClient.fromEnv`** — alerts reach Telegram from a host that cannot reach it

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/dartway_serverpod_core_server.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/dartway_serverpod_core_server.dart
@@ -42,4 +42,5 @@ export 'src/domain/crud/model_configs/dw_save_config.dart';
 export 'src/generated/endpoints.dart' hide ServerpodFutureCallsGetter;
 export 'src/generated/protocol.dart';
 export 'src/static/dw_configuration_keys.dart';
+export 'src/utils/web_logs/dw_public_web_exception.dart';
 export 'src/utils/web_logs/dw_web_server_logger.dart';

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/utils/web_logs/dw_public_web_exception.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/utils/web_logs/dw_public_web_exception.dart
@@ -1,0 +1,32 @@
+/// A failure whose message the caller is allowed to read.
+///
+/// Everything a web route throws ends up in the HTTP response one way or
+/// another; the only question is whether the text was written for that reader.
+/// Without a type saying so, the honest answer is no — a database error
+/// carries its query, a null check carries a file path, a Serverpod failure
+/// carries whatever the framework felt like saying — and the caller of a
+/// webhook is not somebody we authenticated.
+///
+/// So the split is a type rather than a convention: throw this one and the
+/// [message] is the response; throw anything else and the caller is told that
+/// something failed, while the detail goes where detail belongs — the alert
+/// and the `DwWebServerLog` row.
+///
+/// ```dart
+/// if (payload['orderId'] == null) {
+///   throw const DwPublicWebException('orderId is required');
+/// }
+/// ```
+class DwPublicWebException implements Exception {
+  const DwPublicWebException(this.message, {this.statusCode = 400});
+
+  /// Shown to the caller verbatim. Write it for them.
+  final String message;
+
+  /// Defaults to 400: a message worth showing the caller is almost always
+  /// about what they sent.
+  final int statusCode;
+
+  @override
+  String toString() => 'DwPublicWebException($statusCode): $message';
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/utils/web_logs/dw_web_server_logger.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/utils/web_logs/dw_web_server_logger.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
 import '../../private/dw_singleton.dart';
 
@@ -83,16 +84,20 @@ class DwWebServerLogger {
 
       return true;
     } catch (e, st) {
+      final failure = failureFor(e);
+
       error = e.toString();
       status = 'error';
-      statusCode = HttpStatus.internalServerError;
+      statusCode = failure.statusCode;
 
-      dw.alerts.reportError('❌ $handler failed', exception: e, stackTrace: st);
+      if (failure.alert) {
+        dw.alerts.reportError('❌ $handler failed', exception: e, stackTrace: st);
+      }
 
       request.response
-        ..statusCode = HttpStatus.internalServerError
+        ..statusCode = failure.statusCode
         ..headers.contentType = ContentType.json
-        ..write(jsonEncode({'success': false, 'error': e.toString()}));
+        ..write(jsonEncode({'success': false, 'error': failure.message}));
 
       return true;
     } finally {
@@ -134,6 +139,39 @@ class DwWebServerLogger {
     }
   }
 
+  /// What the caller is told about [error], and whether it is an incident.
+  ///
+  /// The whole security question of a web route sits in this one line, so it
+  /// is a function rather than two branches inside a `try`: it can be checked
+  /// without a server, a session or a socket.
+  ///
+  /// A [DwPublicWebException] was written for the caller and goes to the caller
+  /// — and raises no alert, because the route refusing on its own terms is not
+  /// an incident. Anything else was written for us: a database error carries
+  /// its query, a null check carries a file path, and whoever called a webhook
+  /// is not somebody we authenticated. The caller is told that it failed; the
+  /// text lives in the alert and in the [DwWebServerLog] row, where it is of
+  /// use.
+  @visibleForTesting
+  static ({int statusCode, String message, bool alert}) failureFor(
+    Object error,
+  ) => error is DwPublicWebException
+      ? (statusCode: error.statusCode, message: error.message, alert: false)
+      : (
+          statusCode: HttpStatus.internalServerError,
+          message: 'Internal error. The failure has been recorded.',
+          alert: true,
+        );
+
+  /// The body as it is written to [DwWebServerLog] — sensitive values replaced.
+  ///
+  /// Exposed for the test rather than for callers: a walk that misses a shape
+  /// writes a secret into a table and nothing fails, which is not something to
+  /// find out from a log review.
+  @visibleForTesting
+  static String? sanitizeBody(String? body, List<String> keys) =>
+      _sanitizeBody(body, keys);
+
   static bool _isSensitiveKey(String key, List<String> keys) {
     final lower = key.toLowerCase();
 
@@ -159,17 +197,27 @@ class DwWebServerLogger {
       final decoded = jsonDecode(body);
       if (decoded is! Map<String, dynamic>) return null;
 
-      void sanitizeMap(Map<String, dynamic> map) {
-        for (final key in map.keys.toList()) {
-          if (_isSensitiveKey(key, extraKeys)) {
-            map[key] = _sensitiveValue;
-          } else if (map[key] is Map<String, dynamic>) {
-            sanitizeMap(map[key] as Map<String, dynamic>);
+      // Lists as well as maps. A payload keeps its secrets one level inside an
+      // array as readily as under a key — `{"items":[{"token":"…"}]}` — and a
+      // walk that stops at maps writes that token into the log table intact,
+      // with nothing failing.
+      void sanitizeValue(Object? value) {
+        if (value is Map<String, dynamic>) {
+          for (final key in value.keys.toList()) {
+            if (_isSensitiveKey(key, extraKeys)) {
+              value[key] = _sensitiveValue;
+            } else {
+              sanitizeValue(value[key]);
+            }
+          }
+        } else if (value is List) {
+          for (final item in value) {
+            sanitizeValue(item);
           }
         }
       }
 
-      sanitizeMap(decoded);
+      sanitizeValue(decoded);
       return jsonEncode(decoded);
     } catch (_) {
       // Non-JSON bodies are never logged

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -13,6 +13,8 @@ environment:
 
 dependencies:
   serverpod: ^3.4.11
+  # For @visibleForTesting on the two web-route helpers a test drives directly.
+  meta: ^1.16.0
 
   dartway_serverpod_core_shared: ^0.12.0
   collection: ^1.19.1

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/web_logs/dw_web_route_failure_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/web_logs/dw_web_route_failure_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('what a failing web route tells the caller', () {
+    test('an exception written for us stays with us', () {
+      // The caller of a webhook is not somebody we authenticated, and an
+      // arbitrary exception carries whatever it carries — a query, a path, a
+      // framework message. It used to be written straight into the response.
+      final failure = DwWebServerLogger.failureFor(
+        StateError('connection to db-prod-1 failed: SELECT token FROM users'),
+      );
+
+      expect(failure.statusCode, HttpStatus.internalServerError);
+      expect(failure.message, isNot(contains('db-prod-1')));
+      expect(failure.message, isNot(contains('SELECT')));
+      expect(failure.alert, isTrue, reason: 'this one is an incident');
+    });
+
+    test('an exception written for the caller reaches them verbatim', () {
+      final failure = DwWebServerLogger.failureFor(
+        const DwPublicWebException('orderId is required'),
+      );
+
+      expect(failure.statusCode, HttpStatus.badRequest);
+      expect(failure.message, 'orderId is required');
+      // The route refusing on its own terms is not an incident, and alerting
+      // on every malformed request trains people to stop reading alerts.
+      expect(failure.alert, isFalse);
+    });
+
+    test('a public failure may name its own status', () {
+      final failure = DwWebServerLogger.failureFor(
+        const DwPublicWebException('unknown signature', statusCode: 401),
+      );
+
+      expect(failure.statusCode, 401);
+      expect(failure.message, 'unknown signature');
+    });
+  });
+
+  group('what reaches the log table', () {
+    const keys = DwWebServerLogger.knownSensitiveKeys;
+
+    Map<String, dynamic> sanitized(Object body) =>
+        jsonDecode(DwWebServerLogger.sanitizeBody(jsonEncode(body), keys)!)
+            as Map<String, dynamic>;
+
+    test('a secret at the top level is hidden', () {
+      expect(sanitized({'token': 'abc', 'id': 7})['token'], isNot('abc'));
+      expect(sanitized({'token': 'abc', 'id': 7})['id'], 7);
+    });
+
+    test('a secret nested in a map is hidden', () {
+      final out = sanitized({
+        'auth': {'password': 'hunter2'},
+      });
+
+      expect((out['auth'] as Map)['password'], isNot('hunter2'));
+    });
+
+    test('a secret inside a list is hidden too', () {
+      // The walk used to stop at maps. A payload keeps its secrets one level
+      // inside an array as readily as under a key, and that one was written
+      // into the log table intact with nothing failing.
+      final out = sanitized({
+        'items': [
+          {'id': 1, 'token': 'leaked'},
+          {'id': 2, 'nested': {'secret': 'also leaked'}},
+        ],
+      });
+
+      final items = out['items'] as List;
+      expect((items.first as Map)['token'], isNot('leaked'));
+      expect((items.first as Map)['id'], 1);
+      expect(((items[1] as Map)['nested'] as Map)['secret'], isNot('also leaked'));
+    });
+
+    test('a body that is not JSON is not logged at all', () {
+      expect(DwWebServerLogger.sanitizeBody('not json', keys), isNull);
+    });
+  });
+}

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -427,6 +427,10 @@ Only when it does not fit into CRUD (file upload/download — often still shaped
 | The answer is a projection over rows rather than the rows | `DwDtoGetListConfig` |
 | The response must carry the model's relations | `afterSaveTransform` re-reading with the same `include` |
 
+**A webhook is not an endpoint, and it is not yours to wrap.** A route an outside system calls goes through `DwWebServerLogger.handleWithExceptions`, which reads the body once, logs the request into `DwWebServerLog` with sensitive values hidden, and answers in `{success, data}`. Four projects wrote that themselves because nothing pointed at it; the page is `docs/4-server/web-routes.md`.
+
+The part that matters while writing the handler: **only a `DwPublicWebException` reaches the caller.** Its message is the response body and it raises no alert — the route refusing on its own terms is not an incident. A bare `Exception` is answered with a fixed sentence and a `500`, because its text was written for us and the caller of a webhook is not somebody we authenticated. This is the same distinction `DwActionRejection` draws inside CRUD, at the other door.
+
 One class of operation genuinely has no rung, and it is worth naming so the search stops: an operation whose **answer comes from outside the database** — probing an external service under credentials the client must not hold, verifying that a connection works, resolving something from a third party. It reads nothing, writes nothing, and its result must not be stored, because a stored answer to "is this working right now" goes stale in silence. `DwDtoGetListConfig` cannot carry it (the projection is synchronous, and its only argument becomes a SQL `WHERE`), and `DwDtoActionConfig` holds a database connection open across the network call. That one is an endpoint, deliberately — not because you failed to find the rung.
 
 ## Workflow and tests


### PR DESCRIPTION
Closes #80 — though not where the issue expected.

## What the issue turned out to be

#80 asks for four things to move into `dartway_serverpod_core_server`, next to `DwWebServerLog`: the handler wrapper, the sanitiser, the `{success, data}` envelope, and a public exception type.

**Three of the four have been there for a while.** `DwWebServerLogger.handleWithExceptions` reads the body once, logs, and answers in the envelope; `knownSensitiveKeys` is the maintained list. Nothing in `docs/` mentions any of it, which is most of why every project rewrote them — the issue's own words, "a table with no writer", describe a discoverability problem as much as a design one.

The fourth had not moved, and in the current code it is not a duplication concern at all:

```dart
} catch (e, st) {
  ...
  ..write(jsonEncode({'success': false, 'error': e.toString()}));
```

Every internal exception went into the HTTP response body verbatim — a database error with its query, a null check with a file path, whatever Serverpod felt like saying — to a webhook caller we never authenticated. The `500` looked ordinary from the outside, so nothing drew attention to what travelled with it.

## The change

**`DwPublicWebException`** makes "safe to show the caller" a type rather than a convention. Its `message` is the response body and its `statusCode` the status, defaulting to `400`. It raises **no alert**: a route refusing on its own terms is not an incident, and alerting on every malformed request is how people learn to stop reading alerts. The log row still records it.

Everything else answers `500` with a fixed sentence, and the text goes where detail belongs — the alert and the `DwWebServerLog` row.

**The decision is a function**, `DwWebServerLogger.failureFor`, not two branches inside a `try`. The whole security question of a web route sits in that one line, and as a function it can be checked without a server, a session or a socket.

**The sanitiser now walks lists.** It descended into nested maps and stopped there, so `{"items":[{"token":"…"}]}` was written into the log table intact — the exact shape the issue names, "a secret in a log table, and no test fails".

**`docs/4-server/web-routes.md`** — the page that was missing. What the wrapper does, what the caller is told and why, what reaches the log table, and how to extend the sensitive-key list (and when to extend the framework's instead, because the next project will meet the same partner).

## Breaking

The body of a `500` from a web route no longer carries the exception text. A caller that parsed it could only do so because too much was leaking.

`dartway_serverpod_core_server` is already at `0.12.0` on `master` against `0.11.0` on `stable`, so this joins that section rather than moving the version again. The package had no `0.12.0` entry yet; it does now.

## How it is demonstrated

`test/web_logs/dw_web_route_failure_test.dart`: an internal `StateError` naming a host and a `SELECT` produces a message containing neither, with `alert: true`; a `DwPublicWebException` reaches the caller verbatim with `400` and `alert: false`; a public failure may name its own status; a secret is hidden at the top level, inside a nested map, and **inside a list**; a non-JSON body is not logged at all.

Verified by mutation: reverting the list walk turns three of those red.

`dart analyze` clean across `packages/` (one pre-existing `dead_code` in generated Serverpod transport); 97 tests green in the package.