### PR TITLE
feat(core): let an app state the one form its auth identifier is stored in

### DIFF
--- a/docs/4-server/auth-identity.md
+++ b/docs/4-server/auth-identity.md
@@ -1,0 +1,99 @@
+# The auth identifier: when are two typings the same person?
+
+A DartWay user is found by one string — `UserProfile.userIdentifier`, whatever
+the app decided that is: a phone number, an email address, an external id. Every
+sign-in matches on it, and the match decides something bigger than it looks: an
+identifier that matches nothing is not an error, it is a **registration**.
+
+That is the whole subject of this page.
+
+## The failure
+
+An email address is typed by a person, twice: once when they register, and again
+every time they come back. Nothing keeps the two typings identical — a phone
+capitalises the first letter, a password manager pastes a trailing space, a
+person simply types `Ivan@acme.com` on Tuesday and `ivan@acme.com` on Friday.
+
+Matched byte for byte, Friday's address finds nothing. Nothing is broken, so
+nothing complains:
+
+1. the lookup honestly reports that no profile carries this identifier;
+2. the flow honestly resolves the request as a registration;
+3. the person gets a **second account** — empty, in no team, owning nothing;
+4. no error is raised anywhere, because every step did what it was asked.
+
+They notice days later, when their data is "gone". Support sees two rows that
+look like two different people. This is the expensive shape of bug: silent,
+delayed, and indistinguishable from the user's own mistake.
+
+The same split runs deeper than the account. The per-identifier lock and the
+rate-limit bucket are keyed on the same string, so two spellings are also **two
+rate-limit buckets** — an attacker gets the limit once per spelling.
+
+## The rule is yours to state
+
+DartWay does not fold case on its own, and that is deliberate. The identifier is
+not declared to be an email address; an app may legitimately use one where case
+is significant. So the framework refuses to guess and asks instead:
+
+```dart
+DwCore.init<UserProfile>(
+  // ...
+  dwAuthConfig: DwAuthConfig(
+    passwords: passwords,
+    normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+  ),
+);
+```
+
+Declared once, that rule is applied by DartWay everywhere the identifier decides
+*who* someone is:
+
+| Where | What it stops |
+|---|---|
+| the auth request, the moment it arrives | the lookup, the lock and the bucket all read this one field afterwards |
+| the profile a registration writes | the row is stored in the form the next sign-in will look for |
+| `dw.getUserProfileByIdentifier` | a lookup the app makes itself |
+
+**Stating it in the framework rather than on the client is the point.** An app
+can normalize on the sign-in screen, and that works — until a second client, a
+seed script, an admin tool or an environment-provisioned first administrator
+writes one row that skipped the rule. Then there are two copies of the rule with
+nothing checking that they agree, and the disagreement surfaces weeks later as a
+duplicate account.
+
+Your own code paths reach the same rule through `dw.normalizeAuthIdentifier`:
+
+```dart
+final identifier = dw.normalizeAuthIdentifier(invitation.email);
+```
+
+## The rule must be idempotent
+
+DartWay applies it at more than one point on purpose, so `f(f(x))` has to equal
+`f(x)`. `trim().toLowerCase()` is idempotent. Anything that appends, wraps or
+counts is not.
+
+## Turning it on over live data is a migration
+
+`normalizeIdentifier` changes how identifiers are **matched and written from now
+on**. It does not touch rows that are already stored.
+
+So an existing row written as `Ivan@acme.com` stops being found the moment the
+rule lowercases the incoming address — and it fails the way this page opened
+with: as a registration, not as an error. Switching the rule on over a live
+database therefore means bringing the stored identifiers to the same form in the
+same release:
+
+```sql
+UPDATE user_profile SET "userIdentifier" = lower(trim("userIdentifier"));
+```
+
+Run that and you will find out whether your table already holds two rows for one
+person. It probably does — there is no unique index on `userIdentifier`, so
+nothing has been stopping it. Merge them before you add the constraint, not
+after.
+
+A new project has none of this to worry about: declare the rule in
+`DwAuthConfig` on day one and the question never arises. `dartway create` ships
+`template/` with it already declared.

