### PR TITLE
feat(cli): warn on a const colour in the kit — it will not follow a theme

### DIFF
--- a/docs/3-flutter/ui-kit.md
+++ b/docs/3-flutter/ui-kit.md
@@ -79,6 +79,37 @@ into the kit whole** and the feature composes it. Inside the kit the style comes
 (`AppTextStyle.body.resolve(context)`). Silencing the rule with `// ignore:` is a style that escaped
 the kit, and the next screen will never learn it exists.
 
+
+### Inside the kit, a colour comes from the context too
+
+The rule above says where styling may live. It says nothing about **how a kit widget obtains a
+colour**, and the silence has a default answer: a project repeats what the scaffold shows. A token
+declared `static const` does not depend on a context, so changing `ThemeData` does not touch it —
+the theme switches and the kit stays as it was.
+
+Nothing diagnoses that. The analyzer is quiet, the tests are green, and it surfaces on the day
+somebody asks for a light theme: not as a bug but as a rewrite, because every read has to be
+converted at once, along with everything that composed a colour outside `build` — a `decoration`
+getter, a tone's `color`, an icon button's `_iconColor`, none of which had a context. In one real
+kit that was 127 reads across 18 files.
+
+So a kit widget takes its colour and its text style **from the context**, through the palette:
+
+```dart
+// ❌ will not follow a second theme
+static const Color mutedColor = Color(0xFF888888);
+
+// ✅
+Color muted(BuildContext context) => context.colorScheme.onSurfaceVariant;
+```
+
+`dartway check` warns on a `static const Color` or `TextStyle` under `lib/ui_kit/` —
+[`uiKitConstStyle`](../5-tooling/conventions-checker.md). **`ui_kit/theme/` is exempt**: that is
+where the theme is assembled, and a seed colour has to be written down somewhere. Geometry stays
+`const` as well — a radius does not depend on the theme.
+
+One theme in a project means a palette with one set of colours, not the absence of `of(context)`.
+
 ## The rule that makes the previous one hold
 
 **A kit widget's public API accepts no visual types.** No `Color`, `TextStyle`, `EdgeInsets`,

--- a/docs/5-tooling/conventions-checker.md
+++ b/docs/5-tooling/conventions-checker.md
@@ -112,6 +112,7 @@ commit over a 210-line file is a check people disable.
 | `forbiddenUiKitImport` | error | Importing inside `ui_kit/` instead of the `ui_kit.dart` barrel |
 | `uiKitPartMissing` | error | A kit file without `part of '../ui_kit.dart'` |
 | `uiKitContainsText` | warning | A text constant in the kit; texts belong to features and l10n |
+| `uiKitConstStyle` | warning | A `static const Color`/`TextStyle` in the kit outside `ui_kit/theme/` — a token that will not follow a second theme |
 | `invalidTopLevelLayout` | error | A folder or file the declared top level does not name, or a fixed name that is missing |
 | `frameworkRefsDiverged` | warning | The project's `dartway_*` git dependencies are locked to more than one commit |
 | `invalidFeatureStructure` | error | A feature folder with more than one root file |

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 0.9.0
 
+- **`dartway check` warns on a `static const Color` or `TextStyle` inside `lib/ui_kit/`.**
+
+  A token declared const does not depend on a context, so changing `ThemeData` does not touch it:
+  the theme switches and the kit stays as it was. Nothing said so — the guidance covers where
+  styling may live and not how a kit widget obtains a colour, the analyzer is quiet, the tests are
+  green — and it surfaces on the day somebody asks for a light theme, as a rewrite of every read in
+  the kit at once, along with everything that composed a colour outside `build`. In one real kit
+  that was 127 reads across 18 files.
+
+  A warning, not an error: one theme is a legitimate state for a project to be in, and what it will
+  not survive is the second one. **`ui_kit/theme/` is exempt** — that is where the theme is
+  assembled, and a seed colour has to be written down somewhere; without the exemption the rule
+  fires on every project's palette and gets switched off. Geometry is not the rule's business
+  either: a radius does not depend on the theme.
+
 - **An Nginx upstream that no service answers to now stops the deploy, instead of the proxy.**
 
   A snippet under `deploy/nginx.d/` names Compose services as backends, and nothing checked that

