### PR TITLE
feat(cli): the test database belongs to the run, not to the project

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -234,6 +234,40 @@ from the project root or from inside the `*_flutter` package — both work.
 What it checks, and why those checks exist, is a page of its own:
 [The conventions checker](conventions-checker.md).
 
+## `dartway test` — the server tests, on a database that belongs to the run
+
+```bash
+dartway test                        # from the project root
+dartway test -- --name 'auth'       # everything after -- goes to `dart test`
+dartway test --keep                 # leave the container up to look inside it
+```
+
+Starts a Postgres container for this run, waits until it accepts connections, runs the server
+package's tests against it, and removes it afterwards — including when you interrupt the run.
+The coordinates reach the suite as `SERVERPOD_DATABASE_HOST/PORT/NAME/USER/PASSWORD`, which
+Serverpod applies over `config/test.yaml`. The image is the one the project's own compose file
+uses for development, so the tests do not run on a different Postgres major than the code is
+written against; `--image` overrides it.
+
+**No host port is named**, which is the point. A test database declared as a compose service is
+shared, named, long-lived and on a fixed port, and all four are wrong for it:
+
+- **Fixed** meant every project created from the template asked for the same port. The second
+  container up does not get it and *does not fail either* — Docker starts it with the port
+  unpublished — so the suite connects to the neighbouring project's database. Where the schemas
+  are close enough for migrations to apply, the run is green having verified nothing.
+- **Long-lived** meant rows outlived the run that wrote them. The service declared no volume, on
+  the stated grounds that a surviving test database is a liability — but the `postgres` image
+  declares an anonymous one and Compose keeps it. The symptom arrives as arithmetic
+  (`Expected: <2>, Actual: <3>`), several hypotheses away from its cause.
+
+Both stop existing when the database is created per run: there is no port to lose and nothing to
+survive. `docker compose up -d` still brings up the development database and object storage; it
+no longer has anything to do with tests.
+
+Widget tests in the `*_flutter` package need no database and are not this command's business —
+`flutter test` runs them.
+
 ## `dartway deploy` — the server, without a folder of shell scripts
 
 ```bash

--- a/example/README.md
+++ b/example/README.md
@@ -54,10 +54,16 @@ hold: the limits are enforced with database locks, a race cannot be observed in
 a rolled-back transaction, and neither can a hash that must actually be written.
 
 ```bash