--- a/example/dartway_example_server/lib/src/dartway/dartway_core.dart
+++ b/example/dartway_example_server/lib/src/dartway/dartway_core.dart
@@ -122,6 +122,12 @@ void initDartwayCore({
         : null,
     dwAuthConfig: DwAuthConfig(
       passwords: passwords,
+      // One identifier, one account. The identifier here is a phone number, so
+      // this rule only ever strips a stray space — but it is the seam an app
+      // switching to email addresses needs, and stating it now means the day
+      // that happens nobody has to remember that `Ivan@` and `ivan@` were two
+      // people. See `docs/4-server/auth-identity.md`.
+      normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
       legacyPasswordVerifiers: legacyPasswordVerifiers,
       // Test/reviewer accounts carry a fixed, admin-rotated code
       // (UserProfile.testVerificationCode, serverOnly — never sent to clients);

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 0.12.0
 
+- **The same address, typed with a capital, no longer signs a person into a second account.**
+
+  The auth identifier was matched byte for byte, so `Ivan@acme.com` found nothing where
+  `ivan@acme.com` was stored. No step failed: the lookup honestly reported "unknown", the flow
+  honestly resolved the request as a registration, and the person ended up with an empty second
+  account — in no team, owning nothing. Nothing was logged, because nothing went wrong.
+
+  `DwAuthConfig.normalizeIdentifier` lets the app state the rule once — `(id) => id.trim()
+  .toLowerCase()` for an email app — and DartWay applies it at the edge, to the auth request the
+  moment it arrives. Everything downstream reads the identifier off that one field: the profile
+  lookup, the per-identifier lock, the rate-limit bucket (two spellings used to be two buckets),
+  and the profile a registration builds. `dw.normalizeAuthIdentifier` exposes the same rule to an
+  app's own seeds and admin tools, and `getUserProfileByIdentifier` applies it too.
+
+  **The default changes nothing:** with no rule declared the identifier is matched exactly, as
+  before. Switching one on over live data is a data migration — rows written in another form stop
+  being found, silently, as "no such user".
+
 - **A web route no longer answers the caller with whatever the exception happened to say.**
 
   `DwWebServerLogger.handleWithExceptions` caught everything and wrote `e.toString()` into the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
@@ -36,6 +36,11 @@ final class DwAuthKeyIssuanceRejectedException implements Exception {
       'DwAuthKeyIssuanceRejectedException(reason: ${reason.name})';
 }
 
+/// The default [DwAuthConfig.normalizeIdentifier]: the identifier is whatever
+/// the caller typed, matched byte for byte. That is what DartWay has always
+/// done, and staying on it is the only choice that cannot break stored data.
+String _identifierAsTyped(String identifier) => identifier;
+
 class DwAuthConfig<UserProfileClass extends TableRow> {
   final Map<String, String> passwords;
 
@@ -66,7 +71,38 @@ class DwAuthConfig<UserProfileClass extends TableRow> {
     this.authRequestRateLimitWindow = const Duration(minutes: 10),
     this.passwordHasher = const DwBcryptPasswordHasher(),
     this.legacyPasswordVerifiers = const [],
+    this.normalizeIdentifier = _identifierAsTyped,
   });
+
+  /// Brings a user identifier to the single form this app stores it in.
+  ///
+  /// `Ivan@acme.com` and `ivan@acme.com` are one person, or they are two, and
+  /// only the app knows which — the identifier is not declared to be an email
+  /// address, and an app may legitimately use a case-significant one. So
+  /// nothing is folded until the app says so, and the default leaves the
+  /// identifier exactly as it was typed.
+  ///
+  /// Where it is applied: to the auth request the moment it arrives, before
+  /// anything reads the identifier off it, and inside
+  /// [DwCore.getUserProfileByIdentifier]. That covers the profile lookup, the
+  /// per-identifier lock, the rate-limit bucket and — on a registration — the
+  /// profile the app builds out of that same request. **The rule is therefore
+  /// applied more than once, and must be idempotent:** `f(f(x)) == f(x)`.
+  ///
+  /// ```dart
+  /// DwAuthConfig(
+  ///   passwords: passwords,
+  ///   normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+  /// )
+  /// ```
+  ///
+  /// What it does *not* do is touch rows that are already stored. An
+  /// identifier written before the rule existed keeps whatever form it was
+  /// written in, and one that the rule would change stops being found —
+  /// silently, as a "no such user". Switching this on over live data is a data
+  /// migration, not a config change: bring the stored identifiers to the same
+  /// form in the same release.
+  final String Function(String identifier) normalizeIdentifier;
 
   /// The one hash format DartWay writes — on registration, on password change,
   /// and when upgrading a legacy hash after a successful sign-in.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
@@ -31,6 +31,7 @@ import '../utils/iterable_extension.dart';
 /// - [init]: Initializes the framework.
 /// - [getUserProfile]: Gets the user profile.
 /// - [getUserProfileByIdentifier]: Gets the user profile by identifier.
+/// - [normalizeAuthIdentifier]: Brings an identifier to the form this app stores.
 class DwCore<UserProfileClass extends TableRow> {
   final Table userProfileTable;
   final Map<String, Map<String, DwCrudConfig>> _crudConfiguration = {};
@@ -240,24 +241,41 @@ class DwCore<UserProfileClass extends TableRow> {
 
   /// The profile row carrying [identifier], or `null` when there is none.
   ///
+  /// [identifier] is put through [normalizeAuthIdentifier] first, so a caller
+  /// holding an address a human typed does not have to remember the app's own
+  /// rule. Without a rule configured this is an exact match, as it always was.
+  ///
   /// [transaction] carries the same meaning as on [getUserProfile].
   Future<UserProfileClass?> getUserProfileByIdentifier(
     Session session,
     String identifier, {
     Transaction? transaction,
   }) async {
+    final normalized = normalizeAuthIdentifier(identifier);
+
     final profile = await session.db.findFirstRow<UserProfileClass>(
-      where: _userIdentifierColumn.equals(identifier),
+      where: _userIdentifierColumn.equals(normalized),
       include: _userProfileInclude,
       transaction: transaction,
     );
 
     if (profile == null) {
-      session.log('Warning: User profile not found for identifier $identifier');
+      session.log('Warning: User profile not found for identifier $normalized');
     }
 
     return profile;
   }
+
+  /// [identifier] in the form this app stores identifiers in — see
+  /// [DwAuthConfig.normalizeIdentifier].
+  ///
+  /// Returns the value untouched when the app declared no rule, and when it
+  /// runs without the auth module at all. Public because an app has its own
+  /// paths that write or match an identifier — a seed, an admin tool, an
+  /// invitation — and the whole point is that they state the rule once rather
+  /// than each carrying a copy of it.
+  String normalizeAuthIdentifier(String identifier) =>
+      auth?.config.normalizeIdentifier(identifier) ?? identifier;
 
   /// The signed-in caller's profile row, or `null` for a caller with no session.
   ///

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/crud/dw_auth_request_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/crud/dw_auth_request_config.dart
@@ -39,6 +39,19 @@ final dwAuthRequestConfig = DwCrudConfig<DwAuthRequest>(
             saveContext.currentModel.createdAt = DateTime.now();
           }
 
+          // Fold the identifier once, here, before anything has read it.
+          // Everything that follows decides *who* this is from this one field:
+          // the profile lookup, the per-identifier lock, the rate-limit bucket
+          // it counts against, and — on a registration — the profile the app
+          // builds out of this very request. Normalising at each of them
+          // instead would be the same rule in five copies, and the day one is
+          // missed a person signs in with the address they always use, matches
+          // nothing, and is registered a second empty account without a single
+          // error being raised.
+          saveContext.currentModel.userIdentifier = dw.normalizeAuthIdentifier(
+            saveContext.currentModel.userIdentifier,
+          );
+
           final failReason = await dw.prevalidateAuthAttempt(
             session,
             saveContext.currentModel,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/identifier_normalization_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/identifier_normalization_test.dart
@@ -1,0 +1,185 @@
+// `findFirstRow` is internal to Serverpod; the double below has to implement it
+// to catch the query the lookup makes.
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:dartway_serverpod_core_server/src/crud/dw_auth_request_config.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+/// The address as a human typed it the second time: a stray space from the
+/// keyboard's autocomplete, and a capital the phone put there.
+const _asTyped = ' Ivan@Acme.COM ';
+
+/// The one form the app decided to store it in.
+const _stored = 'ivan@acme.com';
+
+class TestUserProfile implements TableRow<int?> {
+  @override
+  int? get id => 1;
+
+  @override
+  Table<int?> get table => _userProfileTable;
+
+  @override
+  Map<String, dynamic> toJson() => const {};
+}
+
+class TestTable extends Table<int?> {
+  TestTable(String name) : super(tableName: name) {
+    userIdentifier = ColumnString(DwCoreConst.userIdentifierColumnName, this);
+  }
+
+  late final ColumnString userIdentifier;
+
+  @override
+  List<Column> get columns => [id, userIdentifier];
+}
+
+final _userProfileTable = TestTable('test_user_profile');
+
+/// Catches the query instead of running it: what these tests are about is which
+/// identifier the framework asks the database for, and that is decided before
+/// any row exists. Every lookup answers "no such profile".
+class RecordingDatabase implements Database {
+  final whereClauses = <String>[];
+
+  @override
+  Future<T?> findFirstRow<T extends TableRow>({
+    Expression? where,
+    int? offset,
+    Column? orderBy,
+    List<Order>? orderByList,
+    bool orderDescending = false,
+    Transaction? transaction,
+    Include? include,
+    LockMode? lockMode,
+    LockBehavior? lockBehavior,
+  }) async {
+    whereClauses.add(where.toString());
+    return null;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('Unexpected database call: ${invocation.memberName}');
+}
+
+class RecordingSession implements Session {
+  final RecordingDatabase database = RecordingDatabase();
+
+  @override
+  Database get db => database;
+
+  @override
+  void log(
+    String message, {
+    LogLevel? level,
+    dynamic exception,
+    StackTrace? stackTrace,
+  }) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('Unexpected session call: ${invocation.memberName}');
+}
+
+DwAuthRequest _loginRequest(String identifier) => DwAuthRequest(
+  requestType: DwAuthRequestType.login,
+  userIdentifier: identifier,
+  authProvider: DwAuthProvider.email,
+);
+
+DwSaveContext<DwAuthRequest> _insertOf(DwAuthRequest request) =>
+    DwSaveContext<DwAuthRequest>(
+      currentUserId: null,
+      isInsert: true,
+      initialModel: null,
+      currentModel: request,
+    );
+
+void main() {
+  // A `where` clause renders its values through the encoder the live database
+  // installs, and no database is created here. Postgres' own encoder does the
+  // rendering without a connection, which is all these assertions read.
+  ValueEncoder.set(PostgresValueEncoder());
+
+  // `DwCore.init` resolves class names through `Serverpod.instance`. Nothing
+  // here is started; no socket and no database is touched.
+  Serverpod(
+    ['--mode', 'test', '--role', 'monolith'],
+    Protocol(),
+    Endpoints(),
+    config: ServerpodConfig.defaultConfig(),
+  );
+
+  final dw = DwCore.init<TestUserProfile>(
+    userProfileTable: _userProfileTable,
+    crudConfigurations: [],
+    dtoConfigurations: [],
+    channelConfigurations: [],
+    userProfileConstructor: (session, {required registrationRequest}) async =>
+        throw UnimplementedError(),
+    dwAlerts: DwAlerts.init(logFunction: (_) {}),
+    dwAuthConfig: DwAuthConfig<TestUserProfile>(
+      passwords: const {},
+      normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+    ),
+  );
+
+  group('with a normalization rule declared', () {
+    test('the profile lookup asks for the stored form', () async {
+      final session = RecordingSession();
+
+      await dw.getUserProfileByIdentifier(session, _asTyped);
+
+      expect(session.database.whereClauses.single, contains(_stored));
+      expect(session.database.whereClauses.single, isNot(contains('Acme')));
+    });
+
+    test('an arriving auth request is rewritten before anything reads it', () async {
+      final request = _loginRequest(_asTyped);
+
+      await dwAuthRequestConfig.saveConfig!.beforeSaveTransaction!(
+        RecordingSession(),
+        _insertOf(request),
+      );
+
+      // The one field every later step reads: the lock, the rate-limit bucket
+      // and the profile a registration builds all take the identifier from
+      // here, so they cannot disagree about who this is.
+      expect(request.userIdentifier, _stored);
+    });
+
+    test(
+      'the same address typed twice resolves to one account, not two',
+      () async {
+        // The defect: a profile stored under `_stored` was not found for
+        // `_asTyped`, the request was resolved as a registration, and the
+        // person got a second, empty account.
+        final session = RecordingSession();
+        final request = _loginRequest(_asTyped);
+
+        await dwAuthRequestConfig.saveConfig!.beforeSaveTransaction!(
+          session,
+          _insertOf(request),
+        );
+
+        expect(
+          session.database.whereClauses,
+          everyElement(contains(_stored)),
+          reason: 'the sign-in looked for an address the registration would '
+              'never have written',
+        );
+      },
+    );
+  });
+
+  group('with no rule declared', () {
+    test('the identifier is left exactly as it was typed', () {
+      const config = DwAuthConfig<TestUserProfile>(passwords: {});
+
+      expect(config.normalizeIdentifier(_asTyped), _asTyped);
+    });
+  });
+}

--- a/template/dartway_starter_server/lib/src/app/bootstrap_admin.dart
+++ b/template/dartway_starter_server/lib/src/app/bootstrap_admin.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:dartway_starter_server/src/generated/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 
+import '../dartway/dartway_core.dart';
+
 /// The `config/passwords.yaml` key naming the first administrator.
 const bootstrapAdminIdentifierKey = 'bootstrapAdminIdentifier';
 
@@ -21,8 +23,8 @@ const bootstrapAdminIdentifierKey = 'bootstrapAdminIdentifier';
 /// admin yet, so restarts stay quiet and an address demoted through the admin
 /// panel is back on the next start.
 Future<void> bootstrapAdmin(Serverpod pod) async {
-  final identifier = pod.server.passwords[bootstrapAdminIdentifierKey]?.trim();
-  if (identifier == null || identifier.isEmpty) {
+  final declared = pod.server.passwords[bootstrapAdminIdentifierKey]?.trim();
+  if (declared == null || declared.isEmpty) {
     stdout.writeln(
       'No administrator is declared: set $bootstrapAdminIdentifierKey in '
       'config/passwords.yaml to reach the admin panel.',
@@ -30,10 +32,17 @@ Future<void> bootstrapAdmin(Serverpod pod) async {
     return;
   }
 
+  // Through the app's own identifier rule, so the row written below carries the
+  // form the sign-in screen will look for. Declared as `Admin@acme.com` and
+  // stored verbatim, the administrator was a second empty account waiting to
+  // happen — the very thing `DwAuthConfig.normalizeIdentifier` exists to stop.
+  final identifier = dw.normalizeAuthIdentifier(declared);
+
   final session = await pod.createSession(enableLogging: false);
   try {
-    // Case-insensitive, and with no wildcards in the pattern: the identifier is
-    // typed twice by a human — once into the config, once on the sign-in screen.
+    // Case-insensitive on top of the rule, and with no wildcards in the
+    // pattern: this also has to recognise an administrator whose row predates
+    // the rule, and refusing to would create the duplicate instead.
     final existing = await UserProfile.db.findFirstRow(
       session,
       where: (t) => t.userIdentifier.ilike(identifier),

--- a/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
+++ b/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
@@ -71,6 +71,12 @@ void initDartwayCore({
         : null,
     dwAuthConfig: DwAuthConfig(
       passwords: passwords,
+      // One identifier, one account. The identifier here is a phone number, so
+      // this rule only ever strips a stray space — but it is the seam an app
+      // switching to email addresses needs, and stating it now means the day
+      // that happens nobody has to remember that `Ivan@` and `ivan@` were two
+      // people. See `docs/4-server/auth-identity.md`.
+      normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
       legacyPasswordVerifiers: legacyPasswordVerifiers,
       // Test/reviewer accounts carry a fixed, admin-rotated code
       // (UserProfile.testVerificationCode, serverOnly — never sent to clients);


### PR DESCRIPTION
Closes #138.

## The defect

`DwCore.getUserProfileByIdentifier` matched `userIdentifier` with a plain `.equals()`. For an app whose identifier is an email address, the address a person typed on Friday (`Ivan@acme.com`) did not match the one stored on Tuesday (`ivan@acme.com`), no profile was found, `preAuthValidation` correctly resolved the request as a **registration**, and the person got a second, empty account — in no team, owning nothing.

Nothing raised an error, because every step did exactly what it was asked.

Confirmed in the tree, and it reached further than the account: the same raw string keys `DwAuthConcurrency.tryLockIdentifier` and the rate-limit count in `dw_auth_request_config.dart`, so two spellings were also **two rate-limit buckets** — the limit applied once per spelling.

## The fix

`DwAuthConfig.normalizeIdentifier` — the app states the rule once, the framework applies it. The default is identity, so **nothing changes for an app that declares no rule**; the identifier is not documented as an email address, and an app may legitimately use a case-significant one.

The rule is applied **at the edge**, to the arriving auth request, before anything has read the identifier off it:

```dart
saveContext.currentModel.userIdentifier =
    dw.normalizeAuthIdentifier(saveContext.currentModel.userIdentifier);
```

Everything downstream decides *who* this is from that one field — the profile lookup, the lock, the rate-limit bucket, and the profile the app's `userProfileConstructor` builds out of that same request — so they cannot disagree. Normalising at each of them instead would be one rule in five copies.

`getUserProfileByIdentifier` applies it too, and `dw.normalizeAuthIdentifier` is public, so an app's own seeds, invitations and admin tools reach the same rule rather than carrying a second copy of it. That second copy is the shape the issue names: it works until one writer skips it.

The rule is applied more than once by design and must therefore be idempotent — stated in the doc comment and on the docs page.

## Why not the alternatives

The issue listed three directions. Normalisation owned by `DwAuthProvider.email` fixes everyone at once and without config, but changes behaviour on live databases: rows already stored with a capital stop being found. That is a data migration in someone else's project, decided by us, and it is not ours to decide — so the seam is offered and the rule stays the app's.

## Acceptance

`test/auth/identifier_normalization_test.dart`. Reverting either half of the fix turns three of the four tests red:

- the profile lookup asks the database for the stored form, not the typed one (the `where` clause is read at a `Database` double — no database, no connection);
- an arriving auth request is rewritten before anything reads it, so the lock, the bucket and a registration's profile all see one form;
- with no rule declared the identifier is left exactly as typed.

## Synchronisation

- `example/` and `template/` declare the rule (`trim().toLowerCase()`). The identifier there is a phone number, so it only strips a stray space — but a new project gets the seam already wired, and the day it moves to email addresses nobody has to remember this.
- `template/`'s `bootstrapAdmin` now writes the administrator through `dw.normalizeAuthIdentifier`. It kept its own case-insensitive `ilike` lookup — an environment-provisioned first account is precisely the writer that used to skip the rule — and the lookup stays forgiving so an administrator row predating the rule is still recognised rather than duplicated.
- `docs/4-server/auth-identity.md` — new page: the failure, the rule, idempotence, and the fact that switching it on over live data is a migration, not a config change.
- `CHANGELOG.md` under `0.12.0`. No version move: core is `0.12.0` on `master` against `0.11.0` on `stable`, so the pending release already carries a bump and the carets stay put.
- No toolkit skill teaches `DwAuthConfig`; nothing there to update.

## Not in this PR

There is still **no unique index on `userIdentifier`** — duplicates are unconstrained at the storage level, in `template/` too. Adding one means a migration and `serverpod create-migration`, and it needs a decision about existing duplicate rows first. The docs page says so out loud and shows the `lower(trim(...))` update a project runs before adding the constraint.