### PR TITLE
feat(core)!: make the identifier form a required choice, not a default

### DIFF
--- a/docs/4-server/auth-identity.md
+++ b/docs/4-server/auth-identity.md
@@ -30,21 +30,40 @@ The same split runs deeper than the account. The per-identifier lock and the
 rate-limit bucket are keyed on the same string, so two spellings are also **two
 rate-limit buckets** — an attacker gets the limit once per spelling.
 
-## The rule is yours to state
+## The rule is yours to state, and stating it is not optional
 
 DartWay does not fold case on its own, and that is deliberate. The identifier is
 not declared to be an email address; an app may legitimately use one where case
-is significant. So the framework refuses to guess and asks instead:
+is significant. So the framework refuses to guess.
+
+**`normalizeIdentifier` is a required parameter.** It shipped with a default
+that changed nothing, and a default that changes nothing is how a defect stays
+open everywhere: the projects that most needed the rule were exactly the ones
+that would not remember to declare it. A question the framework cannot answer is
+not one it may answer quietly — the compiler asks it once, per project.
+
+Two named answers, so the choice reads at the call site:
 
 ```dart
 DwCore.init<UserProfile>(
   // ...
   dwAuthConfig: DwAuthConfig(
     passwords: passwords,
-    normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+    // Trim and case-fold — what an email address wants, and what a phone
+    // number does not object to. This is what `dartway create` gives you.
+    normalizeIdentifier: DwIdentifierForm.folded,
   ),
 );
 ```
+
+`DwIdentifierForm.asTyped` is the other one: byte for byte, for an identifier
+where case is significant — and the only choice that cannot break identifiers
+already stored in mixed forms. A rule of your own is fine too; it only has to be
+idempotent, because DartWay applies it more than once.
+
+**A new project starts on `folded`.** The skeleton states it, so the day a
+project moves from phone numbers to email addresses nobody has to remember that
+`Ivan@` and `ivan@` were two people.
 
 Declared once, that rule is applied by DartWay everywhere the identifier decides
 *who* someone is:

