### PR TITLE
feat(studio-bridge): tell a protocol version mismatch from a foreign message

### DIFF
--- a/docs/6-studio/studio-bridge.md
+++ b/docs/6-studio/studio-bridge.md
@@ -126,6 +126,33 @@ silence. Cross-origin they are one silence and cannot be separated from here:
 check that the URL serves a page, and that it permits `frame-ancestors`, as
 steps of their own before the probe.
 
+## When a connection is silent
+
+Every step of the bridge's filtering ends the same way — the message is dropped
+and nothing is said. That is correct for the ordinary case (a page's `window` is
+a shared bus and most of what crosses it belongs to somebody else) and useless
+for the one case that is a real fault: **an app and a Studio on different
+protocol versions.** Both are speaking the bridge, neither will hear the other
+until one is rebuilt, and it looks exactly like a stranger's message. That is
+what `silent` above hides, and what once cost a day.
+
+`StudioBridgeProtocol.envelopeVersionOf(data)` reads the envelope version out of
+raw postMessage data — null when there is no envelope, so "not ours" and "ours,
+wrong version" stop being the same answer. Decoding cannot tell them apart:
+`tryDecode` returns null for both.
+
+For the steps that happen before decoding — the origin, the sending window, the
+data's type — pass `onMessageDropped` to `createStudioFrameController`,
+`openStudioProbeFrame`, `probeStudioBridge` or, on the app side,
+`StudioBridgeHost.attach`. Each refused message arrives as a `StudioMessageDrop`
+naming the step it died at. Nothing else changes: without an observer the bridge
+is as quiet as it always was.
+
+The observer exists rather than an exposed frame handle because the Studio-side
+source check compares against the window of *its own* frame — an embedder
+watching `window` from outside can only ask "is this some frame of this page",
+which stops distinguishing anything as soon as the page carries two.
+
 See the package [README](../packages/dartway_studio_bridge/README.md) for the
 full API of the wire, `dartway_studio_binding` for the app half, and
 `example/dartway_example_flutter/lib/core/studio/` for what a project is left

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -333,14 +333,14 @@ packages:
       path: "../../packages/dartway_studio_binding"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   dartway_studio_bridge:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.9.0"
   dbus:
     dependency: transitive
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   dartway_router: ^1.1.1
 
   dartway_serverpod_core_flutter: ^0.12.0
-  dartway_studio_bridge: ^0.8.0
+  dartway_studio_bridge: ^0.9.0
 
   dartway_studio_binding: ^0.1.0
 

--- a/js/studio-bridge/CHANGELOG.md
+++ b/js/studio-bridge/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.3.0
+
+**`studioBridgeEnvelopeVersion(data)` — a protocol version mismatch stops
+looking like a stranger's message.** `decodeStudioBridgeMessage` returns null
+for both, and they are opposite diagnoses: foreign traffic on `window` is
+normal and ignored, while our own envelope at another version means neither
+side will hear the other until one is rebuilt. One such handshake — an app on
+v3, a Studio on v4 — cost a day, with nothing anywhere to say which it was.
+
+The reader takes the raw string or an already-parsed object, and `decode` now
+reads the envelope through it, so the check and the diagnostic cannot disagree
+about what an envelope is. The twin of `StudioBridgeProtocol.envelopeVersionOf`
+in the Dart package, kept honest by the same golden wire strings.
+
+**The protocol version stays 4.** Nothing on the wire changed.
+
 ## 0.2.0
 
 **A refused handshake now gets an answer instead of silence.** The app sends

--- a/js/studio-bridge/README.md
+++ b/js/studio-bridge/README.md
@@ -179,6 +179,33 @@ sit at "not connected" with nothing anywhere pointing at the reason, since a
 refusal is silence by design. The local-dev mode above is unaffected: it
 verifies nothing and needs neither.
 