--- a/packages/dartway_cli/lib/src/checker/dw_check_type.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_check_type.dart
@@ -14,6 +14,20 @@ enum DwCheckType {
   /// Raw styles (Color/TextStyle/BorderRadius/theme access) outside `ui_kit/`.
   forbiddenUiUsage,
 
+  /// A `static const Color` or `static const TextStyle` inside `ui_kit/`,
+  /// outside the folder where the theme is assembled.
+  ///
+  /// A token declared const does not depend on a context, so `ThemeData`
+  /// changing does not touch it: the theme switches and the kit stays as it
+  /// was. Nothing diagnoses that — the analyzer is quiet, this checker used to
+  /// be quiet, the tests are green — and it surfaces on the day somebody asks
+  /// for a light theme, as a rewrite of every token read in the kit.
+  ///
+  /// A warning rather than an error: the kit still works, and one theme is a
+  /// legitimate state for a project to be in. What it will not survive is the
+  /// second one.
+  uiKitConstStyle,
+
   /// Importing `ui_kit/*` files directly instead of the `ui_kit.dart` barrel.
   forbiddenUiKitImport,
 
@@ -145,6 +159,7 @@ enum DwCheckType {
   DwCheckSeverity get severity => switch (this) {
     DwCheckType.fileLong => DwCheckSeverity.info,
     DwCheckType.uiKitContainsText ||
+    DwCheckType.uiKitConstStyle ||
     DwCheckType.featureSpecMissing ||
     DwCheckType.forbiddenAssetPath ||
     DwCheckType.unusedFeatureFile ||

--- a/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
@@ -510,7 +510,39 @@ class DwFlutterInspector {
       }
 
       _checkUiKitTextConstants(rel, content);
+      _checkUiKitConstStyles(rel, content);
       _checkAssetPaths(rel, content, 'ui_kit');
+    }
+  }
+
+  /// `static const Color` / `static const TextStyle` in the kit.
+  ///
+  /// Exempt: `ui_kit/theme/`, which is where the theme is assembled — a seed
+  /// colour or a base style has to be written down somewhere, and that is the
+  /// one place it does not depend on a context. Everything else in the kit is
+  /// a consumer, and a consumer holding its own constant is the token that
+  /// will not survive a second theme.
+  void _checkUiKitConstStyles(String rel, String content) {
+    if (rel.startsWith('ui_kit/theme/')) return;
+
+    final lines = content.split('\n');
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i].trim();
+      if (line.startsWith('//') || line.startsWith('*')) continue;
+
+      final match = _uiKitConstStyle.firstMatch(line);
+      if (match == null) continue;
+
+      _add(
+        DwCheckType.uiKitConstStyle,
+        '$rel declares a const ${match.group(1)} (line ${i + 1}) — '
+            'it will not follow a second theme; take it from '
+            'Theme.of(context) through the palette instead',
+        'ui_kit',
+      );
+      // One finding per file: the rest are the same mistake, and a list of
+      // forty is a list nobody reads to the end.
+      return;
     }
   }
 