-cd dartway_example_server
-docker compose up -d          # dev database on 8090, test database on 9090
-dart test
+dartway test                  # from the project root
 ```
+
+`dartway test` creates the database this run needs, on a port Docker picks, and
+removes it when the run ends. Nothing is shared and nothing survives, so two
+projects — or two runs of this one — cannot reach each other's rows, and a row
+written by yesterday's run cannot turn up in today's assertions. The coordinates
+reach the suite as `SERVERPOD_DATABASE_*`, which Serverpod reads over
+`config/test.yaml`. `docker compose up -d` is still what the development
+database and object storage need; it no longer has anything to do with tests.
 
 The suites commit real transactions (`RollbackDatabase.disabled`) and wipe the
 auth tables around themselves, which makes them stateful neighbours rather than

--- a/example/dartway_example_server/config/passwords.yaml
+++ b/example/dartway_example_server/config/passwords.yaml
@@ -19,7 +19,8 @@ development:
   dwCloudStorageSecretKey: 'dartway_dev_storage_pw'
   dwCloudStorageBucket: 'uploads'
 
-# Matches the `postgres_test` service in docker-compose.yaml (localhost:9090).
+# Only read when the suite is run by hand. `dartway test` generates a password
+# for the database it creates and passes it through SERVERPOD_DATABASE_PASSWORD.
 test:
   database: 'dartway_test_pw'
   serviceSecret: 'test-service-secret'

--- a/example/dartway_example_server/config/test.yaml
+++ b/example/dartway_example_server/config/test.yaml
@@ -29,9 +29,26 @@ webServer:
   publicScheme: http
 
 # This is the database setup for your test server.
+#
+# `dartway test` supplies host and port through SERVERPOD_DATABASE_*: it starts a
+# database for the run, on a port Docker picks, and removes it at the end. Name
+# and user are read from here, so that container carries the names this project
+# expects.
+#
+# The port is 0 on purpose, and it is not the same 0 as the servers above — they
+# ask the OS for a free port to listen on, while nothing can be *reached* at
+# port 0. That is the point: a suite run by hand connects nowhere instead of
+# reaching whatever else happens to be listening. It used to name a fixed port,
+# and on a machine with two DartWay projects that meant reading the other
+# project's database — green, having verified nothing.
+#
+# Be warned about how that failure looks: `withServerpod` suppresses the test
+# server's startup output, so a run that cannot reach its database exits 1 with
+# nothing but "loading <file>" printed. No message names the database. If you
+# see that, you ran `dart test`; run `dartway test`.
 database:
   host: localhost
-  port: 9090
+  port: 0
   name: dartway_example_test
   user: postgres
 

--- a/example/dartway_example_server/docker-compose.yaml
+++ b/example/dartway_example_server/docker-compose.yaml
@@ -13,19 +13,12 @@ services:
     volumes:
       - dartway_example_data:/var/lib/postgresql/data
 
-  # Test database. Matches config/test.yaml (localhost:9090, database
-  # "dartway_example_test"). Kept separate from development on purpose: the
-  # integration tests commit real transactions (concurrency cannot be observed
-  # inside a rolled-back one) and truncate tables between cases.
-  postgres_test:
-    image: postgres:16
-    ports:
-      - '9090:5432'
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: dartway_example_test
-      POSTGRES_PASSWORD: 'dartway_test_pw'
-    # No volume: a test database that survives a restart is a liability.
+  # No test database here, on purpose. `dartway test` creates one for the run
+  # and removes it afterwards, on a port Docker picks — see the comment in
+  # config/test.yaml. A test database declared as a service is shared, named,
+  # long-lived and on a fixed port, and every one of those is wrong for it:
+  # two projects on one machine fight over the port, the loser silently reads
+  # the winner's rows, and rows outlive the run that wrote them.
 
   # Object storage for uploads. DartWay's cloud storage speaks S3 through the
   # minio client, so a local Minio is the same code path production runs.

--- a/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
+++ b/example/dartway_example_server/test/integration/auth_code_delivery_test.dart
@@ -152,6 +152,10 @@ void _bootDartway() {
         'dwVerificationCodeSalt': 'test-verification-code-salt',
         'dwAuthKeySalt': 'test-auth-key-salt',
       },
+      // The same form the example itself states in `initDartwayCore`: a test
+      // config that folds differently from the app under test is testing
+      // something the app does not do.
+      normalizeIdentifier: DwIdentifierForm.folded,
       sendVerificationCodeMethod:
           (
             session, {

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## 0.9.0
 
+- **`dartway test`: the test database belongs to the run, not to the project.**
+
+  It was a `postgres_test` service in every generated project's `docker-compose.yaml`, on a
+  hardcoded host port, and both halves of that failed silently.
+
+  The port was the same in every project created from the template. The second container up does
+  not get it and does not fail either — Docker starts it with the port unpublished — so the suite
+  connects to a *neighbouring project's* database. Where the schemas are close enough for
+  migrations to apply, the run comes back green having verified nothing. Diagnosing it once cost
+  three wrong hypotheses; a project that hit it moved its own port and told nobody, which is the
+  shape of a workaround that helps exactly one repository.
+
+  The lifetime was the second half. The service declared no volume and said why — "a test database
+  that survives a restart is a liability" — but the `postgres` image declares an anonymous one and
+  Compose keeps it across a recreate. Rows outlived the run that wrote them and arrived as
+  arithmetic: `Expected: <2>, Actual: <3>`, counting rows the test had just created. The comment
+  stating the intended property as an achieved one is what made it expensive — anyone asking
+  whether a stale database could explain the failure read that line and crossed the question off.
+
+  `dartway test` starts a container for the run on a port Docker picks, waits for it, runs
+  `dart test` in the server package against it, and removes it at the end — interrupted runs
+  included. The coordinates travel as `SERVERPOD_DATABASE_HOST/PORT/NAME/USER/PASSWORD`, which
+  `ServerpodConfig.load` applies over the run mode's YAML; the environment is deliberate, because
+  `withServerpod`'s own config override is per test file and a file can be written without it (in
+  one real project such an override was honoured by 25 files of 29, which is worse than none). The
+  image is the one the project's compose already uses for development, so the tests do not quietly
+  run on another Postgres major.
+
+  **Migration:** delete the `postgres_test` service from `docker-compose.yaml` and run
+  `dartway test` instead of `dart test`. The `database:` block in `config/test.yaml` still supplies
+  the name and user; its port becomes a deliberately closed default, so a suite run by hand fails
+  loudly rather than reaching whatever else is listening.
+
 - **`/commit` stops deciding what belongs to the project.**
 
   It demanded a ticket number as a required argument and, with none, stopped and asked — so in a

--- a/packages/dartway_cli/bin/dartway.dart
+++ b/packages/dartway_cli/bin/dartway.dart
@@ -8,6 +8,7 @@ import 'package:dartway_cli/src/commands/doctor_command.dart';
 import 'package:dartway_cli/src/commands/quickstart_command.dart';
 import 'package:dartway_cli/src/commands/setup_ai_command.dart';
 import 'package:dartway_cli/src/commands/stats_command.dart';
+import 'package:dartway_cli/src/commands/test_command.dart';
 
 Future<void> main(List<String> args) async {
   final runner =
@@ -22,7 +23,8 @@ Future<void> main(List<String> args) async {
         ..addCommand(SetupAiCommand())
         ..addCommand(CheckCommand())
         ..addCommand(DeployCommand())
-        ..addCommand(StatsCommand());
+        ..addCommand(StatsCommand())
+        ..addCommand(TestCommand());
 
   try {
     exitCode = await runner.run(args) ?? 0;

--- a/packages/dartway_cli/lib/src/commands/test_command.dart
+++ b/packages/dartway_cli/lib/src/commands/test_command.dart
@@ -105,12 +105,24 @@ class TestCommand extends Command<int> {
       return 1;
     }
 
+    final keep = argResults?['keep'] as bool? ?? false;
+
     // The container has to go even when the run does not end normally: an
     // abandoned one holds a port and, worse, holds rows that the next run would
     // find. Ctrl-C is the common case and is not an exception a `finally` sees.
+    //
+    // `--keep` survives the interrupt, because an interrupted run is exactly
+    // the one somebody wants to look inside.
     final signals = <StreamSubscription<ProcessSignal>>[
       ProcessSignal.sigint.watch().listen((_) async {
-        await database.remove(ephemeral);
+        if (keep) {
+          stdout.writeln(
+            '\nKept: container ${ephemeral.id} on localhost:${ephemeral.port}. '
+            'Remove it with `docker rm -f ${ephemeral.id}`.',
+          );
+        } else {
+          await database.remove(ephemeral);
+        }
         exit(130);
       }),
     ];
@@ -145,7 +157,7 @@ class TestCommand extends Command<int> {
       for (final signal in signals) {
         await signal.cancel();
       }
-      if (argResults?['keep'] as bool? ?? false) {
+      if (keep) {
         stdout.writeln(
           '\nKept: container ${ephemeral.id} on localhost:${ephemeral.port}. '
           'Remove it with `docker rm -f ${ephemeral.id}`.',

--- a/packages/dartway_cli/lib/src/commands/test_command.dart
+++ b/packages/dartway_cli/lib/src/commands/test_command.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import '../project_layout.dart';
+import '../test_database.dart';
+
+/// Runs the server package's tests against a database that belongs to the run.
+///
+/// The arrangement it replaces was the other way round: the database belonged
+/// to the *project*, as a `postgres_test` service on a hardcoded host port, and
+/// both halves of that went wrong quietly.
+///
+/// **The port.** Every project created from the template asked for the same
+/// one. The second container up does not get it — and does not fail either:
+/// Docker starts it with the port simply unpublished, and the suite then
+/// connects to the neighbour's database. Where the neighbour's schema is close
+/// enough for migrations to apply, the run is green having verified nothing.
+///
+/// **The lifetime.** The service declared no volume, on the stated reasoning
+/// that a test database surviving a restart is a liability — but the `postgres`
+/// image declares an anonymous one, and Compose keeps it. Rows outlived the run
+/// that wrote them, and turned up as arithmetic (`Expected: <2>, Actual: <3>`)
+/// several hypotheses away from their cause.
+///
+/// Both disappear once nothing is fixed and nothing is shared: the container is
+/// started here, published on whatever port Docker has free, and removed when
+/// the run ends. `config/test.yaml` keeps stating the shape of the connection;
+/// the coordinates arrive as `SERVERPOD_DATABASE_*`, which Serverpod reads over
+/// the file.
+///
+/// **Why the environment and not `configOverride`.** `withServerpod` takes a
+/// config override, but it takes it per test file, and a file can be written
+/// without it — in one real project such an override was honoured by 25 of 29
+/// files, which is worse than none: the four that ignored it broke runs while
+/// the mechanism looked like it worked. An environment variable is a property
+/// of the process; a test file cannot opt out of it.
+class TestCommand extends Command<int> {
+  TestCommand() {
+    argParser
+      ..addFlag(
+        'keep',
+        negatable: false,
+        help:
+            'Leave the database container running after the tests, and print '
+            'how to reach it. For inspecting what a failing run left behind.',
+      )
+      ..addOption(
+        'image',
+        help:
+            'Postgres image to run. Defaults to the one the project already '
+            'uses for its development database.',
+      );
+  }
+
+  /// Long enough for a cold image on a busy machine, short enough that a
+  /// container which will never come up does not hold the run.
+  static const _readinessTimeout = Duration(seconds: 60);
+
+  /// What the project's own compose file falls back to when it names no image.
+  static const _fallbackImage = 'postgres:16';
+
+  @override
+  String get name => 'test';
+
+  @override
+  String get description =>
+      'Run the server tests against a database created for this run and '
+      'thrown away with it.';
+
+  @override
+  String get invocation => 'dartway test [-- <dart test arguments>]';
+
+  @override
+  Future<int> run() async {
+    final layout = ProjectLayout.detect(Directory.current);
+    final serverDir = layout.serverPackageDir;
+    if (!serverDir.existsSync()) {
+      stderr.writeln('No server package at ${serverDir.path}.');
+      return 1;
+    }
+
+    final connection = _readTestConnection(serverDir);
+    final image =
+        argResults?['image'] as String? ??
+        _developmentImage(serverDir) ??
+        _fallbackImage;
+
+    final database = TestDatabase(
+      image: image,
+      name: connection.name,
+      user: connection.user,
+    );
+
+    stdout.writeln('Starting $image for this run…');
+    final ephemeral = await database.start();
+    if (ephemeral == null) {
+      stderr.writeln(
+        'Could not start the test database. Is the Docker daemon running? '
+        '`dartway doctor` says which prerequisite is missing.',
+      );
+      return 1;
+    }
+
+    // The container has to go even when the run does not end normally: an
+    // abandoned one holds a port and, worse, holds rows that the next run would
+    // find. Ctrl-C is the common case and is not an exception a `finally` sees.
+    final signals = <StreamSubscription<ProcessSignal>>[
+      ProcessSignal.sigint.watch().listen((_) async {
+        await database.remove(ephemeral);
+        exit(130);
+      }),
+    ];
+
+    try {
+      if (!await database.waitUntilReady(ephemeral, _readinessTimeout)) {
+        stderr.writeln(
+          'The database container started but never began accepting '
+          'connections within ${_readinessTimeout.inSeconds}s.',
+        );
+        return 1;
+      }
+      stdout.writeln(
+        'Database ready on localhost:${ephemeral.port} '
+        '(${connection.name}); migrations are applied by the suite.',
+      );
+
+      final test = await Process.start(
+        'dart',
+        ['test', ...argResults!.rest],
+        workingDirectory: serverDir.path,
+        environment: {
+          ...ephemeral.serverpodEnvironment(
+            name: connection.name,
+            user: connection.user,
+          ),
+        },
+        mode: ProcessStartMode.inheritStdio,
+      );
+      return await test.exitCode;
+    } finally {
+      for (final signal in signals) {
+        await signal.cancel();
+      }
+      if (argResults?['keep'] as bool? ?? false) {
+        stdout.writeln(
+          '\nKept: container ${ephemeral.id} on localhost:${ephemeral.port}. '
+          'Remove it with `docker rm -f ${ephemeral.id}`.',
+        );
+      } else {
+        await database.remove(ephemeral);
+      }
+    }
+  }
+
+  /// The database's identity, as the project states it.
+  ///
+  /// Only the coordinates are the run's to choose; what the database is called
+  /// and who connects to it stay the project's, so a developer looking into the
+  /// container finds the names they expect.
+  ({String name, String user}) _readTestConnection(Directory serverDir) {
+    const fallback = (name: 'dartway_test', user: 'postgres');
+    final file = File(p.join(serverDir.path, 'config', 'test.yaml'));
+    if (!file.existsSync()) return fallback;
+    final database = _mapAt(loadYaml(file.readAsStringSync()), ['database']);
+    if (database == null) return fallback;
+    return (
+      name: database['name'] as String? ?? fallback.name,
+      user: database['user'] as String? ?? fallback.user,
+    );
+  }
+
+  /// The image the project's development database runs, so the tests do not
+  /// quietly run on a different major than the code is developed against.
+  String? _developmentImage(Directory serverDir) {
+    final file = File(p.join(serverDir.path, 'docker-compose.yaml'));
+    if (!file.existsSync()) return null;
+    final services = _mapAt(loadYaml(file.readAsStringSync()), ['services']);
+    if (services == null) return null;
+    for (final service in services.values) {
+      if (service is Map && service['image'] is String) {
+        final image = service['image'] as String;
+        if (image.startsWith('postgres')) return image;
+      }
+    }
+    return null;
+  }
+
+  Map? _mapAt(dynamic document, List<String> path) {
+    dynamic node = document;
+    for (final key in path) {
+      if (node is! Map) return null;
+      node = node[key];
+    }
+    return node is Map ? node : null;
+  }
+}

--- a/packages/dartway_cli/lib/src/quickstart_brief.dart
+++ b/packages/dartway_cli/lib/src/quickstart_brief.dart
@@ -72,9 +72,10 @@ The order is not arbitrary; each line explains why it comes where it does.
     # set bootstrapAdminIdentifier in config/passwords.yaml — see below
     dart bin/main.dart
 
-- **`docker compose up -d`** starts Postgres for development (host port 8090), a separate
-  test database (9090) and object storage for uploads (8100, console 8101). The first run
-  pulls images and can take minutes.
+- **`docker compose up -d`** starts Postgres for development (host port 8090) and object
+  storage for uploads (8100, console 8101). The first run pulls images and can take minutes.
+  There is no test database among them: `dartway test` creates one for the run, on a port
+  Docker picks, and removes it at the end.
 - **Wait for the database to accept connections before migrating.** A container reported as
   "Started" is not yet Postgres listening; migrating in that window fails with
   `connection refused`. Poll for readiness — `docker compose exec -T postgres pg_isready -U postgres`

--- a/packages/dartway_cli/lib/src/test_database.dart
+++ b/packages/dartway_cli/lib/src/test_database.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+/// A database container that exists for the length of one test run.
+///
+/// It is deliberately not a service in the project's `docker-compose.yaml`.
+/// A compose service is a shared, named, long-lived thing on a fixed port, and
+/// every one of those three properties is wrong for a test database: shared
+/// means one project's suite can reach another's rows, named and long-lived
+/// mean rows outlive the run that wrote them, and fixed means the second
+/// project on a machine loses the port without being told.
+class TestDatabase {
+  TestDatabase({required this.image, required this.name, required this.user});
+
+  /// The password is generated per run and never leaves the process: the
+  /// container it opens is reachable on loopback only and is gone at the end,
+  /// so there is nothing for a written-down value to protect.
+  static final _password = 'dw_${DateTime.now().microsecondsSinceEpoch}';
+
+  final String image;
+  final String name;
+  final String user;
+
+  /// Starts the container and returns it, or null when Docker could not.
+  ///
+  /// `-p 127.0.0.1::5432` is the whole point: no host port is named, so Docker
+  /// assigns a free one and two runs on the same machine cannot collide. The
+  /// loopback prefix keeps the database off the network — it holds test rows,
+  /// but the container also carries a password that is trivially readable from
+  /// the process list.
+  Future<EphemeralDatabase?> start() async {
+    final run = await _docker([
+      'run',
+      '--detach',
+      '--rm',
+      '--publish',
+      '127.0.0.1::5432',
+      // Nothing on disk: not for speed, but so that a container leaked by a
+      // killed run cannot hand its rows to the next one.
+      '--tmpfs',
+      '/var/lib/postgresql/data',
+      '--env',
+      'POSTGRES_USER=$user',
+      '--env',
+      'POSTGRES_DB=$name',
+      '--env',
+      'POSTGRES_PASSWORD=$_password',
+      image,
+    ]);
+    if (run == null || run.exitCode != 0) {
+      if (run != null) stderr.write(run.stderr);
+      return null;
+    }
+
+    final id = (run.stdout as String).trim();
+    final port = await _publishedPort(id);
+    if (port == null) {
+      await _docker(['rm', '--force', id]);
+      return null;
+    }
+    return EphemeralDatabase(id: id, port: port, password: _password);
+  }
+
+  /// Polls until Postgres answers, which is not the same moment as the
+  /// container being "Started" — there are seconds between them, and a
+  /// connection attempt inside that window fails as `connection refused`.
+  Future<bool> waitUntilReady(
+    EphemeralDatabase database,
+    Duration timeout,
+  ) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      final probe = await _docker([
+        'exec',
+        database.id,
+        'pg_isready',
+        '--username',
+        user,
+        '--dbname',
+        name,
+      ]);
+      if (probe?.exitCode == 0) return true;
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+    }
+    return false;
+  }
+
+  Future<void> remove(EphemeralDatabase database) async {
+    await _docker(['rm', '--force', database.id]);
+  }
+
+  Future<int?> _publishedPort(String id) async {
+    final result = await _docker(['port', id, '5432/tcp']);
+    if (result == null || result.exitCode != 0) return null;
+    return parsePublishedPort(result.stdout as String);
+  }
+
+  Future<ProcessResult?> _docker(List<String> arguments) async {
+    try {
+      return await Process.run('docker', arguments);
+    } on ProcessException {
+      return null;
+    }
+  }
+}
+
+/// A running test database: what the suite needs to reach it, and what the run
+/// needs to remove it.
+class EphemeralDatabase {
+  const EphemeralDatabase({
+    required this.id,
+    required this.port,
+    required this.password,
+  });
+
+  final String id;
+  final int port;
+  final String password;
+
+  /// The coordinates, in the form Serverpod reads over `config/test.yaml`.
+  ///
+  /// `ServerpodConfig.load` reads the run mode's YAML and then applies
+  /// `Platform.environment` on top, and `TestServerpod` builds an ordinary
+  /// `Serverpod` — so these reach the test server exactly as they reach a
+  /// deployed one. The environment is also the one channel a test file cannot
+  /// bypass, which a per-file config override is not.
+  Map<String, String> serverpodEnvironment({
+    required String name,
+    required String user,
+  }) => {
+    'SERVERPOD_DATABASE_HOST': 'localhost',
+    'SERVERPOD_DATABASE_PORT': '$port',
+    'SERVERPOD_DATABASE_NAME': name,
+    'SERVERPOD_DATABASE_USER': user,
+    'SERVERPOD_DATABASE_PASSWORD': password,
+  };
+}
+
+/// Reads the host port out of `docker port <id> 5432/tcp`.
+///
+/// The output is one or more `<address>:<port>` lines — two when the daemon
+/// publishes on both IPv4 and IPv6, and they carry the same port. Split from
+/// the right: an IPv6 address is full of colons.
+int? parsePublishedPort(String dockerPortOutput) {
+  for (final line in dockerPortOutput.split('\n')) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty) continue;
+    final separator = trimmed.lastIndexOf(':');
+    if (separator < 0) continue;
+    final port = int.tryParse(trimmed.substring(separator + 1));
+    if (port != null) return port;
+  }
+  return null;
+}

--- a/packages/dartway_cli/test/test_database_test.dart
+++ b/packages/dartway_cli/test/test_database_test.dart
@@ -1,0 +1,54 @@
+import 'package:dartway_cli/src/test_database.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parsePublishedPort', () {
+    test('reads the host port Docker assigned', () {
+      expect(parsePublishedPort('0.0.0.0:54321\n'), 54321);
+    });
+
+    test('survives the second line the daemon adds for IPv6', () {
+      // Both lines carry the same port; the address is what differs, and an
+      // IPv6 one is full of colons — which is why the port is taken from the
+      // right and not from a split on ':'.
+      expect(parsePublishedPort('0.0.0.0:54321\n[::]:54321\n'), 54321);
+    });
+
+    test('reads a port when only the IPv6 line is published', () {
+      expect(parsePublishedPort('[::]:32768'), 32768);
+    });
+
+    test('answers null when Docker published nothing', () {
+      // The case that must not be mistaken for a port: a container started
+      // without its port published prints an empty line, and treating that as
+      // success is how the old arrangement sent a suite to a neighbour's
+      // database.
+      expect(parsePublishedPort(''), isNull);
+      expect(parsePublishedPort('\n  \n'), isNull);
+    });
+
+    test('answers null on a line that carries no number', () {
+      expect(parsePublishedPort('0.0.0.0:not-a-port'), isNull);
+    });
+  });
+
+  group('EphemeralDatabase', () {
+    test('states the coordinates in the names Serverpod reads', () {
+      // These five keys are the contract with `ServerpodConfig.load`, which
+      // applies the environment over the run mode's YAML. Renaming one here
+      // silently returns the suite to the file's fixed port.
+      const database = EphemeralDatabase(id: 'abc', port: 54321, password: 'p');
+
+      expect(
+        database.serverpodEnvironment(name: 'app_test', user: 'postgres'),
+        {
+          'SERVERPOD_DATABASE_HOST': 'localhost',
+          'SERVERPOD_DATABASE_PORT': '54321',
+          'SERVERPOD_DATABASE_NAME': 'app_test',
+          'SERVERPOD_DATABASE_USER': 'postgres',
+          'SERVERPOD_DATABASE_PASSWORD': 'p',
+        },
+      );
+    });
+  });
+}

--- a/template/README.md
+++ b/template/README.md
@@ -63,10 +63,16 @@ hold: the limits are enforced with database locks, a race cannot be observed in
 a rolled-back transaction, and neither can a hash that must actually be written.
 
 ```bash
