### PR TITLE
fix(toolkit): /commit stops deciding what belongs to the project

### DIFF
--- a/docs/5-tooling/agent-toolkit.md
+++ b/docs/5-tooling/agent-toolkit.md
@@ -173,9 +173,11 @@ tested, and why there are no coverage thresholds.
 contract, checks the feature's description for drift and the test coverage, then shows suggestions
 and applies only what you confirm.
 
-Two commands come with them. `/commit` — a commit in the format the project's CI checks, with the
-ticket passed as an argument. And `/dartway-checkup` — the state of the project and what is worth
-taking into work next.
+Two commands come with them. `/commit` — one conventional-commit line in English, and nothing local
+decided for you: whether commits carry a ticket, and whether anything checks the message, belongs to
+the project's own `CLAUDE.md`. It used to demand a ticket as a required argument and stop without
+one, which in a project with no tracker stalled the agent mid-task on a question that has no answer.
+And `/dartway-checkup` — the state of the project and what is worth taking into work next.
 
 The checkup answers two questions for the same person on different days: *how bad is it* and *what
 do I fix first*. It runs the project's own gates before reading anything — the checker, the lints,

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## 0.9.0
 
+- **`/commit` stops deciding what belongs to the project.**
+
+  It demanded a ticket number as a required argument and, with none, stopped and asked — so in a
+  project with no tracker the agent stalled mid-task on a question that has no answer. The worst
+  kind of block: it looks like compliance. Whether commits carry a ticket, in what format, and
+  whether any CI job checks the message is the project's own convention, and it is stated in the
+  project's `CLAUDE.md` rather than assumed by the toolkit.
+
+  Two claims went with it. The command described the format as "what the CI checks" — a statement
+  about the consumer's infrastructure that the toolkit cannot make, and one this very repository
+  disproves: there is no such job here. And the format it taught had no scope, while DartWay's own
+  convention welcomes one and its history is full of `feat(cli):` and `fix(deploy):`.
+
+  Added instead: a trailing `(#NN)` in the history is the pull request number GitHub appends on
+  squash-merge, not part of the format. An agent reading `git log` to learn the convention sees a
+  number nobody typed, and reproducing it yields two on the next merge — indistinguishable on sight
+  in a project that numbers its tickets.
+
 - **`dartway check` warns on a `static const Color` or `TextStyle` inside `lib/ui_kit/`.**
 
   A token declared const does not depend on a context, so changing `ThemeData` does not touch it:

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -354,7 +354,7 @@ Live migrations (delete an entry once no project is on the old shape):
 
 ## Git
 
-PRs and diffs go against the `__BASE_BRANCH__` branch. The first line of a commit: `<type>: <description in English> #<TICKET>` (`type` = `feat`/`fix`/`chore`); the ticket is passed as an argument to `/commit`, and the project's CI checks the exact format.
+PRs and diffs go against the `__BASE_BRANCH__` branch. The first line of a commit: `<type>(<scope>): <description in English>` — `type` = `feat`/`fix`/`chore`, the scope optional. Whether commits also carry a ticket, and whether anything checks the format, is this project's own convention and is stated here rather than assumed by the toolkit.
 
 ---
 

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -31,7 +31,7 @@ The skills are **generic**: project-specific values are extracted into placehold
 
 `docs/dev_notes/` is the one thing installed outside `.claude/`: the project's own findings — a risk, a pin that trails, a config written down twice — one **tracked** file per finding, so it travels out in a pull request and is visible in review. `README.md` there states the form and is refreshed on every install; `_coverage.md` is the project's own table of which features `/dartway-checkup` has read, and is written once and never overwritten. A finding about the **framework** gets no file at all — it is filed as an issue in the repository `__NOTES_TRACKER__` names.
 
-Beyond `docs/adr/` and `docs/dev_notes/`, a DartWay project keeps no docs: the description of a feature lives in its `DwFeatureSpec`, the server-side rules in doc comments above the `DwCrudConfig`, cross-cutting registries in code under `lib/core/`, and the methodology in these skills. The ticket for `/commit` is passed as an argument, and the project's CI checks the format.
+Beyond `docs/adr/` and `docs/dev_notes/`, a DartWay project keeps no docs: the description of a feature lives in its `DwFeatureSpec`, the server-side rules in doc comments above the `DwCrudConfig`, cross-cutting registries in code under `lib/core/`, and the methodology in these skills. `/commit` writes one conventional-commit line and decides nothing local: a ticket convention, if the project has one, is stated in the project's own `CLAUDE.md`.
 
 ## Wiring it into a client repo
 

--- a/toolkit/commands/commit.md
+++ b/toolkit/commands/commit.md
@@ -1,28 +1,29 @@
 ---
-description: Commit the current branch's changes in the format the CI checks
-argument-hint: "<TICKET> (e.g. PROJ-123)"
+description: Commit the current branch's changes as one conventional-commit line, in English
 ---
 
 Analyze all the changes in the current branch and make a commit with a precise description of what was done, **in English**, briefly.
 