@@ -744,6 +776,12 @@ class _DwGrade {
 /// A quoted run of at least three characters — what the kit rule reads as a
 /// candidate text constant.
 final _uiKitTextLiteral = RegExp('''["']([^"']{3,})["']''');
+
+/// `static const Color x = …` and its TextStyle twin, in any order of
+/// modifiers a formatter may leave behind.
+final _uiKitConstStyle = RegExp(
+  r'\bstatic\s+(?:final\s+)?const\s+(Color|TextStyle)\b',
+);
 
 /// `fontFamily: 'monospace'` — the literal sits directly in that argument.
 final _fontFamilyArgument = RegExp(r'\bfontFamily\s*:\s*(?:const\s+)?$');

--- a/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
@@ -788,10 +788,15 @@ final _uiKitTextLiteral = RegExp('''["']([^"']{3,})["']''');
 /// `Map<String, Color>`. All three are the same mistake, so the rule asks
 /// whether the line declares a const and names the type anywhere in it.
 ///
-/// `\bColor\b` rather than `Color`: `iconColor` is a name, not a type, and a
-/// rule that reported it would be narrowed within a week.
+/// `Colors` is listed separately on purpose: a word boundary after `Color`
+/// does not fire on `Colors.grey`, which is as ordinary a way to write a
+/// hardcoded colour as the constructor is.
+///
+/// Bounded rather than bare, because `iconColor` is a name and not a type, and
+/// a rule that reported names would be narrowed within a week — and a narrowed
+/// rule stops firing where it mattered.
 final _uiKitConstStyle = RegExp(
-  r'^static\s+const\b.*\b(Color|TextStyle)\b',
+  r'^static\s+const\b.*\b(Colors|Color|TextStyle)\b',
 );
 
 /// `fontFamily: 'monospace'` — the literal sits directly in that argument.

--- a/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_flutter_inspector.dart
@@ -530,6 +530,10 @@ class DwFlutterInspector {
       final line = lines[i].trim();
       if (line.startsWith('//') || line.startsWith('*')) continue;
 
+      // Trimmed, so an indented member matches; a declaration wrapped across
+      // lines by the formatter is missed, as in the text-constant rule beside
+      // it — the same trade, and the same reason: a line is a shape a regex
+      // can judge, and a parse is not what this checker is.
       final match = _uiKitConstStyle.firstMatch(line);
       if (match == null) continue;
 
@@ -777,10 +781,17 @@ class _DwGrade {
 /// candidate text constant.
 final _uiKitTextLiteral = RegExp('''["']([^"']{3,})["']''');
 
-/// `static const Color x = …` and its TextStyle twin, in any order of
-/// modifiers a formatter may leave behind.
+/// A `static const` declaration that mentions a colour or a text style.
+///
+/// Not just `static const Color x` — the type is usually inferred
+/// (`static const muted = Color(0xFF888888)`), and a palette is as often a
+/// `Map<String, Color>`. All three are the same mistake, so the rule asks
+/// whether the line declares a const and names the type anywhere in it.
+///
+/// `\bColor\b` rather than `Color`: `iconColor` is a name, not a type, and a
+/// rule that reported it would be narrowed within a week.
 final _uiKitConstStyle = RegExp(
-  r'\bstatic\s+(?:final\s+)?const\s+(Color|TextStyle)\b',
+  r'^static\s+const\b.*\b(Color|TextStyle)\b',
 );
 
 /// `fontFamily: 'monospace'` — the literal sits directly in that argument.

--- a/packages/dartway_cli/test/ui_kit_const_style_test.dart
+++ b/packages/dartway_cli/test/ui_kit_const_style_test.dart
@@ -58,6 +58,30 @@ class AppTextStyles {
       expect(findings, contains(DwCheckType.uiKitConstStyle));
     });
 
+    test('an inferred type is the same mistake, and the usual spelling',
+        () async {
+      // `static const muted = Color(0xFF888888)` is how this is written more
+      // often than with the type spelled out; a rule that missed it would
+      // report the rarer half of the problem.
+      final findings = await findingsFor('ui_kit/app_tone.dart', '''
+class AppTone {
+  static const muted = Color(0xFF888888);
+}
+''');
+
+      expect(findings, contains(DwCheckType.uiKitConstStyle));
+    });
+
+    test('a palette held in a collection is reported too', () async {
+      final findings = await findingsFor('ui_kit/app_palette.dart', '''
+class AppPalette {
+  static const Map<String, Color> tones = {};
+}
+''');
+
+      expect(findings, contains(DwCheckType.uiKitConstStyle));
+    });
+
     test('it is a warning, not a failure — one theme is a legitimate state',
         () {
       expect(DwCheckType.uiKitConstStyle.severity, DwCheckSeverity.warning);
@@ -86,6 +110,19 @@ class AppCard extends StatelessWidget {
   Widget build(BuildContext context) => Container(
         color: Theme.of(context).colorScheme.surface,
       );
+}
+''');
+
+      expect(findings, isNot(contains(DwCheckType.uiKitConstStyle)));
+    });
+
+    test('a name that merely contains the word is not a type', () async {
+      // `iconColor` is a name. A rule that reported it would be narrowed
+      // within a week, and a narrowed rule stops firing where it mattered.
+      final findings = await findingsFor('ui_kit/app_icon.dart', '''
+class AppIcon {
+  static const double iconColorOpacity = 0.6;
+  static const String colorKey = 'color';
 }
 ''');
 

--- a/packages/dartway_cli/test/ui_kit_const_style_test.dart
+++ b/packages/dartway_cli/test/ui_kit_const_style_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/checker/dw_check_type.dart';
+import 'package:dartway_cli/src/checker/dw_flutter_inspector.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// A token declared `static const` does not depend on a context, so changing
+/// `ThemeData` does not touch it: the theme switches and the kit stays as it
+/// was. Nothing else says so — the analyzer is quiet, the tests are green —
+/// and it surfaces on the day somebody asks for a light theme, as a rewrite of
+/// every token read in the kit.
+///
+/// The exemption is `ui_kit/theme/`, and it comes with its pair below: a seed
+/// colour has to be written down somewhere, and that is the one place in the
+/// kit that does not read from a context.
+void main() {
+  late Directory sandbox;
+
+  setUp(() {
+    sandbox = Directory.systemTemp.createTempSync('dw_ui_kit_const');
+  });
+
+  tearDown(() => sandbox.deleteSync(recursive: true));
+
+  Future<Set<DwCheckType>> findingsFor(String relative, String body) async {
+    File(p.join(sandbox.path, 'pubspec.yaml'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('name: sandbox_flutter\n');
+
+    File(p.join(sandbox.path, 'lib', relative))
+      ..createSync(recursive: true)
+      ..writeAsStringSync("part of '../ui_kit.dart';\n\n$body");
+
+    final inspector = DwFlutterInspector(packageDir: sandbox);
+    await inspector.run();
+    return inspector.findingTypes;
+  }
+
+  group('a token that will not survive a second theme', () {
+    test('a const Color in a kit widget is reported', () async {
+      final findings = await findingsFor('ui_kit/app_card.dart', '''
+class _AppChrome {
+  static const Color mutedColor = Color(0xFF888888);
+}
+''');
+
+      expect(findings, contains(DwCheckType.uiKitConstStyle));
+    });
+
+    test('a const TextStyle is reported the same way', () async {
+      final findings = await findingsFor('ui_kit/app_text.dart', '''
+class AppTextStyles {
+  static const TextStyle body = TextStyle(fontSize: 14);
+}
+''');
+
+      expect(findings, contains(DwCheckType.uiKitConstStyle));
+    });
+
+    test('it is a warning, not a failure — one theme is a legitimate state',
+        () {
+      expect(DwCheckType.uiKitConstStyle.severity, DwCheckSeverity.warning);
+    });
+  });
+
+  group('what the rule must not punish', () {
+    test('the theme folder may hold a seed colour', () async {
+      // Where the theme is assembled is the one place in the kit that does not
+      // read from a context. Without this exemption the rule fires on every
+      // project's palette and gets switched off.
+      final findings = await findingsFor('ui_kit/theme/app_theme.dart', '''
+class AppTheme {
+  static const Color _seed = Color.fromARGB(255, 4, 49, 57);
+}
+''');
+
+      expect(findings, isNot(contains(DwCheckType.uiKitConstStyle)));
+    });
+
+    test('a colour taken from the context is the shape being asked for',
+        () async {
+      final findings = await findingsFor('ui_kit/app_card.dart', '''
+class AppCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Container(
+        color: Theme.of(context).colorScheme.surface,
+      );
+}
+''');
+
+      expect(findings, isNot(contains(DwCheckType.uiKitConstStyle)));
+    });
+
+    test('a const that is neither a colour nor a text style is not the rule',
+        () async {
+      // Geometry does not depend on the theme and stays constant — the issue
+      // says so explicitly, and a rule that swept it up would be wrong.
+      final findings = await findingsFor('ui_kit/app_metrics.dart', '''
+class AppMetrics {
+  static const double cardRadius = 12;
+  static const EdgeInsets pagePadding = EdgeInsets.all(16);
+}
+''');
+
+      expect(findings, isNot(contains(DwCheckType.uiKitConstStyle)));
+    });
+
+    test('a mention inside a comment is prose, not a declaration', () async {
+      final findings = await findingsFor('ui_kit/app_note.dart', '''
+class AppNote {
+  // static const Color legacy = Color(0xFF000000);
+  static Color of(BuildContext context) => Theme.of(context).colorScheme.error;
+}
+''');
+
+      expect(findings, isNot(contains(DwCheckType.uiKitConstStyle)));
+    });
+  });
+}

--- a/packages/dartway_cli/test/ui_kit_const_style_test.dart
+++ b/packages/dartway_cli/test/ui_kit_const_style_test.dart
@@ -72,6 +72,18 @@ class AppTone {
       expect(findings, contains(DwCheckType.uiKitConstStyle));
     });
 
+    test('Colors.grey is a hardcoded colour like any other', () async {
+      // A word boundary after `Color` does not fire on `Colors`, so the
+      // Flutter palette went unreported while the constructor did not.
+      final findings = await findingsFor('ui_kit/app_divider.dart', '''
+class AppDivider {
+  static const line = Colors.grey;
+}
+''');
+
+      expect(findings, contains(DwCheckType.uiKitConstStyle));
+    });
+
     test('a palette held in a collection is reported too', () async {
       final findings = await findingsFor('ui_kit/app_palette.dart', '''
 class AppPalette {

--- a/toolkit/skills/dartway-ui-kit/SKILL.md
+++ b/toolkit/skills/dartway-ui-kit/SKILL.md
@@ -46,6 +46,18 @@ code, it has no `Dw` prefix: `App*` where it would otherwise collide with Flutte
    **moves into the kit whole**, and the feature composes it. Inside the kit the style is taken from a
    token (`AppTextStyle.body.resolve(context)`). Working around the rule with `// ignore:` is a style
    that escaped the kit; the next screen will never learn about it.
+
+   **And inside the kit a colour comes from the context too.** The rule above says where styling may
+   live and nothing about how a kit widget obtains a colour — so a `static const Color` looks
+   permitted, and it is the token that will not survive a second theme: a const does not depend on a
+   context, so changing `ThemeData` does not touch it. Nothing diagnoses it — the analyzer is quiet,
+   the tests are green — and it surfaces on the day somebody asks for a light theme, as a rewrite of
+   every read in the kit at once. Take colours and text styles from the palette
+   (`context.colorScheme`, a `resolve(context)` token); `dartway check` warns on a `static const
+   Color`/`TextStyle` under `lib/ui_kit/` (`uiKitConstStyle`). **`ui_kit/theme/` is exempt** — that is
+   where the theme is assembled and a seed colour has to live somewhere. Geometry stays `const`: a
+   radius does not depend on the theme. One theme in a project means a palette with one set of
+   colours, not the absence of `of(context)`.
 4. **Isolated visual layer.** The kit does not depend on business logic or state. A component =
    pure visuals + minimal props.
 5. **The kit is the app's design system, not a library of shared widgets.** A composite needed by a


### PR DESCRIPTION
Closes #75 — two of its three proposals; the first was already true here.

## What the issue asks, and what the tree says

The issue opens on a scaffold that "declares its tokens as `static const` on a private `_AppChrome`". **That scaffold is not in this repository.** `_AppChrome` appears nowhere; the template kit reads from `Theme.of(context)`, and its single `static const Color` is the ColorScheme seed in `ui_kit/theme/app_theme.dart`, which does not depend on a context by nature. The report was written from a real project's kit — "127 reads across 18 files" happened there, not here.

The other two proposals are alive, and they are the ones that stop it happening again:

> **Why the rule did not help.** The guidance is correct as far as it goes […] It says nothing about **how a kit widget obtains a colour**, and the scaffold shows `static const` with a single theme. The example beats the silence.

The skill teaches `AppTextStyle.resolve(context)` for text styles and is silent on colours. The checker has the *inverse* rule — raw styles **outside** the kit (`forbiddenUiUsage`) — and nothing about a constant inside it.

## The change

**`uiKitConstStyle`** — a `static const Color` or `TextStyle` under `lib/ui_kit/`, reported once per file with what it costs: the token will not follow a second theme, take it from `Theme.of(context)` through the palette.

A **warning**, not an error, and that is the issue's own reading: one theme is a legitimate state for a project to be in, and what it will not survive is the second one.

**`ui_kit/theme/` is exempt.** That is where the theme is assembled and a seed colour has to be written down somewhere — it is the one place in the kit that does not read from a context. Without the exemption the rule fires on every project's palette, including this repo's own template and example, and a rule that fires on correct code is a rule somebody turns off.

**The guidance gains the missing line** — `docs/3-flutter/ui-kit.md`, `toolkit/skills/dartway-ui-kit`, and the rule table in `docs/5-tooling/conventions-checker.md`. Written with the consequence attached rather than as a bare ban, since the whole complaint in the issue is that a rule without its reason loses to the example next to it.

## How it is demonstrated

`ui_kit_const_style_test.dart` runs the real inspector over a sandbox package: a const `Color` in a kit widget is reported, a const `TextStyle` likewise, and the severity is `warning`. Then the pairs — the checker's own convention that every exemption comes with the case it must still catch:

- `ui_kit/theme/app_theme.dart` with a `_seed` is **not** reported;
- a colour taken from `Theme.of(context)` is not reported;
- `static const double cardRadius` and `EdgeInsets` are not reported — geometry does not depend on the theme, which the issue names explicitly;
- a commented-out declaration is prose, not a declaration.

Verified against the real trees: `template/` and `example/` both keep their `_seed` inside `ui_kit/theme/`, so neither gains a finding. `dart analyze` clean, 221 CLI tests green.

`dartway_cli` is at `0.9.0` on `master` against `0.8.0` on `stable`, so the entry joins that section rather than moving the version.