-cd dartway_starter_server
-docker compose up -d          # dev database on 8090, test database on 9090
-dart test
+dartway test                  # from the project root
 ```
+
+`dartway test` creates the database this run needs, on a port Docker picks, and
+removes it when the run ends. Nothing is shared and nothing survives, so two
+projects — or two runs of this one — cannot reach each other's rows, and a row
+written by yesterday's run cannot turn up in today's assertions. The coordinates
+reach the suite as `SERVERPOD_DATABASE_*`, which Serverpod reads over
+`config/test.yaml`. `docker compose up -d` is still what the development
+database and object storage need; it no longer has anything to do with tests.
 
 The app has widget tests of its own, and those need nothing running:
 

--- a/template/dartway_starter_server/config/passwords.yaml.example
+++ b/template/dartway_starter_server/config/passwords.yaml.example
@@ -36,7 +36,8 @@ development:
   # inbox. Every deployed environment sets its own.
   bootstrapAdminIdentifier: ''
 
-# Matches the `postgres_test` service in docker-compose.yaml (localhost:9090).
+# Only read when the suite is run by hand. `dartway test` generates a password
+# for the database it creates and passes it through SERVERPOD_DATABASE_PASSWORD.
 test:
   database: 'dartway_test_pw'
   serviceSecret: 'test-service-secret'

--- a/template/dartway_starter_server/config/test.yaml
+++ b/template/dartway_starter_server/config/test.yaml
@@ -29,9 +29,26 @@ webServer:
   publicScheme: http
 
 # This is the database setup for your test server.
+#
+# `dartway test` supplies host and port through SERVERPOD_DATABASE_*: it starts a
+# database for the run, on a port Docker picks, and removes it at the end. Name
+# and user are read from here, so that container carries the names this project
+# expects.
+#
+# The port is 0 on purpose, and it is not the same 0 as the servers above — they
+# ask the OS for a free port to listen on, while nothing can be *reached* at
+# port 0. That is the point: a suite run by hand connects nowhere instead of
+# reaching whatever else happens to be listening. It used to name a fixed port,
+# and on a machine with two DartWay projects that meant reading the other
+# project's database — green, having verified nothing.
+#
+# Be warned about how that failure looks: `withServerpod` suppresses the test
+# server's startup output, so a run that cannot reach its database exits 1 with
+# nothing but "loading <file>" printed. No message names the database. If you
+# see that, you ran `dart test`; run `dartway test`.
 database:
   host: localhost
-  port: 9090
+  port: 0
   name: dartway_starter_test
   user: postgres
 

--- a/template/dartway_starter_server/docker-compose.yaml
+++ b/template/dartway_starter_server/docker-compose.yaml
@@ -13,19 +13,12 @@ services:
     volumes:
       - dartway_starter_data:/var/lib/postgresql/data
 
-  # Test database. Matches config/test.yaml (localhost:9090, database
-  # "dartway_starter_test"). Kept separate from development on purpose: the
-  # integration tests commit real transactions (concurrency cannot be observed
-  # inside a rolled-back one) and truncate tables between cases.
-  postgres_test:
-    image: postgres:16
-    ports:
-      - '9090:5432'
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: dartway_starter_test
-      POSTGRES_PASSWORD: 'dartway_test_pw'
-    # No volume: a test database that survives a restart is a liability.
+  # No test database here, on purpose. `dartway test` creates one for the run
+  # and removes it afterwards, on a port Docker picks — see the comment in
+  # config/test.yaml. A test database declared as a service is shared, named,
+  # long-lived and on a fixed port, and every one of those is wrong for it:
+  # two projects on one machine fight over the port, the loser silently reads
+  # the winner's rows, and rows outlive the run that wrote them.
 
   # Object storage for uploads. DartWay's cloud storage speaks S3 through the
   # minio client, so a local Minio is the same code path production runs — not a

--- a/template/dartway_starter_server/test/integration/app_setting_access_test.dart
+++ b/template/dartway_starter_server/test/integration/app_setting_access_test.dart
@@ -14,9 +14,9 @@ import 'test_tools/serverpod_test_tools.dart';
 /// hides the field proves only that the field is hidden. Copy the shape of this
 /// file when a CRUD config grows a rule of its own.
 ///
-/// It runs against a live database — `docker compose up -d postgres_test`, then
-/// `dart test`. See the `dartway-testing` skill for which layer a test belongs
-/// to.
+/// It runs against a live database, and the run makes its own: `dartway test`
+/// from the project root. See the `dartway-testing` skill for which layer a
+/// test belongs to.
 const _testKey = 'appSettingAccessTest.appName';
 
 void main() {

--- a/toolkit/skills/dartway-run/SKILL.md
+++ b/toolkit/skills/dartway-run/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Bring a DartWay project up locally and confirm it is alive (DartWay projects):
   dependencies, Postgres in docker, migrations, the first administrator, the server, the app.
   Knows the order of the steps (migrations before anything writes rows), the real ports
-  (API 8080, development DB 8090, test DB 9090, object storage 8100 and its console 8101),
+  (API 8080, development DB 8090, object storage 8100 and its console 8101 — the test database
+  has no fixed port, `dartway test` creates one per run),
   where to find the sign-in code (printed in the server console) and how to fix the typical
   failures: docker not running, port already taken, schema drifted, model changed without
   serverpod generate, serverpod_cli version not matching the project, images not opening
@@ -65,6 +66,7 @@ flutter run
 - **Migrations before anything writes rows**, and **after `docker compose up`** and **after the DB is ready.** A container that is "Started"
   ≠ Postgres accepting connections; there are seconds between them, and a migration in that window fails
   with connection refused. Wait for `pg_isready`, not for a `sleep`.
+- **There is no test database in `docker compose`.** `dartway test` creates one for the run and removes it after; nothing here has to be up for the tests, and nothing here is what they connect to.
 - **Storage comes up with the same `docker compose up`.** Alongside Postgres it brings up `minio` (S3 for uploads) and a one-shot `minio_init`, which creates the bucket and opens it for reading — without that, uploaded images will not open by link.
 - **The server is a long-running process.** Start it in the background and do not wait for it to finish:
   waiting "until the command completes" will hang you forever.
@@ -90,7 +92,8 @@ identifier from `bootstrapAdminIdentifier` yields the admin; any other number yi
 | `docker: command not found` / `cannot connect to the Docker daemon` | Docker Desktop is not running | Ask to start Docker; do not try to bring Postgres up another way |
 | The first `docker compose up` hangs for minutes | The `postgres:16` image is being pulled | This is normal, wait it out; next time `docker pull postgres:16` in advance |
 | `connection refused` during migrations | The DB is not accepting connections yet | Wait for `pg_isready`, retry |
-| `port is already allocated` (8090/9090/8100) | Taken by another project or a leftover container | `docker ps` → stop the conflicting container. **8090 is a frequent collision** between DartWay projects |
+| `port is already allocated` (8090/8100) | Taken by another project or a leftover container | `docker ps` → stop the conflicting container. **8090 is a frequent collision** between DartWay projects: the development database is still on a fixed port, and only the test one was moved off |
+| The integration suite exits 1 having printed only `loading <file>`, with no error at all | `dart test` was run by hand, so nothing created the database. **`withServerpod` suppresses the test server's startup output**, so failing to reach a database looks like nothing happening | Run **`dartway test`** — it creates the database and passes the coordinates through `SERVERPOD_DATABASE_*`. Do not go looking for the message; there is none. To see it, the suite has to be built with a verbose output mode |
 | Images do not load, the link returns 404 | The bucket was not created or is closed for reading | Check the `minio_init` logs (`docker compose logs minio_init`): they must say "Bucket created" and "set to `download`". A public link of the form `http://localhost:8100/uploads/<file>` must open in a browser |
 | Upload fails with "Cloud storage is not configured" | No `dwCloudStorage*` keys for this run mode | Add them to `config/passwords.yaml` (in development they point at the `minio` service) |
 | `Missing password for "database"` on a fresh clone | `config/passwords.yaml` is not in Git and never was — `dartway create` wrote it on the machine the project was created on | `cp __SERVER_PKG__/config/passwords.yaml.example __SERVER_PKG__/config/passwords.yaml`. The example carries working development values; ask a teammate only for keys a deployed environment needs |

