### PR TITLE
fix(template): the build context admits the shared package, so the skeleton builds again

### DIFF
--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 0.9.0
 
+- **A created project can be deployed again: the skeleton's build context admits its shared package.**
+
+  Both images failed at their first `COPY`. `template/.dockerignore` denies everything and re-admits
+  packages by name, and it never named `dartway_starter_shared` — which both Dockerfiles copy. So
+  every project `dartway create` produced carried a skeleton that could not be built:
+  `"/dartway_starter_shared": not found`.
+
+  The package list lives in three places — the pubspec's `path:` dependencies, the `COPY` lines, and
+  that allow-list — and the test guarding this class compared only the first two. It now reads the
+  allow-list as well. **Nothing to do in an existing project** unless its own `.dockerignore` was
+  written before its shared package existed, in which case the two `!<name>/` lines are the fix.
+
 - **`dartway test`: the test database belongs to the run, not to the project.**
 
   It was a `postgres_test` service in every generated project's `docker-compose.yaml`, on a

--- a/packages/dartway_cli/test/template_build_context_test.dart
+++ b/packages/dartway_cli/test/template_build_context_test.dart
@@ -47,6 +47,33 @@ void main() {
         match.group(1)!,
   };
 
+  /// Top-level directories `.dockerignore` lets back into the build context.
+  ///
+  /// The file denies everything and re-admits packages by name, so it is a
+  /// third copy of the same list — after the pubspec's `path:` dependencies and
+  /// the Dockerfile's `COPY` lines. It is the copy that broke: the shared
+  /// package was wired into both halves and copied by both images, and stayed
+  /// out of the context because nothing here admitted it.
+  ///
+  /// Returns null when the file does not deny by default, in which case there
+  /// is nothing to admit and no way to get this wrong.
+  Set<String>? admittedByIgnoreFile(File ignoreFile) {
+    if (!ignoreFile.existsSync()) return null;
+    final lines = ignoreFile
+        .readAsLinesSync()
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty && !line.startsWith('#'));
+    var deniesEverything = false;
+    final admitted = <String>{};
+    for (final line in lines) {
+      if (line == '**' || line == '*') deniesEverything = true;
+      if (RegExp(r'^!([a-z0-9_]+)/').firstMatch(line) case final match?) {
+        admitted.add(match.group(1)!);
+      }
+    }
+    return deniesEverything ? admitted : null;
+  }
+
   /// Sibling packages [pubspec] depends on by path.
   Set<String> pathDepsOf(File pubspec) {
     final document = loadYaml(pubspec.readAsStringSync());
@@ -61,7 +88,10 @@ void main() {
     };
   }
 
-  for (final package in const ['dartway_starter_server', 'dartway_starter_flutter']) {
+  for (final package in const [
+    'dartway_starter_server',
+    'dartway_starter_flutter',
+  ]) {
     test('$package: the image copies every package it depends on', () {
       final dockerfile = File(p.join(template.path, package, 'Dockerfile'));
       final pubspec = File(p.join(template.path, package, 'pubspec.yaml'));
@@ -97,6 +127,40 @@ void main() {
             'path dependencies missing from the build context of $package. '
             'Add a COPY line for each, or pub inside the image fails on a '
             'directory that is not there.',
+      );
+    });
+  }
+
+  for (final package in const [
+    'dartway_starter_server',
+    'dartway_starter_flutter',
+  ]) {
+    test('$package: .dockerignore admits everything the image copies', () {
+      // A COPY line and an allow-list entry are two statements of one fact, and
+      // they fail in opposite directions. A missing COPY fails as `pub get`
+      // exit code 66, three layers deep; a missing allow-list entry fails
+      // earlier and louder — `"/<package>": not found` at the COPY itself —
+      // but only for whoever builds the image, and nothing in this repository
+      // builds them. `web-compile.yml` compiles the Flutter web target from
+      // source; the images are built by `dartway deploy`, on a server, by a
+      // person. So the loud failure went unheard for as long as nobody
+      // deployed a fresh skeleton.
+      final admitted = admittedByIgnoreFile(
+        File(p.join(template.path, '.dockerignore')),
+      );
+      if (admitted == null) return;
+
+      final copied = copiedBy(
+        File(p.join(template.path, package, 'Dockerfile')),
+      );
+
+      expect(
+        copied.difference(admitted),
+        isEmpty,
+        reason:
+            'the $package image copies directories that .dockerignore keeps '
+            'out of the build context. The COPY fails outright — add the pair '
+            'of `!<name>/` and `!<name>/**` lines for each.',
       );
     });
   }

--- a/template/.dockerignore
+++ b/template/.dockerignore
@@ -13,6 +13,8 @@
 !dartway_starter_flutter/**
 !dartway_starter_server/
 !dartway_starter_server/**
+!dartway_starter_shared/
+!dartway_starter_shared/**
 
 **/.dart_tool/
 **/build/


### PR DESCRIPTION
Closes #177.

## What was broken

Both of the skeleton's images failed at their first `COPY`. `template/.dockerignore` denies everything and re-admits packages by name, and `dartway_starter_shared` was never among them — while both Dockerfiles copy it. Reproduced with a throwaway Dockerfile so no base image is involved:

```
$ printf 'FROM alpine:latest\nCOPY dartway_starter_shared/ x/\n' > probe.Dockerfile
$ docker build -f probe.Dockerfile template/
ERROR: failed to solve: failed to compute cache key:
  "/dartway_starter_shared": not found
```

Every project `dartway create` produced carried a skeleton that could not be deployed. Two lines fix that.

## Why it was not noticed, which is the part worth fixing

The package list exists **three** times: the pubspec's `path:` dependencies, the `COPY` lines in each Dockerfile, and this allow-list. #139 shipped the shared package, updated the first two, and added `template_build_context_test.dart` to hold the second against the first. The break landed in the third, which nothing read — so the test that exists for exactly this class of error watched it happen.

The ignore file argues for its own direction, and the argument is sound:

> Deny everything, then admit the packages the Dockerfiles copy. A new package is invisible to a build until it is listed here, **which is the failure mode worth having: loud at build time rather than silently shipped.**

It is loud. But **nothing in this repository builds these images**: `web-compile.yml` compiles the Flutter web target from source, and the images are built only by `dartway deploy`, on a server, by a person. A failure that is loud in a room nobody enters is a silent failure. That general shape is #173.

## The change

1. `template/.dockerignore` admits `dartway_starter_shared`.
2. `template_build_context_test.dart` reads the allow-list as a third copy: everything a Dockerfile copies must be admitted. The check returns early when a `.dockerignore` does not deny by default — then there is nothing to admit and no way to get it wrong.

The two failure directions are worth keeping apart, and the new test's comment says so: a missing `COPY` fails as `pub get` exit code 66 three layers deep, while a missing allow-list entry fails at the `COPY` itself. Different depths, same cause, and only one of them had a guard.

## Shown both ways

- the reproduction above now builds;
- removing the two new lines turns the extended test red on **both** images — `Expected: empty / Actual: Set:['dartway_starter_shared']`;
- `dartway_cli`: 234 tests green, `dart analyze` clean.

## Not covered, deliberately

`example/` has the same three copies and they agree today — it has no shared package, and per `CLAUDE.md` the CLI no longer hands the example out. The template is what ships, so the guard is where the skeleton is. Collapsing the three lists into one rather than comparing them is #158's territory, and after this it is worth re-reading: that issue is written about two copies, and there are three.