+## When the preview stays empty
+
+The host ignores anything on `window` that is not a bridge message, silently —
+most of what crosses a page's `window` belongs to somebody else. One case hides
+in that silence and is a real fault: **this package and the Studio you are
+connecting to speak different protocol versions.** Both are talking, neither
+hears the other, and it looks exactly like a stranger's message.
+
+`studioBridgeEnvelopeVersion(data)` separates them:
+
+```ts
+import { studioBridgeEnvelopeVersion, studioBridgeProtocol } from '@dartway/studio-bridge';
+
+window.addEventListener('message', (event) => {
+  const version = studioBridgeEnvelopeVersion(event.data);
+  if (version === null) return;                      // not ours — ignore
+  if (version !== studioBridgeProtocol.version) {
+    console.warn(`Studio speaks v${version}, this build speaks v${studioBridgeProtocol.version}`);
+  }
+});
+```
+
+`decodeStudioBridgeMessage` cannot tell you this — it returns null for a foreign
+message and for our own envelope at the wrong version alike. Upgrading this
+package is what closes a mismatch; the version is checked strictly on decode, in
+both directions.
+
 ## Licence
 
 Apache-2.0, as the rest of the [DartWay](https://github.com/dartway/dartway)

--- a/js/studio-bridge/package.json
+++ b/js/studio-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dartway/studio-bridge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "App side of the DartWay Studio bridge for JavaScript apps: declare your screens and features, let Studio preview and drive the running build.",
   "license": "Apache-2.0",
   "type": "module",

--- a/js/studio-bridge/src/index.ts
+++ b/js/studio-bridge/src/index.ts
@@ -23,6 +23,7 @@ export { studioBridgeProtocol } from './protocol/protocol.ts';
 export {
   decodeStudioBridgeMessage,
   encodeStudioBridgeMessage,
+  studioBridgeEnvelopeVersion,
   type AppReadyMessage,
   type ConnectRefusedMessage,
   type FeaturesChangedMessage,

--- a/js/studio-bridge/src/protocol/messages.ts
+++ b/js/studio-bridge/src/protocol/messages.ts
@@ -236,6 +236,34 @@ export function encodeStudioBridgeMessage(message: StudioBridgeMessage): string 
  * (dev tooling, browser extensions, other frames) and must be ignored
  * silently.
  */
+/**
+ * The envelope version inside raw postMessage `data`, or null when there is no
+ * envelope — the data is not ours at all.
+ *
+ * This is the one thing decoding cannot tell you. A message that fails to
+ * decode fails the same way whether it belongs to somebody else or is our own
+ * envelope at another version, and the two are opposite diagnoses: ignore the
+ * first, repair the second. An app on v3 and a Studio on v4 were simply quiet
+ * at each other for a day because nothing said which.
+ *
+ * Accepts either the raw string off the wire or an already-parsed object, so a
+ * caller that has parsed the JSON does not parse it twice. The twin of
+ * `StudioBridgeProtocol.envelopeVersionOf` in the Dart package.
+ */
+export function studioBridgeEnvelopeVersion(data: unknown): number | null {
+  let decoded: unknown = data;
+  if (typeof data === 'string') {
+    try {
+      decoded = JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+  if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) return null;
+  const version = (decoded as Record<string, unknown>)[studioBridgeProtocol.envelopeKey];
+  return typeof version === 'number' ? version : null;
+}
+
 export function decodeStudioBridgeMessage(data: unknown): StudioBridgeMessage | null {
   if (typeof data !== 'string') return null;
   let decoded: unknown;
@@ -247,7 +275,10 @@ export function decodeStudioBridgeMessage(data: unknown): StudioBridgeMessage | 
   if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) return null;
 
   const envelope = decoded as Record<string, unknown>;
-  if (envelope[studioBridgeProtocol.envelopeKey] !== studioBridgeProtocol.version) return null;
+  // Read through `studioBridgeEnvelopeVersion` rather than the key directly:
+  // the version check and the diagnostic that explains a drop have to agree
+  // about what an envelope is, and two readings of it would not.
+  if (studioBridgeEnvelopeVersion(envelope) !== studioBridgeProtocol.version) return null;
 
   const payload = asJson(envelope[studioBridgeProtocol.payloadKey]);
   const string = (value: unknown, fallback = ''): string =>

--- a/js/studio-bridge/test/protocol.test.ts
+++ b/js/studio-bridge/test/protocol.test.ts
@@ -4,6 +4,7 @@ import { describe, test } from 'node:test';
 import {
   decodeStudioBridgeMessage,
   encodeStudioBridgeMessage,
+  studioBridgeEnvelopeVersion,
   studioBridgeProtocol,
   type StudioBridgeMessage,
 } from '../src/index.ts';
@@ -307,4 +308,38 @@ test('every message type survives a round trip', () => {
       `round trip failed for ${message.type}`,
     );
   }
+});
+
+describe('a version mismatch is not a foreign message', () => {
+  test('reads the version out of one of our envelopes', () => {
+    assert.equal(
+      studioBridgeEnvelopeVersion(encodeStudioBridgeMessage({ type: 'appReady' })),
+      studioBridgeProtocol.version,
+    );
+  });
+
+  test('reads a version this build does not speak — the whole point', () => {
+    // `decodeStudioBridgeMessage` answers null here and to the foreign message
+    // below alike; only this tells the two apart, and they are opposite
+    // diagnoses: rebuild one side, or ignore the traffic.
+    const wrongVersion = '{"dartwayStudioBridge":3,"type":"appReady","payload":{}}';
+    assert.equal(decodeStudioBridgeMessage(wrongVersion), null);
+    assert.equal(studioBridgeEnvelopeVersion(wrongVersion), 3);
+  });
+
+  test('null for somebody else message on the same window', () => {
+    assert.equal(studioBridgeEnvelopeVersion('{"source":"react-devtools"}'), null);
+    assert.equal(studioBridgeEnvelopeVersion('not json at all'), null);
+    assert.equal(studioBridgeEnvelopeVersion('[1,2,3]'), null);
+    assert.equal(studioBridgeEnvelopeVersion(null), null);
+    assert.equal(studioBridgeEnvelopeVersion(42), null);
+  });
+
+  test('null when the marker is there but is not a version', () => {
+    assert.equal(studioBridgeEnvelopeVersion('{"dartwayStudioBridge":"4"}'), null);
+  });
+
+  test('takes an already-parsed object, so nobody parses twice', () => {
+    assert.equal(studioBridgeEnvelopeVersion({ dartwayStudioBridge: 4 }), 4);
+  });
 });

--- a/packages/dartway_studio_binding/CHANGELOG.md
+++ b/packages/dartway_studio_binding/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1
+
+- Follows `dartway_studio_bridge` to `^0.9.0`. Nothing here changed: the binding
+  attaches the host exactly as before. An app that wants the bridge's new
+  connection diagnostics (`onMessageDropped`) reaches for
+  `StudioBridgeHost.attach` directly for now.
+
 ## 0.1.0
 
 - First release. `DwStudioBinding` is the app half of the Studio wiring: one widget in

--- a/packages/dartway_studio_binding/pubspec.yaml
+++ b/packages/dartway_studio_binding/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_studio_binding
 description: "The app half of the DartWay Studio wiring: one widget that attaches the bridge, reports route, features, session and language, and executes what Studio asks."
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -28,7 +28,7 @@ dependencies:
   dartway_serverpod_core_flutter: ^0.12.0
   # The wire. Both this package and Studio depend on it; its version means the
   # protocol, which is why host-side changes do not belong there.
-  dartway_studio_bridge: ^0.8.0
+  dartway_studio_bridge: ^0.9.0
   flutter_riverpod: ^3.0.0
 
 dev_dependencies:

--- a/packages/dartway_studio_bridge/CHANGELOG.md
+++ b/packages/dartway_studio_bridge/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.9.0
+
+**Silence now has a reason attached, on both sides of the wire.** A channel that
+drops a window message has five or six ways to arrive at the same nothing, and
+the most expensive one — our own envelope at another protocol version — looked
+exactly like a stranger's message on `window`. An app on v3 and a Studio on v4
+say nothing to each other; one such handshake cost a day of debugging, and
+neither end could say why.
+
+**`StudioBridgeProtocol.envelopeVersionOf(data)` reads the envelope version out
+of raw postMessage data**, or answers null when there is no envelope. It is the
+one thing decoding cannot tell you: `tryDecode` returns null for a foreign
+message and for our own envelope at the wrong version alike, and those are
+opposite diagnoses — ignore the first, rebuild for the second. It takes the raw
+string or an already-decoded map, so a caller that has parsed the JSON does not
+parse it twice, and `tryDecode` now reads the envelope through it: the check
+and the diagnostic that explains a drop cannot disagree about what an envelope
+is. The same reader exists in `@dartway/studio-bridge` as
+`studioBridgeEnvelopeVersion`.
+
+**The channels can be asked what they refused.** `createStudioFrameController`,
+`openStudioProbeFrame`, `probeStudioBridge` and `StudioBridgeHost.attach` take
+an optional `onMessageDropped`, called with a `StudioMessageDrop` for every
+window message that did not make it: the reason, the sender's origin, and the
+envelope version where there was one. Nothing changes without one — the bridge
+is exactly as quiet as before, and an observer that throws is reported through
+`FlutterError.reportError` rather than taking the channel down.
+
+`StudioMessageDropReason` names each step: `notAMessageEvent`, `foreignOrigin`,
+`foreignSource`, `nonStringData`, `notAnEnvelope`, `versionMismatch`,
+`unknownType`. The last three are what the payload turned out to be, and they
+are split for the same reason the version reader exists — `unknownType` means
+the other side is *newer* (a type added inside a version is how the protocol
+grows without cutting off the field), which is not a fault and must not send
+anyone rebuilding. `StudioMessageDropReason.ofPayload(data)` classifies a raw
+string on its own, for an embedder watching `window` from outside.
+
+**Why an observer rather than exposing the frame.** An embedder cannot
+reproduce the Studio-side filtering from outside: the channel compares the
+sender against the window of *its own* frame, so an outside observer can only
+ask "is this some frame of this page", which stops distinguishing anything the
+moment the page carries two — a live preview and a probe, say. The reason now
+lives where the decision is made and cannot drift from it.
+
+Closes #98 and #95.
+
 ## 0.8.1
 
 **A parameterized screen is recognised again.** `StudioManifestIndex.specForPath`

--- a/packages/dartway_studio_bridge/README.md
+++ b/packages/dartway_studio_bridge/README.md
@@ -244,3 +244,60 @@ separate steps before this one.
 
 `runStudioHandshake(channel)` is the same state machine over a channel you
 already own — what the probe is with the frame taken out of it.
+
+## Why nothing arrived (both sides)
+
+A bridge channel drops what is not for it, and says nothing about it — foreign
+traffic on `window` is normal traffic, and logging it would be noise. The cost
+is that a rejection then looks like every other reason a message never came,
+including the one that is a genuine fault: **our own envelope at another
+protocol version.** An app on v3 and a Studio on v4 are simply quiet at each
+other, and that quiet once cost a day.
+
+Two things separate those cases, and neither changes what the bridge does by
+default.
+
+**Read the version off any raw postMessage data:**
+
+```dart
+final version = StudioBridgeProtocol.envelopeVersionOf(data);
+// null            — not our envelope at all; somebody else's message
+// == StudioBridgeProtocol.version — ours, and current
+// anything else   — ours, and one of us needs rebuilding
+```
+
+`tryDecode` cannot tell you this: it answers null to a foreign message and to
+our own envelope at the wrong version alike. Takes the raw string or a map you
+have already decoded. The same reader exists in `@dartway/studio-bridge` as
+`studioBridgeEnvelopeVersion`.
+
+**Or watch what a channel refuses**, which is the same answer plus the steps
+that happen before decoding:
+
+```dart
+final controller = createStudioFrameController(
+  appUrl: appUrl,
+  onMessageDropped: (drop) => diagnostics.add('$drop'),
+);
+// StudioMessageDrop(versionMismatch, origin: https://app.example, envelope: v3)
+```
+
+`onMessageDropped` is taken by `createStudioFrameController`,
+`openStudioProbeFrame` and `probeStudioBridge` on the Studio side, and by
+`StudioBridgeHost.attach` on the app side — an app that hears nothing from
+Studio has the same problem from the other end. The reason names the step:
+`notAMessageEvent`, `foreignOrigin`, `foreignSource`, `nonStringData`,
+`notAnEnvelope`, `versionMismatch`, `unknownType`. The last one means the other
+side is *newer* — a type added inside a version, which is how the protocol grows
+without cutting off builds in the field — so it is not a fault and nobody should
+go rebuilding over it.
+
+Installing an observer changes nothing else: the channel filters exactly as
+before, and an observer that throws is reported through
+`FlutterError.reportError` instead of taking the channel down with it.
+
+An embedder cannot write this from outside. The Studio-side channel compares the
+sender against the window of **its own** frame; an observer on `window` can only
+ask "is this some frame of this page", which stops distinguishing anything the
+moment the page carries two — a live preview and a probe, say. What an outside
+observer *can* reuse is the payload half, `StudioMessageDropReason.ofPayload`.

--- a/packages/dartway_studio_bridge/lib/dartway_studio_bridge.dart
+++ b/packages/dartway_studio_bridge/lib/dartway_studio_bridge.dart
@@ -27,3 +27,4 @@ export 'src/client/studio_handshake_probe.dart';
 export 'src/transport/client/studio_frame_controller.dart';
 export 'src/transport/client/studio_probe_frame.dart';
 export 'src/transport/studio_message_channel.dart';
+export 'src/transport/studio_message_drop.dart';

--- a/packages/dartway_studio_bridge/lib/src/client/studio_handshake_probe.dart
+++ b/packages/dartway_studio_bridge/lib/src/client/studio_handshake_probe.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import '../protocol/studio_bridge_message.dart';
 import '../transport/client/studio_probe_frame.dart';
 import '../transport/studio_message_channel.dart';
+import '../transport/studio_message_drop.dart';
 import 'studio_bridge_client.dart';
 
 /// What came back from one handshake — the three answers a preview cannot tell
@@ -51,6 +52,12 @@ enum StudioHandshakeResult {
 /// be repeated at a frame that is still loading — and nothing retries: an
 /// answer that has not arrived within [timeout] is [StudioHandshakeResult.silent].
 ///
+/// [StudioHandshakeResult.silent] stays as coarse as it is documented to be,
+/// but it is no longer the only thing this call can tell you: pass
+/// [onMessageDropped] and the frame's channel reports what it refused on the
+/// way — an app answering at another protocol version arrives there, as
+/// [StudioMessageDropReason.versionMismatch], rather than as more silence.
+///
 /// Throws whatever [accessToken] throws. A supplier that cannot produce a token
 /// leaves the question unasked, and reporting that as silence would blame the
 /// app for something on this side.
@@ -61,8 +68,12 @@ Future<StudioHandshakeResult> probeStudioBridge({
   required String appUrl,
   StudioAccessTokenSupplier? accessToken,
   Duration timeout = const Duration(seconds: 10),
+  StudioMessageDropObserver? onMessageDropped,
 }) async {
-  final frame = openStudioProbeFrame(appUrl: appUrl);
+  final frame = openStudioProbeFrame(
+    appUrl: appUrl,
+    onMessageDropped: onMessageDropped,
+  );
   try {
     return await runStudioHandshake(
       frame.channel,

--- a/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
+++ b/packages/dartway_studio_bridge/lib/src/host/studio_bridge_host.dart
@@ -9,6 +9,7 @@ import '../models/studio_session_state.dart';
 import '../protocol/studio_bridge_message.dart';
 import '../transport/host/studio_host_channel.dart';
 import '../transport/studio_message_channel.dart';
+import '../transport/studio_message_drop.dart';
 
 /// What the app does when Studio asks — navigation and session actions run
 /// inside the app through its regular flows (Studio never learns router
@@ -89,8 +90,17 @@ class StudioBridgeHost {
     // only thing an app ever wants; pass one to drive the host from a test, or
     // to embed the app somewhere that is not an iframe.
     StudioMessageChannel? channel,
+    // Told about every window message the default channel refused — a
+    // diagnostic for "Studio says it connected and this app heard nothing",
+    // which until now looked identical to a stranger's message on `window`.
+    // Installing one changes no behaviour: the app is as quiet as before.
+    //
+    // Ignored when [channel] is given, because then this host owns no channel
+    // to observe — a caller supplying its own pipe already sees everything that
+    // arrives on it.
+    StudioMessageDropObserver? onMessageDropped,
   }) {
-    channel ??= createStudioHostChannel();
+    channel ??= createStudioHostChannel(onMessageDropped: onMessageDropped);
     if (channel == null) return null;
     return StudioBridgeHost._(
       channel,

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_message.dart
@@ -34,7 +34,10 @@ sealed class StudioBridgeMessage {
       return null;
     }
     if (decoded is! Map<String, dynamic>) return null;
-    if (decoded[StudioBridgeProtocol.envelopeKey] !=
+    // Read through [StudioBridgeProtocol.envelopeVersionOf] rather than the key
+    // directly: the version check and the diagnostic that explains a drop have
+    // to agree about what an envelope is, and two readings of it would not.
+    if (StudioBridgeProtocol.envelopeVersionOf(decoded) !=
         StudioBridgeProtocol.version) {
       return null;
     }

--- a/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_protocol.dart
+++ b/packages/dartway_studio_bridge/lib/src/protocol/studio_bridge_protocol.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// Wire-level constants of the Studio bridge protocol.
 ///
 /// Every message is a JSON object encoded as a string:
@@ -49,4 +51,29 @@ abstract final class StudioBridgeProtocol {
   static const signOutRequest = 'signOutRequest';
   static const localeRequest = 'localeRequest';
   static const inspectPointRequest = 'inspectPointRequest';
+
+  /// The envelope version inside raw postMessage [data], or null when there is
+  /// no envelope — the data is not ours at all.
+  ///
+  /// This is the one thing decoding cannot tell you. A message that fails to
+  /// decode fails the same way whether it belongs to somebody else or is our
+  /// own envelope at another [version], and the two are opposite diagnoses:
+  /// ignore the first, repair the second. An app on v3 and a Studio on v4 were
+  /// simply quiet at each other for a day because nothing here said which.
+  ///
+  /// Accepts either the raw string off the wire or an already-decoded map, so a
+  /// caller that has parsed the JSON does not parse it twice.
+  static int? envelopeVersionOf(Object? data) {
+    Object? decoded = data;
+    if (data is String) {
+      try {
+        decoded = jsonDecode(data);
+      } on FormatException {
+        return null;
+      }
+    }
+    if (decoded is! Map) return null;
+    final version = decoded[envelopeKey];
+    return version is int ? version : null;
+  }
 }

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_client_web_channel.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_client_web_channel.dart
@@ -4,7 +4,10 @@ import 'dart:js_interop';
 import 'package:web/web.dart' as web;
 
 import '../../protocol/studio_bridge_message.dart';
+import '../../protocol/studio_bridge_protocol.dart';
 import '../studio_message_channel.dart';
+import '../studio_message_drop.dart';
+import '../studio_message_drop_report.dart';
 
 /// The Studio-side channel to an app in an iframe: `window` message events,
 /// filtered down to bridge messages that really came from that frame.
@@ -14,14 +17,26 @@ import '../studio_message_channel.dart';
 /// written once. Two copies of it would be two chances to forget the source
 /// check, and the one that forgot would accept messages from any page that
 /// happens to sit on the app's origin.
+///
+/// Every one of those filtering steps is a message that silently never arrives.
+/// [onMessageDropped] is how an embedder sees them; the channel behaves exactly
+/// the same whether one is installed or not.
 class StudioClientWebChannel implements StudioMessageChannel {
-  StudioClientWebChannel(this._frame, this._appOrigin) {
+  StudioClientWebChannel(
+    this._frame,
+    this._appOrigin, {
+    this.onMessageDropped,
+  }) {
     _jsListener = _onMessageEvent.toJS;
     web.window.addEventListener('message', _jsListener);
   }
 
   final web.HTMLIFrameElement _frame;
   final String _appOrigin;
+
+  /// Told about each window message this channel refused. Diagnostics only.
+  final StudioMessageDropObserver? onMessageDropped;
+
   final _controller = StreamController<StudioBridgeMessage>.broadcast();
   late final JSFunction _jsListener;
 
@@ -29,22 +44,61 @@ class StudioClientWebChannel implements StudioMessageChannel {
   Stream<StudioBridgeMessage> get messages => _controller.stream;
 
   void _onMessageEvent(web.Event event) {
-    if (!event.isA<web.MessageEvent>()) return;
+    if (!event.isA<web.MessageEvent>()) {
+      _dropped(StudioMessageDropReason.notAMessageEvent);
+      return;
+    }
     event as web.MessageEvent;
-    if (event.origin != _appOrigin) return;
+    if (event.origin != _appOrigin) {
+      _dropped(StudioMessageDropReason.foreignOrigin, origin: event.origin);
+      return;
+    }
     final appWindow = _frame.contentWindow;
     if (appWindow == null ||
         event.source == null ||
         !(event.source as JSObject)
             .strictEquals(appWindow as JSObject)
             .toDart) {
+      _dropped(StudioMessageDropReason.foreignSource, origin: event.origin);
       return;
     }
     final data = event.data;
-    if (data == null || !data.isA<JSString>()) return;
-    final message = StudioBridgeMessage.tryDecode((data as JSString).toDart);
-    if (message == null) return;
-    _controller.add(message);
+    if (data == null || !data.isA<JSString>()) {
+      _dropped(StudioMessageDropReason.nonStringData, origin: event.origin);
+      return;
+    }
+    final payload = (data as JSString).toDart;
+    final message = StudioBridgeMessage.tryDecode(payload);
+    if (message != null) {
+      _controller.add(message);
+      return;
+    }
+    if (onMessageDropped == null) return;
+    // The payload is parsed again only here, to explain a drop — never on the
+    // delivered path, and never at all when nobody is watching. `ofPayload`
+    // returns null only for a payload that decodes, and this one did not.
+    _dropped(
+      StudioMessageDropReason.ofPayload(payload) ??
+          StudioMessageDropReason.unknownType,
+      origin: event.origin,
+      envelopeVersion: StudioBridgeProtocol.envelopeVersionOf(payload),
+    );
+  }
+
+  void _dropped(
+    StudioMessageDropReason reason, {
+    String? origin,
+    int? envelopeVersion,
+  }) {
+    if (onMessageDropped == null) return;
+    reportStudioMessageDrop(
+      onMessageDropped,
+      StudioMessageDrop(
+        reason,
+        origin: origin,
+        envelopeVersion: envelopeVersion,
+      ),
+    );
   }
 
   @override

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller.dart
@@ -8,7 +8,11 @@ export 'studio_frame_controller_stub.dart'
 /// exposes the message channel to the app inside.
 ///
 /// Create instances via `createStudioFrameController` from the compile-time
-/// implementation; the non-web stub throws (Studio runs on web only).
+/// implementation; the non-web stub throws (Studio runs on web only). It takes
+/// an optional `onMessageDropped` — a diagnostic observer of the window
+/// messages the channel refuses, and the only way to see them: the source check
+/// compares against *this* frame's window, which nothing outside the channel
+/// can reproduce once the page carries more than one frame.
 abstract interface class StudioFrameController {
   /// Platform view type to pass to `HtmlElementView`.
   String get viewType;

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_stub.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_stub.dart
@@ -1,7 +1,10 @@
+import '../studio_message_drop.dart';
 import 'studio_frame_controller.dart';
 
 /// The Studio client renders the app in an iframe — web only.
-StudioFrameController createStudioFrameController({required String appUrl}) =>
-    throw UnsupportedError(
-      'StudioFrameController is only available in web builds',
-    );
+StudioFrameController createStudioFrameController({
+  required String appUrl,
+  StudioMessageDropObserver? onMessageDropped,
+}) => throw UnsupportedError(
+  'StudioFrameController is only available in web builds',
+);

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_web.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_frame_controller_web.dart
@@ -3,17 +3,22 @@ import 'dart:ui_web' as ui_web;
 import 'package:web/web.dart' as web;
 
 import '../studio_message_channel.dart';
+import '../studio_message_drop.dart';
 import 'studio_client_web_channel.dart';
 import 'studio_frame_controller.dart';
 
 int _instanceCounter = 0;
 
-StudioFrameController createStudioFrameController({required String appUrl}) =>
-    _StudioFrameControllerWeb(appUrl);
+StudioFrameController createStudioFrameController({
+  required String appUrl,
+  StudioMessageDropObserver? onMessageDropped,
+}) => _StudioFrameControllerWeb(appUrl, onMessageDropped);
 
 class _StudioFrameControllerWeb implements StudioFrameController {
-  _StudioFrameControllerWeb(String appUrl)
-    : viewType = 'dartway-studio-frame-${_instanceCounter++}' {
+  _StudioFrameControllerWeb(
+    String appUrl,
+    StudioMessageDropObserver? onMessageDropped,
+  ) : viewType = 'dartway-studio-frame-${_instanceCounter++}' {
     _frame = web.document.createElement('iframe') as web.HTMLIFrameElement
       ..src = appUrl;
     _frame.style
@@ -24,7 +29,11 @@ class _StudioFrameControllerWeb implements StudioFrameController {
       viewType,
       (int viewId) => _frame,
     );
-    _channel = StudioClientWebChannel(_frame, Uri.parse(appUrl).origin);
+    _channel = StudioClientWebChannel(
+      _frame,
+      Uri.parse(appUrl).origin,
+      onMessageDropped: onMessageDropped,
+    );
   }
 
   late final web.HTMLIFrameElement _frame;

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame.dart
@@ -15,7 +15,10 @@ export 'studio_probe_frame_stub.dart'
 /// corner of the screen for the lifetime of the app.
 ///
 /// Create instances via `openStudioProbeFrame` from the compile-time
-/// implementation; the non-web stub throws, as Studio runs on web only.
+/// implementation; the non-web stub throws, as Studio runs on web only. It
+/// takes the same optional `onMessageDropped` as the preview's controller:
+/// a probe that comes back silent is exactly when the refused messages are
+/// worth seeing.
 abstract interface class StudioProbeFrame {
   /// Channel to the app inside the frame (origin-locked to the app URL).
   StudioMessageChannel get channel;

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_stub.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_stub.dart
@@ -1,5 +1,9 @@
+import '../studio_message_drop.dart';
 import 'studio_probe_frame.dart';
 
 /// The Studio client loads an app in an iframe — web only.
-StudioProbeFrame openStudioProbeFrame({required String appUrl}) =>
+StudioProbeFrame openStudioProbeFrame({
+  required String appUrl,
+  StudioMessageDropObserver? onMessageDropped,
+}) =>
     throw UnsupportedError('StudioProbeFrame is only available in web builds');

--- a/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_web.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/client/studio_probe_frame_web.dart
@@ -1,14 +1,20 @@
 import 'package:web/web.dart' as web;
 
 import '../studio_message_channel.dart';
+import '../studio_message_drop.dart';
 import 'studio_client_web_channel.dart';
 import 'studio_probe_frame.dart';
 
-StudioProbeFrame openStudioProbeFrame({required String appUrl}) =>
-    _StudioProbeFrameWeb(appUrl);
+StudioProbeFrame openStudioProbeFrame({
+  required String appUrl,
+  StudioMessageDropObserver? onMessageDropped,
+}) => _StudioProbeFrameWeb(appUrl, onMessageDropped);
 
 class _StudioProbeFrameWeb implements StudioProbeFrame {
-  _StudioProbeFrameWeb(String appUrl) {
+  _StudioProbeFrameWeb(
+    String appUrl,
+    StudioMessageDropObserver? onMessageDropped,
+  ) {
     _frame = web.document.createElement('iframe') as web.HTMLIFrameElement
       ..src = appUrl;
     _frame.style
@@ -42,7 +48,11 @@ class _StudioProbeFrameWeb implements StudioProbeFrame {
       _container,
     );
 
-    _channel = StudioClientWebChannel(_frame, Uri.parse(appUrl).origin);
+    _channel = StudioClientWebChannel(
+      _frame,
+      Uri.parse(appUrl).origin,
+      onMessageDropped: onMessageDropped,
+    );
   }
 
   late final web.HTMLIFrameElement _frame;

--- a/packages/dartway_studio_bridge/lib/src/transport/host/studio_host_channel.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/host/studio_host_channel.dart
@@ -3,7 +3,10 @@
 /// reports "not embedded" on every other platform.
 ///
 /// Provides `isEmbeddedInStudioFrame` (web and inside an iframe) and
-/// `createStudioHostChannel` (null when not embedded).
+/// `createStudioHostChannel` (null when not embedded). The latter takes an
+/// optional `onMessageDropped`: an app that hears nothing from Studio has the
+/// same problem the Studio side has, from the other end — a version mismatch
+/// and a stranger's message on `window` are both simply silence otherwise.
 ///
 /// Origin note: the channel accepts the first valid bridge message from the
 /// embedding window and pins that origin for its replies. There is no origin

--- a/packages/dartway_studio_bridge/lib/src/transport/host/studio_host_channel_stub.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/host/studio_host_channel_stub.dart
@@ -1,7 +1,11 @@
 import '../studio_message_channel.dart';
+import '../studio_message_drop.dart';
 
 /// Non-web platforms are never embedded in a Studio frame.
 bool get isEmbeddedInStudioFrame => false;
 
-/// No transport exists outside the web; the bridge host stays dormant.
-StudioMessageChannel? createStudioHostChannel() => null;
+/// No transport exists outside the web; the bridge host stays dormant, so
+/// there is nothing to drop and [onMessageDropped] is never called.
+StudioMessageChannel? createStudioHostChannel({
+  StudioMessageDropObserver? onMessageDropped,
+}) => null;

--- a/packages/dartway_studio_bridge/lib/src/transport/host/studio_host_channel_web.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/host/studio_host_channel_web.dart
@@ -4,7 +4,10 @@ import 'dart:js_interop';
 import 'package:web/web.dart' as web;
 
 import '../../protocol/studio_bridge_message.dart';
+import '../../protocol/studio_bridge_protocol.dart';
 import '../studio_message_channel.dart';
+import '../studio_message_drop.dart';
+import '../studio_message_drop_report.dart';
 
 /// True when this page runs inside an iframe (a potential Studio frame).
 bool get isEmbeddedInStudioFrame {
@@ -13,18 +16,23 @@ bool get isEmbeddedInStudioFrame {
   return !(web.window as JSObject).strictEquals(parent as JSObject).toDart;
 }
 
-/// See the origin note on the conditional-export file.
-StudioMessageChannel? createStudioHostChannel() {
+/// See the origin note on the conditional-export file. [onMessageDropped] is
+/// told about every window message this channel refused; the channel behaves
+/// exactly the same whether one is installed or not.
+StudioMessageChannel? createStudioHostChannel({
+  StudioMessageDropObserver? onMessageDropped,
+}) {
   if (!isEmbeddedInStudioFrame) return null;
-  return _StudioHostWebChannel();
+  return _StudioHostWebChannel(onMessageDropped);
 }
 
 class _StudioHostWebChannel implements StudioMessageChannel {
-  _StudioHostWebChannel() {
+  _StudioHostWebChannel(this._onMessageDropped) {
     _jsListener = _onMessageEvent.toJS;
     web.window.addEventListener('message', _jsListener);
   }
 
+  final StudioMessageDropObserver? _onMessageDropped;
   final _controller = StreamController<StudioBridgeMessage>.broadcast();
   late final JSFunction _jsListener;
 
@@ -36,14 +44,47 @@ class _StudioHostWebChannel implements StudioMessageChannel {
   Stream<StudioBridgeMessage> get messages => _controller.stream;
 
   void _onMessageEvent(web.Event event) {
-    if (!event.isA<web.MessageEvent>()) return;
+    if (!event.isA<web.MessageEvent>()) {
+      _dropped(StudioMessageDropReason.notAMessageEvent);
+      return;
+    }
     event as web.MessageEvent;
     final data = event.data;
-    if (data == null || !data.isA<JSString>()) return;
-    final message = StudioBridgeMessage.tryDecode((data as JSString).toDart);
-    if (message == null) return;
-    _peerOrigin = event.origin;
-    _controller.add(message);
+    if (data == null || !data.isA<JSString>()) {
+      _dropped(StudioMessageDropReason.nonStringData, origin: event.origin);
+      return;
+    }
+    final payload = (data as JSString).toDart;
+    final message = StudioBridgeMessage.tryDecode(payload);
+    if (message != null) {
+      _peerOrigin = event.origin;
+      _controller.add(message);
+      return;
+    }
+    if (_onMessageDropped == null) return;
+    // Parsed again only to explain a drop — see the Studio-side channel.
+    _dropped(
+      StudioMessageDropReason.ofPayload(payload) ??
+          StudioMessageDropReason.unknownType,
+      origin: event.origin,
+      envelopeVersion: StudioBridgeProtocol.envelopeVersionOf(payload),
+    );
+  }
+
+  void _dropped(
+    StudioMessageDropReason reason, {
+    String? origin,
+    int? envelopeVersion,
+  }) {
+    if (_onMessageDropped == null) return;
+    reportStudioMessageDrop(
+      _onMessageDropped,
+      StudioMessageDrop(
+        reason,
+        origin: origin,
+        envelopeVersion: envelopeVersion,
+      ),
+    );
   }
 
   @override

--- a/packages/dartway_studio_bridge/lib/src/transport/studio_message_drop.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/studio_message_drop.dart
@@ -1,0 +1,94 @@
+import '../protocol/studio_bridge_message.dart';
+import '../protocol/studio_bridge_protocol.dart';
+
+/// What a channel did with a window message it did not deliver, and at which
+/// step it let it go.
+///
+/// Ignoring foreign traffic on `window` silently is correct — it is normal
+/// traffic on a shared bus. The cost is that a rejection then looks exactly
+/// like every other reason a message never arrived, so an embedder debugging a
+/// connection is left guessing. These name the step instead.
+enum StudioMessageDropReason {
+  /// Not a `MessageEvent` at all. Effectively unreachable on a `message`
+  /// listener; kept so the enum covers every early return the channel has.
+  notAMessageEvent,
+
+  /// The sender's origin is not the app's. Studio-side only: the app-side
+  /// channel pins no origin (see the origin note on `studio_host_channel.dart`).
+  foreignOrigin,
+
+  /// The origin matched, but the sender is not the window of *this* channel's
+  /// frame. Studio-side only, and the reason an embedder cannot reproduce the
+  /// channel's filtering from outside: a page with two frames on one origin —
+  /// a live preview and a probe, say — cannot tell them apart without this.
+  foreignSource,
+
+  /// The event carried something other than a string. Every bridge message is
+  /// JSON encoded as a string.
+  nonStringData,
+
+  /// A string, but no bridge envelope in it: unparseable, or JSON that does not
+  /// carry [StudioBridgeProtocol.envelopeKey]. Somebody else's message —
+  /// nothing to repair.
+  notAnEnvelope,
+
+  /// Our envelope at another protocol version. The one case that looks like
+  /// silence and is not: both sides are speaking the bridge protocol and
+  /// neither will hear the other until one of them is rebuilt.
+  versionMismatch,
+
+  /// Our envelope, our version, a message type this build does not know.
+  /// Expected and harmless in one direction — a type added inside a version is
+  /// how the protocol grows without cutting off the field (see
+  /// [StudioBridgeProtocol.version]) — so read it as "the other side is newer",
+  /// not as a fault.
+  unknownType;
+
+  /// Why the string [data] off the wire would not become a message, or null
+  /// when it decodes cleanly.
+  ///
+  /// The steps before this one — is it a message event, whose origin, whose
+  /// window, is the data a string — belong to the transport that observed the
+  /// event. This is the part an embedder watching `window` from outside cannot
+  /// write without re-implementing the envelope, which is precisely the copy
+  /// that drifts on the next protocol change.
+  static StudioMessageDropReason? ofPayload(String data) {
+    final version = StudioBridgeProtocol.envelopeVersionOf(data);
+    if (version == null) return notAnEnvelope;
+    if (version != StudioBridgeProtocol.version) return versionMismatch;
+    return StudioBridgeMessage.tryDecode(data) == null ? unknownType : null;
+  }
+}
+
+/// One window message a channel did not deliver.
+class StudioMessageDrop {
+  const StudioMessageDrop(this.reason, {this.origin, this.envelopeVersion});
+
+  final StudioMessageDropReason reason;
+
+  /// The sender's origin, when the event carried one.
+  final String? origin;
+
+  /// The version read out of the envelope — present for
+  /// [StudioMessageDropReason.versionMismatch] and
+  /// [StudioMessageDropReason.unknownType], null when there was no envelope to
+  /// read it from.
+  final int? envelopeVersion;
+
+  @override
+  String toString() {
+    final details = [
+      if (origin != null) 'origin: $origin',
+      if (envelopeVersion != null) 'envelope: v$envelopeVersion',
+    ];
+    return 'StudioMessageDrop(${reason.name}'
+        '${details.isEmpty ? '' : ', ${details.join(', ')}'})';
+  }
+}
+
+/// Told about every window message a channel refused, and nothing else — the
+/// delivered ones are the channel's `messages` stream.
+///
+/// The bridge still says nothing by default: an observer is installed by
+/// whoever is debugging a connection, and installing one changes no behaviour.
+typedef StudioMessageDropObserver = void Function(StudioMessageDrop drop);

--- a/packages/dartway_studio_bridge/lib/src/transport/studio_message_drop_report.dart
+++ b/packages/dartway_studio_bridge/lib/src/transport/studio_message_drop_report.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart';
+
+import 'studio_message_drop.dart';
+
+/// Hands one drop to a diagnostic [observer] without letting it take the
+/// channel down: an observer is debugging code, and a channel that stopped
+/// filtering messages because a log line threw would be a worse bug than the
+/// one being chased. The error is not swallowed either — it goes to
+/// [FlutterError.reportError], the path every other UI error in a DartWay app
+/// takes.
+///
+/// Shared by both web channels so that "what happens when the observer throws"
+/// has one answer instead of two.
+void reportStudioMessageDrop(
+  StudioMessageDropObserver? observer,
+  StudioMessageDrop drop,
+) {
+  if (observer == null) return;
+  try {
+    observer(drop);
+  } catch (error, stackTrace) {
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'dartway_studio_bridge',
+        context: ErrorDescription('reporting a dropped Studio bridge message'),
+      ),
+    );
+  }
+}

--- a/packages/dartway_studio_bridge/pubspec.yaml
+++ b/packages/dartway_studio_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_studio_bridge
 description: "Open bridge between a DartWay app and DartWay Studio: in-code screen spec registry models and the runtime postMessage protocol."
-version: 0.8.1
+version: 0.9.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_studio_bridge/test/studio_message_drop_test.dart
+++ b/packages/dartway_studio_bridge/test/studio_message_drop_test.dart
@@ -1,0 +1,173 @@
+import 'package:dartway_studio_bridge/dartway_studio_bridge.dart';
+// Not part of the public API: the guard both web channels share, and the one
+// piece of them a VM test can reach at all.
+import 'package:dartway_studio_bridge/src/transport/studio_message_drop_report.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// An envelope of ours at [version], carrying [type].
+String _envelope(int version, String type) =>
+    '{"dartwayStudioBridge":$version,"type":"$type","payload":{}}';
+
+void main() {
+  group('envelopeVersionOf', () {
+    test('reads the version out of one of our envelopes', () {
+      expect(
+        StudioBridgeProtocol.envelopeVersionOf(
+          const AppReadyMessage().encode(),
+        ),
+        StudioBridgeProtocol.version,
+      );
+    });
+
+    test('reads a version we do not speak — the whole point', () {
+      expect(
+        StudioBridgeProtocol.envelopeVersionOf(_envelope(3, 'appReady')),
+        3,
+      );
+    });
+
+    test('null for somebody else JSON on the same window', () {
+      expect(
+        StudioBridgeProtocol.envelopeVersionOf('{"type":"webpackHotUpdate"}'),
+        isNull,
+      );
+    });
+
+    test('null for anything that is not JSON, or not a map', () {
+      expect(StudioBridgeProtocol.envelopeVersionOf('not json at all'), isNull);
+      expect(StudioBridgeProtocol.envelopeVersionOf('[1,2,3]'), isNull);
+      expect(StudioBridgeProtocol.envelopeVersionOf(null), isNull);
+      expect(StudioBridgeProtocol.envelopeVersionOf(42), isNull);
+    });
+
+    test('null when the marker is there but is not a version', () {
+      expect(
+        StudioBridgeProtocol.envelopeVersionOf('{"dartwayStudioBridge":"4"}'),
+        isNull,
+      );
+    });
+
+    test('takes an already-decoded map, so nobody parses twice', () {
+      expect(
+        StudioBridgeProtocol.envelopeVersionOf(const {
+          'dartwayStudioBridge': 4,
+        }),
+        4,
+      );
+    });
+  });
+
+  group('StudioMessageDropReason.ofPayload', () {
+    test('null for a message that decodes', () {
+      expect(
+        StudioMessageDropReason.ofPayload(const AppReadyMessage().encode()),
+        isNull,
+      );
+    });
+
+    test('a foreign message is not a repair', () {
+      expect(
+        StudioMessageDropReason.ofPayload('{"source":"react-devtools"}'),
+        StudioMessageDropReason.notAnEnvelope,
+      );
+      expect(
+        StudioMessageDropReason.ofPayload('ping'),
+        StudioMessageDropReason.notAnEnvelope,
+      );
+    });
+
+    test('an app on v3 talking to a Studio on v4 is a version mismatch', () {
+      // The day-long handshake from issue #98: both sides speak the bridge and
+      // neither hears the other. `tryDecode` cannot tell this from the line
+      // above — it answers null to both.
+      final wrongVersion = _envelope(
+        StudioBridgeProtocol.version - 1,
+        StudioBridgeProtocol.appReady,
+      );
+      expect(StudioBridgeMessage.tryDecode(wrongVersion), isNull);
+      expect(
+        StudioMessageDropReason.ofPayload(wrongVersion),
+        StudioMessageDropReason.versionMismatch,
+      );
+      expect(
+        StudioBridgeProtocol.envelopeVersionOf(wrongVersion),
+        StudioBridgeProtocol.version - 1,
+      );
+    });
+
+    test('our version, a type this build has not heard of', () {
+      // How the protocol grows without cutting off the field: the other side is
+      // newer, not broken. Reporting it as a version mismatch would send
+      // somebody rebuilding for nothing.
+      expect(
+        StudioMessageDropReason.ofPayload(
+          _envelope(StudioBridgeProtocol.version, 'somethingAddedLater'),
+        ),
+        StudioMessageDropReason.unknownType,
+      );
+    });
+  });
+
+  group('StudioMessageDrop', () {
+    test('says what it knows and nothing it does not', () {
+      expect(
+        const StudioMessageDrop(
+          StudioMessageDropReason.versionMismatch,
+          origin: 'https://app.example',
+          envelopeVersion: 3,
+        ).toString(),
+        'StudioMessageDrop(versionMismatch, origin: https://app.example, '
+        'envelope: v3)',
+      );
+      expect(
+        const StudioMessageDrop(
+          StudioMessageDropReason.notAMessageEvent,
+        ).toString(),
+        'StudioMessageDrop(notAMessageEvent)',
+      );
+    });
+  });
+
+  group('reporting a drop', () {
+    test('no observer, nothing happens', () {
+      expect(
+        () => reportStudioMessageDrop(
+          null,
+          const StudioMessageDrop(StudioMessageDropReason.notAnEnvelope),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('the observer gets the drop', () {
+      final seen = <StudioMessageDrop>[];
+      reportStudioMessageDrop(
+        seen.add,
+        const StudioMessageDrop(
+          StudioMessageDropReason.foreignSource,
+          origin: 'https://app.example',
+        ),
+      );
+      expect(seen.single.reason, StudioMessageDropReason.foreignSource);
+      expect(seen.single.origin, 'https://app.example');
+    });
+
+    test('an observer that throws does not take the channel with it', () {
+      final errors = <FlutterErrorDetails>[];
+      final previous = FlutterError.onError;
+      FlutterError.onError = errors.add;
+      addTearDown(() => FlutterError.onError = previous);
+
+      expect(
+        () => reportStudioMessageDrop(
+          (_) => throw StateError('the diagnostic itself is broken'),
+          const StudioMessageDrop(StudioMessageDropReason.versionMismatch),
+        ),
+        returnsNormally,
+      );
+      expect(errors.single.exception, isA<StateError>());
+      expect(errors.single.library, 'dartway_studio_bridge');
+    });
+  });
+}

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -333,14 +333,14 @@ packages:
       path: "../../packages/dartway_studio_binding"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   dartway_studio_bridge:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_studio_bridge"
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.9.0"
   dbus:
     dependency: transitive
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   dartway_router: ^1.1.1
 
   dartway_serverpod_core_flutter: ^0.12.0
-  dartway_studio_bridge: ^0.8.0
+  dartway_studio_bridge: ^0.9.0
 
   dartway_studio_binding: ^0.1.0
 


### PR DESCRIPTION
## What was wrong

`StudioBridgeMessage.tryDecode` returns null for a stranger's JSON on `window` and for our own envelope at another protocol version alike — the caller cannot separate them. They are opposite diagnoses: foreign traffic is normal and must be ignored, while two sides on different versions will not hear each other until one is rebuilt. One handshake spent a day on exactly that: an app on v3, a Studio on v4, both quiet. The same gap on the app side, from the other end.

## What this does

**`StudioBridgeProtocol.envelopeVersionOf(data)`** — the envelope version out of raw postMessage data, null when there is no envelope. Takes the raw string or an already-decoded map. `tryDecode` now checks the version through it, so the check and the diagnostic that explains a drop cannot disagree about what an envelope is. `@dartway/studio-bridge` gets the same reader as `studioBridgeEnvelopeVersion`, covered by the golden-string tests.

**`onMessageDropped`** on `createStudioFrameController`, `openStudioProbeFrame`, `probeStudioBridge` (Studio side) and `StudioBridgeHost.attach` (app side). Called with a `StudioMessageDrop` — reason, sender's origin, envelope version — for every window message the channel refused. Without one nothing changes: the bridge is exactly as quiet as before. An observer that throws is reported through `FlutterError.reportError` instead of taking the channel down.

**`StudioMessageDropReason`** names each step: `notAMessageEvent`, `foreignOrigin`, `foreignSource`, `nonStringData`, `notAnEnvelope`, `versionMismatch`, `unknownType`. `StudioMessageDropReason.ofPayload(data)` classifies a raw string on its own, for an embedder watching `window` from outside.

## Two departures from the issues, deliberate

- **#95 proposed one `undecodable` reason; this splits it three ways.** Once the version is readable, "not our envelope", "our envelope at another version" and "our version, a type this build has not heard of" are three different answers, and the third one means the other side is *newer* — a type added inside a version is how the protocol grows without cutting off the field. Collapsing it into `versionMismatch` would send people rebuilding over the protocol working as designed.
- **The observer reports drops only, not "took it".** The delivered path is already the channel's `messages` stream; a second way to learn the same thing would be two sources for one fact.

Option 1 in #95 (exposing `frameWindow`) is not taken, for the reason the issue itself gives: the source check compares against the window of *its own* frame, and an outside observer can only ask "is this some frame of this page" — which stops distinguishing anything the moment the page carries two.

## Synchronisation

- `example/`, `template/`, `dartway_studio_binding` — carets to `^0.9.0` (bridge `0.8.1` → `0.9.0`, equal to `stable`, additive minor). `dartway_studio_binding` `0.1.0` → `0.1.1`: it follows the caret and nothing else. npm package `0.2.0` → `0.3.0`.
- `docs/6-studio/studio-bridge.md`, both package READMEs, both CHANGELOGs.
- No toolkit skill teaches this API, so nothing to update there.
- **Protocol version stays 4** — nothing on the wire changed.
- **The Studio side was checked.** `dartway_studio` carries the private copy #98 describes: `dartway_studio_flutter/lib/app/projects/settings/logic/window_message_observation.dart` re-implements the envelope read and the channel's five checks. Nothing there breaks — the additions are optional — and that file can now be rewritten on `envelopeVersionOf` / `StudioMessageDropReason.ofPayload`, or dropped in favour of `onMessageDropped`. That is a change in the other repository and not part of this PR.

## Checks

`dart analyze` clean on the bridge and the binding; `flutter analyze` clean in `example/` and `template/`; 104 bridge tests + 10 binding tests green; `npm run check` in `js/studio-bridge` green (74 tests); `flutter build web --release` of `example/` green (the web channels are dart2js-only code and unit tests on the VM cannot see them).

The version distinction is held by a test that fails when `ofPayload` stops making it — verified by breaking it.

Closes #98
Closes #95