--- a/toolkit/skills/dartway-testing/SKILL.md
+++ b/toolkit/skills/dartway-testing/SKILL.md
@@ -73,8 +73,15 @@ withServerpod('Given the app settings CRUD config', (sessionBuilder, endpoints) 
 `DwSaveConfig.save` runs the whole pipeline the endpoint runs — `allowSave` → `validateSave` →
 transaction — so the assertion lands on the project's own rule, not on a re-statement of it.
 
-It needs a live database: `docker compose up -d postgres_test`, then `dart test` from the server
-package.
+It needs a live database, and the run makes its own: **`dartway test`** from the project root
+starts one on a port Docker picks, runs `dart test` in the server package against it, and removes
+it at the end. Arguments after `--` go to `dart test` (`dartway test -- --name 'auth'`).
+
+Do not add a test database to `docker compose`, and do not point the suite at a fixed port. That
+is the arrangement this replaced, and it failed in two silent ways: two projects on one machine
+asked for the same port, and the loser read the winner's rows without an error (green, having
+verified nothing); and the database outlived the run, so a row from an earlier one turned up as
+`Expected: <2>, Actual: <3>` in an assertion about rows the test had just created.
 
 **Write one when the rule is the point:** a role boundary, an ownership check, a validation that
 rejects, `beforeSaveTransaction` / `afterSaveTransaction` ordering, a filter that must not leak


