### PR TITLE
fix(template): the sheet follows the keyboard instead of arriving before it

### DIFF
--- a/example/dartway_example_flutter/lib/ui_kit/2_frequent/show_app_bottom_sheet_extension.dart
+++ b/example/dartway_example_flutter/lib/ui_kit/2_frequent/show_app_bottom_sheet_extension.dart
@@ -28,47 +28,53 @@ extension ShowAppBottomSheetExtension on BuildContext {
         ),
       ),
       builder: (sheetContext) {
-        return Container(
-          constraints: BoxConstraints.loose(
-            Size(
-              min(MediaQuery.of(sheetContext).size.width, 500),
-              MediaQuery.of(sheetContext).size.height * 0.9 +
-                  MediaQuery.viewInsetsOf(sheetContext).bottom,
-            ),
-          ),
-          child: DecoratedBox(
-            decoration: const BoxDecoration(
-              borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(32),
-                topRight: Radius.circular(32),
+        // Both the height and the bottom padding come from the same smoothed
+        // inset. Leaving either one on the raw `viewInsets` makes the two
+        // halves visibly slide apart, which is worse than the snap this fixes.
+        return AppKeyboardInset(
+          builder: (_, keyboardInset) => Container(
+            constraints: BoxConstraints.loose(
+              Size(
+                min(MediaQuery.of(sheetContext).size.width, 500),
+                MediaQuery.of(sheetContext).size.height * 0.9 + keyboardInset,
               ),
             ),
-            child: Padding(
-              padding: EdgeInsets.fromLTRB(
-                16,
-                16,
-                16,
-                16 +
-                    MediaQuery.viewInsetsOf(sheetContext).bottom +
-                    MediaQuery.paddingOf(sheetContext).bottom,
+            child: DecoratedBox(
+              decoration: const BoxDecoration(
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(32),
+                  topRight: Radius.circular(32),
+                ),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (isWithDragHandle)
-                    const SizedBox(
-                      width: 32,
-                      height: 4,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.all(Radius.circular(100)),
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(
+                  16,
+                  16,
+                  16,
+                  16 +
+                      keyboardInset +
+                      MediaQuery.paddingOf(sheetContext).bottom,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (isWithDragHandle)
+                      const SizedBox(
+                        width: 32,
+                        height: 4,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.all(
+                              Radius.circular(100),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                  const SizedBox(height: 16),
-                  Flexible(fit: FlexFit.loose, child: child),
-                ],
+                    const SizedBox(height: 16),
+                    Flexible(fit: FlexFit.loose, child: child),
+                  ],
+                ),
               ),
             ),
           ),

--- a/example/dartway_example_flutter/lib/ui_kit/ui_kit.dart
+++ b/example/dartway_example_flutter/lib/ui_kit/ui_kit.dart
@@ -34,6 +34,7 @@ part 'theme/app_button.dart';
 part 'theme/app_context.dart';
 part 'theme/app_text.dart';
 part 'theme/app_theme.dart';
+part 'utils/app_keyboard_inset.dart';
 part 'utils/conditional_parent.dart';
 part 'utils/date_labels.dart';
 part 'utils/formatters.dart';

--- a/example/dartway_example_flutter/lib/ui_kit/utils/app_keyboard_inset.dart
+++ b/example/dartway_example_flutter/lib/ui_kit/utils/app_keyboard_inset.dart
@@ -1,0 +1,36 @@
+part of '../ui_kit.dart';
+
+/// A keyboard inset that arrives with the keyboard instead of ahead of it.
+///
+/// The system reports the keyboard as a **step change** in `viewInsets` — on
+/// iOS as two steps, first for the accessory bar above the keyboard and then
+/// for the keyboard itself — while the keyboard actually travels for about
+/// 250 ms. Layout computed straight from the raw inset therefore snaps to its
+/// final geometry while the keyboard is still on its way, and what the user
+/// sees reads as "it blinked and re-opened".
+///
+/// [builder] receives the same inset, travelling at the keyboard's own pace.
+/// Compute *everything* that depends on the keyboard from it — height, bottom
+/// padding, edges. Half the layout left on the raw inset drifts apart from the
+/// other half, and that looks worse than the original snap.
+///
+/// Nothing animates on the first build: with no `begin` the tween starts at its
+/// end value, so a sheet opened over an already-raised keyboard is simply in
+/// place.
+class AppKeyboardInset extends StatelessWidget {
+  const AppKeyboardInset({required this.builder, super.key});
+
+  /// Exactly as long as the keyboard itself travels.
+  static const duration = Duration(milliseconds: 250);
+  static const curve = Curves.easeOut;
+
+  final Widget Function(BuildContext context, double keyboardInset) builder;
+
+  @override
+  Widget build(BuildContext context) => TweenAnimationBuilder<double>(
+    tween: Tween<double>(end: MediaQuery.viewInsetsOf(context).bottom),
+    duration: duration,
+    curve: curve,
+    builder: (context, keyboardInset, _) => builder(context, keyboardInset),
+  );
+}

--- a/template/dartway_starter_flutter/lib/ui_kit/2_frequent/show_app_bottom_sheet_extension.dart
+++ b/template/dartway_starter_flutter/lib/ui_kit/2_frequent/show_app_bottom_sheet_extension.dart
@@ -28,47 +28,53 @@ extension ShowAppBottomSheetExtension on BuildContext {
         ),
       ),
       builder: (sheetContext) {
-        return Container(
-          constraints: BoxConstraints.loose(
-            Size(
-              min(MediaQuery.of(sheetContext).size.width, 500),
-              MediaQuery.of(sheetContext).size.height * 0.9 +
-                  MediaQuery.viewInsetsOf(sheetContext).bottom,
-            ),
-          ),
-          child: DecoratedBox(
-            decoration: const BoxDecoration(
-              borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(32),
-                topRight: Radius.circular(32),
+        // Both the height and the bottom padding come from the same smoothed
+        // inset. Leaving either one on the raw `viewInsets` makes the two
+        // halves visibly slide apart, which is worse than the snap this fixes.
+        return AppKeyboardInset(
+          builder: (_, keyboardInset) => Container(
+            constraints: BoxConstraints.loose(
+              Size(
+                min(MediaQuery.of(sheetContext).size.width, 500),
+                MediaQuery.of(sheetContext).size.height * 0.9 + keyboardInset,
               ),
             ),
-            child: Padding(
-              padding: EdgeInsets.fromLTRB(
-                16,
-                16,
-                16,
-                16 +
-                    MediaQuery.viewInsetsOf(sheetContext).bottom +
-                    MediaQuery.paddingOf(sheetContext).bottom,
+            child: DecoratedBox(
+              decoration: const BoxDecoration(
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(32),
+                  topRight: Radius.circular(32),
+                ),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (isWithDragHandle)
-                    const SizedBox(
-                      width: 32,
-                      height: 4,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.all(Radius.circular(100)),
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(
+                  16,
+                  16,
+                  16,
+                  16 +
+                      keyboardInset +
+                      MediaQuery.paddingOf(sheetContext).bottom,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (isWithDragHandle)
+                      const SizedBox(
+                        width: 32,
+                        height: 4,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.all(
+                              Radius.circular(100),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                  const SizedBox(height: 16),
-                  Flexible(fit: FlexFit.loose, child: child),
-                ],
+                    const SizedBox(height: 16),
+                    Flexible(fit: FlexFit.loose, child: child),
+                  ],
+                ),
               ),
             ),
           ),

--- a/template/dartway_starter_flutter/lib/ui_kit/ui_kit.dart
+++ b/template/dartway_starter_flutter/lib/ui_kit/ui_kit.dart
@@ -33,6 +33,7 @@ part 'theme/app_button.dart';
 part 'theme/app_context.dart';
 part 'theme/app_text.dart';
 part 'theme/app_theme.dart';
+part 'utils/app_keyboard_inset.dart';
 part 'utils/conditional_parent.dart';
 part 'utils/date_labels.dart';
 part 'utils/formatters.dart';

--- a/template/dartway_starter_flutter/lib/ui_kit/utils/app_keyboard_inset.dart
+++ b/template/dartway_starter_flutter/lib/ui_kit/utils/app_keyboard_inset.dart
@@ -1,0 +1,36 @@
+part of '../ui_kit.dart';
+
+/// A keyboard inset that arrives with the keyboard instead of ahead of it.
+///
+/// The system reports the keyboard as a **step change** in `viewInsets` — on
+/// iOS as two steps, first for the accessory bar above the keyboard and then
+/// for the keyboard itself — while the keyboard actually travels for about
+/// 250 ms. Layout computed straight from the raw inset therefore snaps to its
+/// final geometry while the keyboard is still on its way, and what the user
+/// sees reads as "it blinked and re-opened".
+///
+/// [builder] receives the same inset, travelling at the keyboard's own pace.
+/// Compute *everything* that depends on the keyboard from it — height, bottom
+/// padding, edges. Half the layout left on the raw inset drifts apart from the
+/// other half, and that looks worse than the original snap.
+///
+/// Nothing animates on the first build: with no `begin` the tween starts at its
+/// end value, so a sheet opened over an already-raised keyboard is simply in
+/// place.
+class AppKeyboardInset extends StatelessWidget {
+  const AppKeyboardInset({required this.builder, super.key});
+
+  /// Exactly as long as the keyboard itself travels.
+  static const duration = Duration(milliseconds: 250);
+  static const curve = Curves.easeOut;
+
+  final Widget Function(BuildContext context, double keyboardInset) builder;
+
+  @override
+  Widget build(BuildContext context) => TweenAnimationBuilder<double>(
+    tween: Tween<double>(end: MediaQuery.viewInsetsOf(context).bottom),
+    duration: duration,
+    curve: curve,
+    builder: (context, keyboardInset, _) => builder(context, keyboardInset),
+  );
+}

--- a/template/dartway_starter_flutter/test/ui_kit/app_keyboard_inset_test.dart
+++ b/template/dartway_starter_flutter/test/ui_kit/app_keyboard_inset_test.dart
@@ -1,0 +1,168 @@
+import 'package:dartway_starter_flutter/ui_kit/ui_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The keyboard, as a test can state it: a step change in `viewInsets`.
+///
+/// That is how the system reports it — one step, or two on iOS — while the
+/// keyboard itself travels for about 250 ms. Everything here is about the
+/// distance between those two facts.
+Widget _withKeyboard(double inset, Widget child) => MediaQuery(
+  data: MediaQueryData(viewInsets: EdgeInsets.only(bottom: inset)),
+  child: Directionality(textDirection: TextDirection.ltr, child: child),
+);
+
+/// A host for the sheet, which needs a `Navigator` and therefore an app.
+///
+/// The `MediaQuery` goes in through `builder:` and not around `MaterialApp`:
+/// the app installs its own from the view, so one wrapped around it reaches
+/// nothing — and a modal route is built above `home`, so only `builder:` is
+/// seen by both.
+class _SheetHost extends StatefulWidget {
+  const _SheetHost({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_SheetHost> createState() => _SheetHostState();
+}
+
+class _SheetHostState extends State<_SheetHost> {
+  double keyboard = 0;
+
+  void raiseKeyboard(double inset) => setState(() => keyboard = inset);
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+    builder: (context, child) => MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(size: _screen, viewInsets: EdgeInsets.only(bottom: keyboard)),
+      child: child!,
+    ),
+    home: Scaffold(body: widget.child),
+  );
+}
+
+const _screen = Size(400, 800);
+const _raised = 300.0;
+const _sheetPadding = 16.0;
+
+void main() {
+  group('AppKeyboardInset', () {
+    testWidgets('hands a step change over gradually, not at once', (
+      tester,
+    ) async {
+      late double inset;
+      Widget tree(double keyboard) => _withKeyboard(
+        keyboard,
+        AppKeyboardInset(
+          builder: (_, value) {
+            inset = value;
+            return const SizedBox.shrink();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(tree(0));
+      expect(inset, 0);
+
+      await tester.pumpWidget(tree(_raised));
+      await tester.pump(AppKeyboardInset.duration ~/ 2);
+
+      // The point of the widget: halfway through the keyboard's travel the
+      // layout is halfway too, instead of having arrived on the first frame.
+      expect(inset, greaterThan(0));
+      expect(inset, lessThan(_raised));
+
+      await tester.pumpAndSettle();
+      expect(inset, _raised);
+    });
+
+    testWidgets('delivers a keyboard that is already up without animating', (
+      tester,
+    ) async {
+      final delivered = <double>[];
+      await tester.pumpWidget(
+        _withKeyboard(
+          _raised,
+          AppKeyboardInset(
+            builder: (_, value) {
+              delivered.add(value);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // A sheet opened over a raised keyboard must be in place, not slide into
+      // it. The tween has no `begin`, so it starts at its end.
+      expect(delivered, [_raised]);
+    });
+  });
+
+  group('showAppBottomSheet', () {
+    const childKey = Key('sheet-child');
+
+    /// The inset as the sheet's own box and its own padding each report it —
+    /// the two places that used to read `viewInsets` directly.
+    ({double fromHeight, double fromPadding}) insetsInSheet(
+      WidgetTester tester,
+    ) {
+      final box = tester.widget<Container>(
+        find
+            .ancestor(of: find.byKey(childKey), matching: find.byType(Container))
+            .first,
+      );
+      final padding = tester.widget<Padding>(
+        find
+            .ancestor(of: find.byKey(childKey), matching: find.byType(Padding))
+            .first,
+      );
+      return (
+        fromHeight: box.constraints!.maxHeight - _screen.height * 0.9,
+        fromPadding: (padding.padding as EdgeInsets).bottom - _sheetPadding,
+      );
+    }
+
+    testWidgets('moves its height and its padding on one travelling inset', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _SheetHost(
+          child: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => context.showAppBottomSheet(
+                child: const SizedBox(key: childKey, height: 40),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      tester.state<_SheetHostState>(find.byType(_SheetHost)).raiseKeyboard(
+        _raised,
+      );
+      await tester.pump();
+      await tester.pump(AppKeyboardInset.duration ~/ 2);
+
+      final midTravel = insetsInSheet(tester);
+      expect(midTravel.fromPadding, greaterThan(0));
+      expect(midTravel.fromPadding, lessThan(_raised));
+
+      // The half that matters. Either value left on the raw inset arrives a
+      // frame after the tap while the other is still travelling, and the two
+      // halves of the sheet visibly slide apart — worse than the snap this
+      // removes.
+      expect(midTravel.fromHeight, closeTo(midTravel.fromPadding, 0.01));
+
+      await tester.pumpAndSettle();
+      final settled = insetsInSheet(tester);
+      expect(settled.fromPadding, closeTo(_raised, 0.01));
+      expect(settled.fromHeight, closeTo(_raised, 0.01));
+    });
+  });
+}

--- a/toolkit/skills/dartway-ui-kit/SKILL.md
+++ b/toolkit/skills/dartway-ui-kit/SKILL.md
@@ -374,7 +374,7 @@ lib/ui_kit/
   3_special/               // narrow, grouped by feature: pin code, chat bubble
   theme/                   // app_theme.dart, app_text.dart, app_button.dart, app_context.dart
   layout/                  // device_frame_shell.dart
-  utils/                   // conditional_parent.dart, formatters, date labels
+  utils/                   // conditional_parent.dart, app_keyboard_inset.dart, formatters, date labels
 ```
 
 The numbered prefixes keep the kit sorted by usage frequency — the most needed on top.
@@ -385,5 +385,16 @@ The numbered prefixes keep the kit sorted by usage frequency — the most needed
 - Don't breed variants by copy-paste — composition and extensions (see `dartway-clean-code`).
 - Don't put outer `padding`/`margin` inside a component — the parent sets the spacing.
 - Consistency beats visual hacks.
+- **Anything that depends on the keyboard is computed from the smoothed inset, never from
+  `MediaQuery.viewInsets` directly.** The system reports the keyboard as a step change — on iOS as
+  two steps, the accessory bar and then the keyboard — while it actually travels for about 250 ms, so
+  layout taken from the raw inset lands in its final geometry before the keyboard gets there and
+  reads as "it blinked and re-opened". `AppKeyboardInset` in `utils/` hands the same inset over at
+  the keyboard's own pace; `showAppBottomSheet` computes both its height and its bottom padding
+  through it. Compute **everything** keyboard-dependent from it: half the layout left on the raw
+  inset visibly slides apart from the other half, which is worse than the snap. It does not look like
+  a violation on the page — a raw `viewInsets` in layout is exactly what the Flutter documentation
+  suggests — so the check is a grep: `grep -rn 'viewInsetsOf' lib/ui_kit`, and any hit outside the
+  smoother itself is one.
 - Tempted by a "client-specific hack" inside a framework widget — that's a signal that an extension
   point is missing. Introduce it in the kit, don't fork `dartway_flutter`.


### PR DESCRIPTION
## What

`showAppBottomSheet` in the template UI kit computed both of its keyboard-dependent values straight from `MediaQuery.viewInsetsOf` — the height constraint and the bottom padding. The system reports the keyboard as a **step change** (on iOS as two steps: the accessory bar, then the keyboard), while the keyboard actually travels for about 250 ms. The sheet therefore snapped to its final geometry while the keyboard was still on its way, and that reads as "it blinked and re-opened".

Noticed on a login form — template code, untouched by the project. Anyone who opens any sheet with a text field on it sees it.

## The change

`AppKeyboardInset` (`ui_kit/utils/`) hands the same inset over at the keyboard's own pace, and the sheet computes both values through it. Ten lines of widget; the discipline that comes with them is the part that matters, and it is now stated in `dartway-ui-kit`:

> Anything that depends on the keyboard is computed from the smoothed inset, never from `MediaQuery.viewInsets` directly. […] Compute **everything** keyboard-dependent from it: half the layout left on the raw inset visibly slides apart from the other half, which is worse than the snap.

Nothing animates on the first build — with no `begin` the tween starts at its end, so a sheet opened over an already-raised keyboard is in place rather than sliding into it.

## The rule is guarded, not just stated

`template/…/test/ui_kit/app_keyboard_inset_test.dart` raises the keyboard, stops halfway through its travel, and asserts that both values are mid-flight **and equal to each other** — which is exactly the half-converted mistake the rule warns about.

Checked by breaking it: with the padding put back on the raw inset the test goes red mid-travel — `Expected: a value less than <300.0>, Actual: <300.0>` — while the height is still at 205.

Green as it stands: `flutter analyze` clean in both packages, `flutter test` 16 passing in `template/`, 8 in `example/`.

## Mirrors

- `template/` and `example/` both get the widget and the rewritten sheet — the two kits carry byte-identical copies of that file and would otherwise drift;
- `toolkit/skills/dartway-ui-kit` — the rule, the structure listing, and the greppable drift check (`grep -rn 'viewInsetsOf' lib/ui_kit`, any hit outside the smoother);
- no package changed, so no version moves and no `CHANGELOG` entry is due;
- **`docs/` deliberately untouched**: no page describes the sheet or the keyboard, and the kit pages argue why the framework ships no design. A paragraph there would be padding, and the skill is where an agent actually reads this.

The test lives in `template/` only — that is the skeleton every project receives, so that is where the guarantee ships. `example/`'s copy of the kit rides on the same assertion by being identical, which is checked by reading the diff rather than by a second suite.

Closes #151