-## The ticket is a required argument
-
-The ticket number is passed as a **command argument**: `$ARGUMENTS` (e.g. `PROJ-123`). We do **not** pull the ticket out of the branch name. If the argument is empty — stop and ask for the ticket number, do not commit.
-
 ## The format of the first line
 
-`<type>: <short description> #<TICKET>`
+`<type>(<scope>): <short description>`
 
-- `<type>` — `feat`, `fix` or `chore` (lowercase), then `: ` (a colon plus one space). Determine it from the meaning of the changes.
-- `<short description>` — in English, terse, what was done; latin letters/digits/spaces/`-`/`.`/`_`.
-- `#<TICKET>` — `#` + the argument passed in (e.g. `#PROJ-123`).
+- `<type>` — `feat`, `fix` or `chore` (lowercase). Determine it from the meaning of the changes.
+- `<scope>` — optional, and welcome where the change belongs to a named part: `feat(session):`, `fix(deploy):`.
+- `<short description>` — terse, what was done, in English.
 
 Examples:
 
-- `fix: stabilize quiz result option bar layout #PROJ-58`
-- `feat: add survey redirect condition #PROJ-149`
-- `chore: add local docker dev setup #PROJ-14`
+- `fix: stabilize the quiz result option bar layout`
+- `feat(survey): add a redirect condition`
+- `chore: add a local docker dev setup`
 
-The exact ticket format (prefix, case) is set by the project's CI — it does the final check; see the project's `CLAUDE.md`/README if you need to confirm. The commit body (after a blank line) is optional; keep useful context the way the project does.
+The body (after a blank line) is optional; keep useful context the way the project does.
 
-First determine the type (`feat`/`fix`/`chore`) from the meaning of the changes, assemble one correct first line with the ticket passed in, and make the commit.
+## What this command deliberately does not decide
+
+**Anything local belongs to the project, not here.** Whether commits carry a ticket number, in what format, whether a CI job checks the message at all — that is the project's convention, and it lives in the project's own `CLAUDE.md`. Read it; follow it if it says something; do not invent a requirement it does not state, and do not stop to ask for a ticket in a project that has no tracker. A command that blocks on an answer that does not exist looks like compliance and is not.
+
+**A trailing `(#NN)` in the history is not part of the format.** GitHub appends the pull request number on squash-merge, after the fact. Reading `git log` to learn the convention therefore shows a number nobody typed — reproduce it and the next merge yields two, one of them meaningless. In a project numbering its tickets, the two are indistinguishable on sight.
+
+First determine the type from the meaning of the changes, assemble one correct first line, and make the commit.


### PR DESCRIPTION
Closes #69.

## The block

`/commit` states the ticket number is a required argument, and *"if the argument is empty — stop and ask for the ticket number, do not commit"*.

In a project with no tracker that question has no answer. The agent, having honestly followed the command, stops mid-task and asks for a number that does not exist — **the worst kind of block, because it looks like compliance.**

Not hypothetical, and the demonstration is this repository: `git log --format=%s -20 | grep -c '#[A-Z]'` returns **0**. The command DartWay ships to every project would stall in DartWay.

## What is removed, and why it is removal rather than a mechanism

The issue proposes detecting the convention from history. The owner's call was sharper and I agree with it: **the toolkit should not have an opinion about tickets at all.** Whether commits carry one, in what format, and whether anything checks the message is local, and it belongs in the project's own `CLAUDE.md` — which the agent already reads. A detection mechanism would be a workaround for a rule that should not be there.

Two further claims went with it:

**"The format the project's CI checks."** A statement about the *consumer's* infrastructure, made by a framework that neither knows nor controls it. This repository disproves it: the workflows are review, telegram-notify and web-compile — no commit-format job. So an agent believes the message is verified, a human believes a broken one would be caught, and nothing catches anything. Same class as a doc promising what no mechanism keeps.

**A format with no scope.** The command taught `<type>: <description>` while DartWay's own `CLAUDE.md` says an optional scope is welcome, and its history is `feat(cli):`, `fix(deploy):`, `feat(core)!:`. The toolkit was handing out a rule its own repository does not live by.

## What is added

**A trailing `(#NN)` is not part of the format.** GitHub appends the pull request number on squash-merge, after the fact — so an agent reading `git log` to learn the convention sees a number nobody typed. Reproduce it and the next merge yields two, one meaningless; in a project numbering its tickets they are indistinguishable on sight.

## Mirrors

`toolkit/CLAUDE.md` and `toolkit/README.md` both repeated the ticket-and-CI claim and are corrected; `docs/5-tooling/agent-toolkit.md` described the command by the behaviour being removed. `dartway_cli` is at `0.9.0` on `master` against `0.8.0` on `stable`, so the entry joins that section.

No project literals introduced under `toolkit/`; 225 CLI tests green.

## Left for later

#71 is the sibling worth naming: the navigation rule has no stated exception, so a transition from a tapped notification — which by construction has no context — reads as a violation, and the next agent "fixes" working code. Same shape as this one: a rule written for one world that never asked whether it is in that world. Not in this PR.