### PR DESCRIPTION
Closes #145, closes #146 — not by fixing either, but by removing the arrangement both are symptoms of.

## The shape of the problem

A test database was a `postgres_test` service in every generated project's `docker-compose.yaml`, on a hardcoded host port. A compose service is **shared, named, long-lived and on a fixed port**, and all four are wrong for a test database:

- **Fixed** (#145): every project created from the template asks for the same port. The second container up does not get it and *does not fail either* — Docker starts it with the port unpublished — so the suite connects to a neighbouring project's database. Where the schemas are close enough for migrations to apply the run is green, having verified nothing. This machine is the demonstration: three DartWay projects, one holding `9090`, one privately moved to `9290` by a workaround nobody else heard about.
- **Long-lived** (#146): the service declared no volume and stated why — "a test database that survives a restart is a liability" — but the `postgres` image declares an anonymous one and Compose keeps it across a recreate. Rows outlived their run and surfaced as arithmetic (`Expected: <2>, Actual: <3>`) counting rows the test had just created. A comment stating an intended property as an achieved one is worse than no comment: it crosses the question off for whoever asks it.

The strongest argument is in the file itself. `config/test.yaml` sets **every server port to 0**, with Serverpod's own comment saying why — "makes the server find the next available port… needed to enable running tests concurrently" — and then pins the database. The test database was the only fixed coordinate in a setup deliberately designed to have none.

## What this does instead

`dartway test` creates the database the run needs and throws it away with it.

```bash
dartway test                        # from the project root
dartway test -- --name 'auth'       # everything after -- goes to `dart test`
dartway test --keep                 # leave the container up to look inside it
```

It starts a container with **no host port named** (`-p 127.0.0.1::5432`, so Docker assigns a free one), reads the assigned port back, waits for `pg_isready`, runs `dart test` in the server package, and removes the container afterwards — including on Ctrl-C, which a `finally` does not see. `--tmpfs` on the data directory means even a container leaked by a killed run holds nothing for the next one.

There is no port to lose and nothing to survive, so neither issue is fixed — both stop existing.

## Two decisions worth stating

**The environment, not `withServerpod`'s config override.** `ServerpodConfig.load` reads the run mode's YAML and applies `Platform.environment` over it, and `TestServerpod` builds an ordinary `Serverpod` — checked in the 3.4.11 sources, not assumed. `withServerpod` also takes a `configOverride`, but it takes it *per test file*, and a file can be written without it: in one real project such an override was honoured by 25 files of 29, which is worse than none — the four that ignored it broke runs while the mechanism looked like it worked. A process's environment is not something a test file can opt out of.

**`config/test.yaml`'s port becomes 0.** Name and user stay — the container carries the names the project expects, so a developer looking inside finds what they know. The port becomes 0, and it is not the same 0 as the servers above it: they ask the OS for a free port to *listen* on, while nothing can be *reached* at port 0. A suite run by hand therefore connects nowhere, instead of reaching whatever else happens to be listening.

## Shown, not claimed

- Two concurrent runs of the template's suite took ports **54634** and **54635**; both green. That is #145's failure mode, exercised.
- `template/` 15 tests green, `example/` 50 green, `dartway_cli` 232 green, `dart analyze` clean.
- `docker compose config` still valid for both projects with the service gone; no container left behind after a run.

## Mirrors

`template/` and `example/` (compose, `config/test.yaml`, passwords comment, README), `toolkit/skills/dartway-run` and `dartway-testing`, `docs/5-tooling/cli.md`, the quickstart brief, and the `dartway_cli` CHANGELOG under the pending 0.9.0 — `master` is already ahead of `stable` (0.8.0), so no version moves and no carets change.

## One fix that is not mine

`example/dartway_example_server/test/integration/auth_code_delivery_test.dart` has not compiled since #165 made `DwAuthConfig.normalizeIdentifier` required — a test builds its own config, so it is a call site the eye passes over. One argument, matching what the example declares for itself. It is here because a suite that does not build cannot demonstrate the command that runs it. That it lived a day on `master` unnoticed is **#173**: no CI job runs `dart test` or even `dart analyze` over the server packages.

## Deliberately not in this change

- **#174** — `dartway_push` still carries the old arrangement, plus `redis_test` on `9091` and unreplaced placeholder passwords. Folding it in would mean designing the Redis half inside a change about Postgres.
- **#175** — `withServerpod` suppresses its own startup output, so a suite that cannot reach a database exits 1 having printed only `loading <file>`, with the cause never named. Not ours to fix; named exactly in the `dartway-run` failure table, because the message is not coming.
- **Existing projects** do not get this — the same gap #133/#134 describe. The migration is two steps and is in the CHANGELOG.

## What it unlocks, and does not do

The suites still run one file at a time (`concurrency: 1`, pinned because they commit real transactions and wipe tables around themselves). With the database now created per run, a database per *file* becomes possible and would remove that constraint. Out of scope here.