--- a/example/dartway_example_server/lib/src/dartway/dartway_core.dart
+++ b/example/dartway_example_server/lib/src/dartway/dartway_core.dart
@@ -127,7 +127,7 @@ void initDartwayCore({
       // switching to email addresses needs, and stating it now means the day
       // that happens nobody has to remember that `Ivan@` and `ivan@` were two
       // people. See `docs/4-server/auth-identity.md`.
-      normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+      normalizeIdentifier: DwIdentifierForm.folded,
       legacyPasswordVerifiers: legacyPasswordVerifiers,
       // Test/reviewer accounts carry a fixed, admin-rotated code
       // (UserProfile.testVerificationCode, serverOnly — never sent to clients);

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -34,9 +34,9 @@
   and the profile a registration builds. `dw.normalizeAuthIdentifier` exposes the same rule to an
   app's own seeds and admin tools, and `getUserProfileByIdentifier` applies it too.
 
-  **The default changes nothing:** with no rule declared the identifier is matched exactly, as
-  before. Switching one on over live data is a data migration — rows written in another form stop
-  being found, silently, as "no such user".
+  Switching a rule on over live data is a data migration — rows written in another form stop being
+  found, silently, as "no such user". The parameter shipped optional in this same cycle and is
+  required by the entry above; within this release there is no "no rule declared" state.
 
 - **A web route no longer answers the caller with whatever the exception happened to say.**
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 0.12.0
 
+- **Breaking: `DwAuthConfig.normalizeIdentifier` is required.**
+
+  It arrived a release earlier with a default that changed nothing, on the reasoning that folding
+  case cannot be right for every app and must not break stored data. Both true — and together they
+  meant the defect the parameter exists to close stayed open in every project that did not remember
+  to declare a rule, which is precisely the projects that needed it. A default that changes nothing
+  is not a safe default; it is the old behaviour wearing a new name.
+
+  So the compiler asks once, per project. `DwIdentifierForm.folded` trims and case-folds;
+  `DwIdentifierForm.asTyped` keeps the identifier byte for byte, and is still the only choice that
+  cannot break identifiers already stored in mixed forms — but it is now chosen rather than
+  inherited. A rule of your own still works; it only has to be idempotent.
+
+  **Migration:** one line at the `DwAuthConfig` call site. An app that wants today's behaviour
+  passes `DwIdentifierForm.asTyped` — and, having read this far, knows what it is keeping. The
+  skeleton and `example/` state `DwIdentifierForm.folded`, so a new project starts on the rule
+  rather than remembering to add it.
+
 - **The same address, typed with a capital, no longer signs a person into a second account.**
 
   The auth identifier was matched byte for byte, so `Ivan@acme.com` found nothing where

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/example/README.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/example/README.md
@@ -94,7 +94,11 @@ dw = DwCore.init<UserProfile>(
   dtoConfigurations: [],
   userProfileConstructor: _buildUserProfile,
   dwAlerts: DwAlerts.init(),
-  dwAuthConfig: DwAuthConfig(passwords: passwords),
+  dwAuthConfig: DwAuthConfig(
+    passwords: passwords,
+    // Required: the app states the one form it stores identifiers in.
+    normalizeIdentifier: DwIdentifierForm.folded,
+  ),
 );
 ```
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
@@ -36,10 +36,25 @@ final class DwAuthKeyIssuanceRejectedException implements Exception {
       'DwAuthKeyIssuanceRejectedException(reason: ${reason.name})';
 }
 
-/// The default [DwAuthConfig.normalizeIdentifier]: the identifier is whatever
-/// the caller typed, matched byte for byte. That is what DartWay has always
-/// done, and staying on it is the only choice that cannot break stored data.
-String _identifierAsTyped(String identifier) => identifier;
+/// The two answers to "what form does this app store its identifier in".
+///
+/// Named rather than written inline, so the choice is readable at the call site
+/// and greppable across projects — and so that the common one is not
+/// re-implemented slightly differently in each of them. A project whose rule is
+/// neither of these passes its own function; it only has to be idempotent, see
+/// [DwAuthConfig.normalizeIdentifier].
+abstract final class DwIdentifierForm {
+  /// Trim and case-fold. What an email address wants, and what a phone number
+  /// does not object to.
+  static String folded(String identifier) => identifier.trim().toLowerCase();
+
+  /// Byte for byte, as the caller typed it.
+  ///
+  /// The right answer for an app whose identifier is case-significant, and the
+  /// only one that cannot break data already stored in mixed forms. Choosing it
+  /// is choosing it — that is the point of making the parameter required.
+  static String asTyped(String identifier) => identifier;
+}
 
 class DwAuthConfig<UserProfileClass extends TableRow> {
   final Map<String, String> passwords;
@@ -71,16 +86,22 @@ class DwAuthConfig<UserProfileClass extends TableRow> {
     this.authRequestRateLimitWindow = const Duration(minutes: 10),
     this.passwordHasher = const DwBcryptPasswordHasher(),
     this.legacyPasswordVerifiers = const [],
-    this.normalizeIdentifier = _identifierAsTyped,
+    required this.normalizeIdentifier,
   });
 
   /// Brings a user identifier to the single form this app stores it in.
   ///
   /// `Ivan@acme.com` and `ivan@acme.com` are one person, or they are two, and
   /// only the app knows which — the identifier is not declared to be an email
-  /// address, and an app may legitimately use a case-significant one. So
-  /// nothing is folded until the app says so, and the default leaves the
-  /// identifier exactly as it was typed.
+  /// address, and an app may legitimately use a case-significant one.
+  ///
+  /// **Required, and deliberately so.** It shipped with a default that changed
+  /// nothing, which meant the defect this exists to close — the same address
+  /// typed with a capital signing a person into a second account — stayed open
+  /// in every project that did not remember to declare a rule. A question the
+  /// framework cannot answer is not a question it may answer quietly; it is one
+  /// the compiler asks once, per project. Take [DwIdentifierForm.folded] or
+  /// [DwIdentifierForm.asTyped], or state your own.
   ///
   /// Where it is applied: to the auth request the moment it arrives, before
   /// anything reads the identifier off it, and inside

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
@@ -269,8 +269,9 @@ class DwCore<UserProfileClass extends TableRow> {
   /// [identifier] in the form this app stores identifiers in — see
   /// [DwAuthConfig.normalizeIdentifier].
   ///
-  /// Returns the value untouched when the app declared no rule, and when it
-  /// runs without the auth module at all. Public because an app has its own
+  /// Returns the value untouched when the app runs without the auth module at
+  /// all — there is no other way to get an unrewritten identifier now, since
+  /// [DwAuthConfig.normalizeIdentifier] is required. Public because an app has its own
   /// paths that write or match an identifier — a seed, an admin tool, an
   /// invitation — and the whole point is that they state the rule once rather
   /// than each carrying a copy of it.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/identifier_normalization_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/identifier_normalization_test.dart
@@ -175,11 +175,23 @@ void main() {
     );
   });
 
-  group('with no rule declared', () {
-    test('the identifier is left exactly as it was typed', () {
-      const config = DwAuthConfig<TestUserProfile>(passwords: {});
+  group('the app has to state the form it stores', () {
+    // There is no default any more, and that is the fix: the previous one
+    // changed nothing, so the defect this exists to close stayed open in every
+    // project that did not remember to declare a rule. A question the framework
+    // cannot answer is not one it may answer quietly.
+    test('both named answers are idempotent, as the contract demands', () {
+      for (final form in [DwIdentifierForm.folded, DwIdentifierForm.asTyped]) {
+        expect(form(form(' Ivan@Acme.com ')), form(' Ivan@Acme.com '));
+      }
+    });
 
-      expect(config.normalizeIdentifier(_asTyped), _asTyped);
+    test('folded brings the shapes of one address together', () {
+      expect(DwIdentifierForm.folded(' Ivan@Acme.com '), 'ivan@acme.com');
+    });
+
+    test('asTyped keeps what was typed, for a case-significant identifier', () {
+      expect(DwIdentifierForm.asTyped(' Ivan@Acme.com '), ' Ivan@Acme.com ');
     });
   });
 }

--- a/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
+++ b/template/dartway_starter_server/lib/src/dartway/dartway_core.dart
@@ -76,7 +76,7 @@ void initDartwayCore({
       // switching to email addresses needs, and stating it now means the day
       // that happens nobody has to remember that `Ivan@` and `ivan@` were two
       // people. See `docs/4-server/auth-identity.md`.
-      normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+      normalizeIdentifier: DwIdentifierForm.folded,
       legacyPasswordVerifiers: legacyPasswordVerifiers,
       // Test/reviewer accounts carry a fixed, admin-rotated code
       // (UserProfile.testVerificationCode, serverOnly — never sent to clients);


### PR DESCRIPTION
Follows #138, closed by #164. The fix landed, and it was opt-in.

## Why this is a follow-up and not a nit

#164 added `DwAuthConfig.normalizeIdentifier` with a default that changes nothing, and said so plainly:

> **The default changes nothing:** with no rule declared the identifier is matched exactly, as before.

The reasoning is sound on both halves — folding case cannot be right for every app, and it must not break identifiers already stored in mixed forms. Together they produce the wrong outcome: **the defect the parameter exists to close stays open in every project that does not remember to declare a rule**, which is precisely the set of projects that needed it. That is how #138 happened in the first place; nobody knew the question was there to answer.

A default that changes nothing is not a safe default. It is the old behaviour wearing a new name, and it puts the decision where nobody will meet it.

## The change

`normalizeIdentifier` is **required**. The compiler asks once, per project.

Two named answers, so the choice reads at the call site rather than as an inline closure re-written slightly differently in every project:

| | |
|---|---|
| `DwIdentifierForm.folded` | trim + case-fold — what an email address wants, what a phone number does not object to |
| `DwIdentifierForm.asTyped` | byte for byte, for a case-significant identifier — still the only choice that cannot break mixed-form stored data, but now **chosen** rather than inherited |

A project's own function still works; it only has to be idempotent, as the doc comment already required.

**The skeleton and `example/` state `folded`.** A new project starts on the rule instead of remembering to add it — so the framework forces the decision and the scaffold demonstrates the sensible answer, rather than one of them doing both jobs badly.

## Migration

One line at the `DwAuthConfig` call site. An app that wants today's behaviour writes `DwIdentifierForm.asTyped`, and having gone looking for what to write, now knows what it is keeping.

## Verification

`dart analyze` clean across `packages/` (one pre-existing `dead_code` in generated Serverpod transport); `template/dartway_starter_server` and `example/dartway_example_server` both analyze clean beyond a pre-existing Serverpod deprecation; 103 tests green in the core server package.

The default-behaviour test is replaced rather than deleted: there is no default to test, so what is pinned now is the contract the two named answers have to satisfy — idempotence, which DartWay depends on because it applies the rule more than once.

`dartway_serverpod_core_*` is at `0.12.0` on `master` against `0.11.0` on `stable`, so this joins that section rather than moving the version again.