### PR TITLE
feat(cli): deploy check reads the package graph, so a broken image is found before the deploy

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -302,15 +302,30 @@ data volume under a different name than the rendered configuration would use, it
 instead of starting the stack — Compose would otherwise create an empty database beside the real one
 and serve it, which looks like a successful deploy of an application that has lost everything.
 
-`check` changes nothing and answers whether a deployment would work. Fourteen assertions on the
-working copy, eight over the network — including that every `publicHost` resolves to the deployment
-host, which is the mistake that otherwise burns a Let's Encrypt rate limit before anyone notices.
-With the server unreachable it degrades: the SSH check fails, the rest report as skipped.
+`check` changes nothing and answers whether a deployment would work. One set of assertions runs over
+the working copy and another over the network — including that every `publicHost` resolves to the
+deployment host, which is the mistake that otherwise burns a Let's Encrypt rate limit before anyone
+notices. With the server unreachable it degrades: the SSH check fails, the rest report as skipped.
 
-Two of the local assertions are about whether the images build at all. The rendered compose file builds both of them
+**The current list is what the command prints**, each with its stable id, and it is not counted here
+on purpose: a number maintained by hand is a second copy of something the code already knows, and
+this one had already fallen a check behind before anybody noticed.
+
+Three of the local assertions are about whether the images build at all. The rendered compose file builds both of them
 from the project root — `<project>_server/Dockerfile` and `<project>_flutter/Dockerfile`, named by
 convention rather than configured — so a project that never wrote one fails on the server, after the
-checkout has already moved. The other is the shape of the server image's `ENTRYPOINT`: migrations
+checkout has already moved.
+
+The second reads the package graph, because the images copy package directories **by name** and the
+name has to be written down in two more places than the pubspec: the `COPY` lines, and the
+allow-list of a `.dockerignore` that denies by default. A package missing from the first fails inside
+the image as `pub get` exit code 66, three layers from the cause; missing from the second, the `COPY`
+fails outright. Neither is visible in a checkout — there the path resolves — so the two facts meet
+the first time somebody deploys, by which point the change is several merges back. `COPY . .` is
+read as taking everything and passes; `COPY --from=<stage>` is not a context read and does not count
+as one.
+
+The third is the shape of the server image's `ENTRYPOINT`: migrations
 run as `docker compose run backend … --apply-migrations`, and shell form ignores appended arguments,
 so an unnoticed shell form turns every migration into an ordinary server start that reports success.
 The template ships the canonical pair; `server_entrypoint` remains the escape for an image you did
@@ -461,7 +476,7 @@ The rest are the flags worth knowing before you need them:
 | Subcommand | Flag | What it is for |
 |---|---|---|
 | `setup` | `--dry-run` | Print the rendered `docker-compose.yml` and `nginx.conf`, and what would be uploaded beside them, without touching the server. The way to review a template change |
-| `check` | `--local` | Skip DNS and the server; assert over the working copy only. The form that needs no SSH key and no host yet — the fourteen working-copy assertions still run, the eight network ones report as skipped |
+| `check` | `--local` | Skip DNS and the server; assert over the working copy only. The form that needs no SSH key and no host yet — every working-copy assertion still runs, the network ones report as skipped |
 | `run` | `--dry-run` | Print the plan and change nothing |
 | `run` | `--skip-git-update` | Deploy what is already checked out on the server, without fetching. For a rebuild of the same commit — and the flag to suspect when a deploy "did not pick up" a push |
 | `secret push` | `--dry-run` | Report what would be sent, send nothing |

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 0.9.0
 
+- **`deploy check` reads the package graph, so a project learns before the deploy that an image cannot build.**
+
+  Images are built from the project root and copy package directories **by name**, which writes the
+  package list down twice more than the pubspec does: the `COPY` lines, and the allow-list of a
+  `.dockerignore` that denies by default. A package missing from the first fails inside the image as
+  `pub get` exit code 66 — three layers from the cause, naming neither the Dockerfile nor the package.
+  Missing from the second, the `COPY` fails outright.
+
+  **Neither is visible in a checkout**, and that is structural rather than unlucky: repository checks
+  compile inside the working copy, where every path resolves, and the images are built only by
+  `dartway deploy`, on the server. So a project stays green and cannot ship, and the two facts do not
+  meet until somebody deploys — for the project that hit this, hours after the package landed and
+  several merges on top of it.
+
+  The new local check, `docker-context-packages`, compares both pairs and errors. `COPY . .` is read
+  as taking the whole context and passes; `COPY --from=<stage>` reads an earlier stage rather than the
+  context and is not counted as a declaration. The reading it uses is the one the template's own
+  regression test uses, moved into `lib/` so there is one parser rather than two.
+
 - **A created project can be deployed again: the skeleton's build context admits its shared package.**
 
   Both images failed at their first `COPY`. `template/.dockerignore` denies everything and re-admits

--- a/packages/dartway_cli/lib/src/build_context.dart
+++ b/packages/dartway_cli/lib/src/build_context.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// Reading the build context out of a project's own files.
+///
+/// Images are built from the project root and name package directories one by
+/// one, so the package graph ends up written down three times: as `path:`
+/// dependencies in a pubspec, as `COPY` lines in a Dockerfile, and as the
+/// allow-list of a `.dockerignore` that denies by default. The three have to
+/// agree, and nothing makes them.
+///
+/// Both failures are silent where people look. A directory a Dockerfile never
+/// names does not enter the context, and `pub get` inside the image fails as
+/// exit code 66 — three layers from the cause, pointing at neither the
+/// Dockerfile nor the package. A directory the ignore file never admits fails
+/// louder, at the `COPY` itself, but only for whoever builds the image; a
+/// checkout compiles fine either way, because inside it the path resolves.
+///
+/// This lives in `lib/` rather than in a test because both readers need it: the
+/// template's own regression test, and `dartway deploy check`, which is the
+/// only place a project that has left the skeleton behind gets told.
+
+/// What a Dockerfile takes from the build context.
+typedef BuildContextReads = ({
+  /// `COPY . .` — the whole context, so every directory is satisfied and
+  /// nothing can be missing from it.
+  bool wholeContext,
+
+  /// Top-level directories named one by one.
+  Set<String> directories,
+});
+
+/// The directories [dockerfile] copies out of the build context.
+///
+/// `COPY --from=<stage>` is excluded deliberately: it reads an earlier stage's
+/// filesystem, not the context, so counting it would let a multi-stage file
+/// claim directories that were never sent to the daemon.
+BuildContextReads readsOf(File dockerfile) {
+  final directories = <String>{};
+  var wholeContext = false;
+
+  for (final line in dockerfile.readAsLinesSync()) {
+    final copy = RegExp(r'^\s*COPY\s+(.*)$').firstMatch(line);
+    if (copy == null) continue;
+
+    final arguments = copy
+        .group(1)!
+        .split(RegExp(r'\s+'))
+        .where((argument) => argument.isNotEmpty)
+        .toList();
+    if (arguments.any((argument) => argument.startsWith('--from='))) continue;
+
+    final sources = arguments
+        .where((argument) => !argument.startsWith('--'))
+        .toList();
+    // The last argument is the destination; everything before it is a source.
+    if (sources.length < 2) continue;
+    for (final source in sources.sublist(0, sources.length - 1)) {
+      if (source == '.' || source == './') {
+        wholeContext = true;
+        continue;
+      }
+      if (RegExp(r'^([a-z0-9_]+)/').firstMatch(source) case final match?) {
+        directories.add(match.group(1)!);
+      }
+    }
+  }
+
+  return (wholeContext: wholeContext, directories: directories);
+}
+
+/// Top-level directories a `.dockerignore` lets back into the context.
+///
+/// Returns null when the file is absent or does not deny by default — then
+/// everything is in the context already and there is nothing to admit.
+Set<String>? admittedBy(File ignoreFile) {
+  if (!ignoreFile.existsSync()) return null;
+
+  var deniesEverything = false;
+  final admitted = <String>{};
+  for (final raw in ignoreFile.readAsLinesSync()) {
+    final line = raw.trim();
+    if (line.isEmpty || line.startsWith('#')) continue;
+    if (line == '**' || line == '*') deniesEverything = true;
+    if (RegExp(r'^!([a-z0-9_]+)/').firstMatch(line) case final match?) {
+      admitted.add(match.group(1)!);
+    }
+  }
+  return deniesEverything ? admitted : null;
+}
+
+/// Sibling packages [pubspec] depends on by path, by directory name.
+Set<String> pathDependenciesOf(File pubspec) {
+  if (!pubspec.existsSync()) return const {};
+  final document = loadYaml(pubspec.readAsStringSync());
+  final dependencies = document is YamlMap ? document['dependencies'] : null;
+  if (dependencies is! YamlMap) return const {};
+  return {
+    for (final entry in dependencies.entries)
+      if (entry.value is YamlMap && (entry.value as YamlMap)['path'] != null)
+        entry.key.toString(),
+  };
+}
+
+/// Every sibling package an image for [package] has to carry, transitively.
+///
+/// Transitive because the graph is: the client is a path dependency of the
+/// Flutter package, and whatever the client pulls in by path has to be in the
+/// context too. A check that stopped at the first level would pass the case it
+/// exists for.
+Set<String> packagesNeededBy(Directory projectRoot, String package) {
+  final pending = <String>{
+    ...pathDependenciesOf(
+      File(p.join(projectRoot.path, package, 'pubspec.yaml')),
+    ),
+  };
+  final needed = <String>{};
+  while (pending.isNotEmpty) {
+    final name = pending.first;
+    pending.remove(name);
+    if (!needed.add(name)) continue;
+    pending.addAll(
+      pathDependenciesOf(File(p.join(projectRoot.path, name, 'pubspec.yaml'))),
+    );
+  }
+  return needed;
+}
+
+/// Everything wrong with the build context of [packages], as sentences.
+///
+/// Empty means every package reaches every image that needs it. Pure over the
+/// files it reads, so the rule is testable without standing up a deployment.
+List<String> buildContextProblems({
+  required Directory projectRoot,
+  required Iterable<String> packages,
+}) {
+  final admitted = admittedBy(File(p.join(projectRoot.path, '.dockerignore')));
+  final problems = <String>[];
+
+  for (final package in packages) {
+    final dockerfile = File(p.join(projectRoot.path, package, 'Dockerfile'));
+    if (!dockerfile.existsSync()) continue;
+
+    final reads = readsOf(dockerfile);
+    final needed = packagesNeededBy(projectRoot, package)..add(package);
+
+    // `COPY . .` takes the whole context, so nothing the Dockerfile names can
+    // be missing — it names nothing. What the ignore file admits still decides
+    // what "the whole context" contains, so that half is checked either way.
+    if (!reads.wholeContext) {
+      final uncopied = (needed.difference(reads.directories)).toList()..sort();
+      if (uncopied.isNotEmpty) {
+        problems.add(
+          '$package/Dockerfile does not copy ${uncopied.join(', ')}',
+        );
+      }
+    }
+
+    if (admitted != null) {
+      final wanted = reads.wholeContext ? needed : reads.directories;
+      final excluded = (wanted.difference(admitted)).toList()..sort();
+      if (excluded.isNotEmpty) {
+        problems.add(
+          '.dockerignore keeps ${excluded.join(', ')} out of the '
+          '$package build context',
+        );
+      }
+    }
+  }
+
+  return problems;
+}

--- a/packages/dartway_cli/lib/src/deploy/deploy_check.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_check.dart
@@ -453,9 +453,6 @@ Future<DwDeployVerdict> _checkPasswordsCoverEnvironment(
   );
 }
 
-/// The compose file names two Dockerfiles by convention rather than by
-/// configuration, so a project that never wrote one fails at build time on the
-/// server — after the checkout has already moved.
 /// The package graph, as the Dockerfiles and the ignore file each restate it.
 ///
 /// Two comparisons, because the graph is written down three times and the pairs
@@ -489,6 +486,9 @@ Future<DwDeployVerdict> _checkBuildContextPackages(
   );
 }
 
+/// The compose file names two Dockerfiles by convention rather than by
+/// configuration, so a project that never wrote one fails at build time on the
+/// server — after the checkout has already moved.
 Future<DwDeployVerdict> _checkDockerfiles(DwDeployContext context) async {
   final missing = [
     for (final package in [context.serverPackage, context.flutterPackage])

--- a/packages/dartway_cli/lib/src/deploy/deploy_check.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_check.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
+import '../build_context.dart';
 import '../checker/dw_check_type.dart';
 import 'deploy_target.dart';
 import 'nginx_upstreams.dart';
@@ -205,6 +206,18 @@ const List<DwDeployCheck> dwLocalDeployChecks = [
     stage: DwDeployCheckStage.local,
     severity: DwCheckSeverity.error,
     evaluate: _checkDockerfiles,
+  ),
+  DwDeployCheck(
+    id: 'docker-context-packages',
+    title: 'Each image copies every package it depends on',
+    stage: DwDeployCheckStage.local,
+    // Error, and not a warning like "docker-context" next to it: that one
+    // judges how much is sent to the daemon, this one whether the build can
+    // succeed at all. A package missing from the context is not a deploy that
+    // ships too much — it is a deploy that cannot happen, discovered on the
+    // server.
+    severity: DwCheckSeverity.error,
+    evaluate: _checkBuildContextPackages,
   ),
   DwDeployCheck(
     id: 'dockerfile-entrypoint-form',
@@ -443,6 +456,39 @@ Future<DwDeployVerdict> _checkPasswordsCoverEnvironment(
 /// The compose file names two Dockerfiles by convention rather than by
 /// configuration, so a project that never wrote one fails at build time on the
 /// server — after the checkout has already moved.
+/// The package graph, as the Dockerfiles and the ignore file each restate it.
+///
+/// Two comparisons, because the graph is written down three times and the pairs
+/// fail differently. A package a Dockerfile never copies fails as `pub get`
+/// exit code 66, three layers down. A package the ignore file never admits
+/// fails at the `COPY` itself — louder, but still only on the machine that
+/// builds the image, which is the server.
+///
+/// **Neither is visible in a checkout**, which is why this is a deploy check
+/// and not something the repository's own tests could ever catch: they compile
+/// inside the working copy, where every path resolves. The two facts meet the
+/// first time somebody deploys, and by then the change is several merges back.
+Future<DwDeployVerdict> _checkBuildContextPackages(
+  DwDeployContext context,
+) async {
+  final problems = buildContextProblems(
+    projectRoot: context.projectRoot,
+    packages: [context.serverPackage, context.flutterPackage],
+  );
+  if (problems.isEmpty) {
+    return const DwDeployVerdict.pass('every package reaches the image');
+  }
+  return DwDeployVerdict.fail(
+    problems.join('; '),
+    fix:
+        'Add a `COPY <package>/ <package>/` line for each package the image '
+        'needs, and — if the project has a `.dockerignore` that denies by '
+        'default — the matching `!<package>/` and `!<package>/**` lines. '
+        'Without both, `pub get` inside the image fails as exit code 66, or '
+        'the COPY fails outright, and neither happens until a deploy.',
+  );
+}
+
 Future<DwDeployVerdict> _checkDockerfiles(DwDeployContext context) async {
   final missing = [
     for (final package in [context.serverPackage, context.flutterPackage])

--- a/packages/dartway_cli/test/build_context_test.dart
+++ b/packages/dartway_cli/test/build_context_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/build_context.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory root;
+
+  setUp(() => root = Directory.systemTemp.createTempSync('dw_context_'));
+  tearDown(() => root.deleteSync(recursive: true));
+
+  void write(String path, String content) {
+    final file = File(p.join(root.path, path));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  /// A package that depends on [dependencies] by path.
+  void package(String name, {List<String> dependencies = const []}) {
+    write(
+      '$name/pubspec.yaml',
+      [
+        'name: $name',
+        if (dependencies.isNotEmpty) 'dependencies:',
+        for (final dependency in dependencies)
+          '  $dependency:\n    path: ../$dependency',
+      ].join('\n'),
+    );
+  }
+
+  group('readsOf', () {
+    test('names the directories a Dockerfile takes from the context', () {
+      write('app/Dockerfile', '''
+FROM dart:stable AS build
+COPY shared/ shared/
+COPY app/ app/
+''');
+      final reads = readsOf(File(p.join(root.path, 'app', 'Dockerfile')));
+      expect(reads.directories, {'shared', 'app'});
+      expect(reads.wholeContext, isFalse);
+    });
+
+    test('reads `COPY . .` as the whole context, not as a parse failure', () {
+      // Named in the issue: a Dockerfile that takes everything satisfies every
+      // package, and must not be reported as one that names nothing.
+      write('app/Dockerfile', 'FROM alpine\nCOPY . .\n');
+      final reads = readsOf(File(p.join(root.path, 'app', 'Dockerfile')));
+      expect(reads.wholeContext, isTrue);
+      expect(reads.directories, isEmpty);
+    });
+
+    test('does not count a copy from an earlier stage', () {
+      // Also named in the issue. `--from` reads a stage's filesystem, not the
+      // context; counting it would let a multi-stage file claim directories
+      // that were never sent to the daemon.
+      write('app/Dockerfile', '''
+FROM dart:stable AS build
+COPY app/ app/
+FROM alpine
+COPY --from=build /workspace/shared/ shared/
+COPY --from=build /server /app/server
+''');
+      final reads = readsOf(File(p.join(root.path, 'app', 'Dockerfile')));
+      expect(reads.directories, {'app'});
+    });
+
+    test('survives flags before the source and several sources at once', () {
+      write('app/Dockerfile', 'FROM alpine\nCOPY --chown=1:1 a/ b/ dest/\n');
+      expect(
+        readsOf(File(p.join(root.path, 'app', 'Dockerfile'))).directories,
+        {'a', 'b'},
+      );
+    });
+  });
+
+  group('admittedBy', () {
+    test('lists what a deny-by-default ignore file lets back in', () {
+      write('.dockerignore', '# a comment\n**\n!app/\n!app/**\n!shared/\n');
+      expect(admittedBy(File(p.join(root.path, '.dockerignore'))), {
+        'app',
+        'shared',
+      });
+    });
+
+    test('answers null when the file does not deny by default', () {
+      // Then everything is in the context already: there is nothing to admit
+      // and no way to get this wrong, so the check has nothing to say.
+      write('.dockerignore', '**/.dart_tool/\n**/build/\n');
+      expect(admittedBy(File(p.join(root.path, '.dockerignore'))), isNull);
+    });
+
+    test('answers null when there is no ignore file', () {
+      expect(admittedBy(File(p.join(root.path, '.dockerignore'))), isNull);
+    });
+  });
+
+  group('packagesNeededBy', () {
+    test('follows path dependencies through', () {
+      // The real shape: the Flutter package depends on the client, and the
+      // client pulls in shared. A check that stopped at the first level would
+      // pass the case it exists for.
+      package('app', dependencies: ['client']);
+      package('client', dependencies: ['shared']);
+      package('shared');
+      expect(packagesNeededBy(root, 'app'), {'client', 'shared'});
+    });
+
+    test('does not loop on a cycle', () {
+      package('a', dependencies: ['b']);
+      package('b', dependencies: ['a']);
+      expect(packagesNeededBy(root, 'a'), {'a', 'b'});
+    });
+  });
+
+  group('buildContextProblems', () {
+    setUp(() {
+      package('server', dependencies: ['shared']);
+      package('shared');
+    });
+
+    test('says nothing when every package reaches the image', () {
+      write(
+        'server/Dockerfile',
+        'FROM alpine\nCOPY shared/ shared/\nCOPY server/ server/\n',
+      );
+      write(
+        '.dockerignore',
+        '**\n!server/\n!server/**\n!shared/\n!shared/**\n',
+      );
+      expect(
+        buildContextProblems(projectRoot: root, packages: ['server']),
+        isEmpty,
+      );
+    });
+
+    test('names a dependency the Dockerfile never copies', () {
+      write('server/Dockerfile', 'FROM alpine\nCOPY server/ server/\n');
+      expect(buildContextProblems(projectRoot: root, packages: ['server']), [
+        'server/Dockerfile does not copy shared',
+      ]);
+    });
+
+    test('names a directory the ignore file keeps out', () {
+      // The failure that shipped: both Dockerfiles copied the shared package
+      // and the ignore file never admitted it, so the COPY failed outright —
+      // on the server, at deploy time, and nowhere else.
+      write(
+        'server/Dockerfile',
+        'FROM alpine\nCOPY shared/ shared/\nCOPY server/ server/\n',
+      );
+      write('.dockerignore', '**\n!server/\n!server/**\n');
+      expect(buildContextProblems(projectRoot: root, packages: ['server']), [
+        '.dockerignore keeps shared out of the server build context',
+      ]);
+    });
+
+    test('a whole-context copy still answers to the ignore file', () {
+      // `COPY . .` cannot miss a package, but the context it copies is still
+      // only what the ignore file admitted.
+      write('server/Dockerfile', 'FROM alpine\nCOPY . .\n');
+      write('.dockerignore', '**\n!server/\n!server/**\n');
+      expect(buildContextProblems(projectRoot: root, packages: ['server']), [
+        '.dockerignore keeps shared out of the server build context',
+      ]);
+    });
+
+    test('a whole-context copy with nothing denied is simply fine', () {
+      write('server/Dockerfile', 'FROM alpine\nCOPY . .\n');
+      expect(
+        buildContextProblems(projectRoot: root, packages: ['server']),
+        isEmpty,
+      );
+    });
+
+    test('a package with no Dockerfile is not this check\'s business', () {
+      expect(
+        buildContextProblems(projectRoot: root, packages: ['shared']),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/packages/dartway_cli/test/template_build_context_test.dart
+++ b/packages/dartway_cli/test/template_build_context_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:dartway_cli/src/build_context.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
@@ -39,65 +40,15 @@ void main() {
     }
   }();
 
-  /// Package directories a Dockerfile copies into its context.
-  Set<String> copiedBy(File dockerfile) => {
-    for (final line in dockerfile.readAsLinesSync())
-      if (RegExp(r'^\s*COPY\s+([a-z0-9_]+)/\s').firstMatch(line)
-          case final match?)
-        match.group(1)!,
-  };
-
-  /// Top-level directories `.dockerignore` lets back into the build context.
-  ///
-  /// The file denies everything and re-admits packages by name, so it is a
-  /// third copy of the same list — after the pubspec's `path:` dependencies and
-  /// the Dockerfile's `COPY` lines. It is the copy that broke: the shared
-  /// package was wired into both halves and copied by both images, and stayed
-  /// out of the context because nothing here admitted it.
-  ///
-  /// Returns null when the file does not deny by default, in which case there
-  /// is nothing to admit and no way to get this wrong.
-  Set<String>? admittedByIgnoreFile(File ignoreFile) {
-    if (!ignoreFile.existsSync()) return null;
-    final lines = ignoreFile
-        .readAsLinesSync()
-        .map((line) => line.trim())
-        .where((line) => line.isNotEmpty && !line.startsWith('#'));
-    var deniesEverything = false;
-    final admitted = <String>{};
-    for (final line in lines) {
-      if (line == '**' || line == '*') deniesEverything = true;
-      if (RegExp(r'^!([a-z0-9_]+)/').firstMatch(line) case final match?) {
-        admitted.add(match.group(1)!);
-      }
-    }
-    return deniesEverything ? admitted : null;
-  }
-
-  /// Sibling packages [pubspec] depends on by path.
-  Set<String> pathDepsOf(File pubspec) {
-    final document = loadYaml(pubspec.readAsStringSync());
-    final dependencies = document is YamlMap ? document['dependencies'] : null;
-    if (dependencies is! YamlMap) {
-      return const {};
-    }
-    return {
-      for (final entry in dependencies.entries)
-        if (entry.value is YamlMap && (entry.value as YamlMap)['path'] != null)
-          entry.key.toString(),
-    };
-  }
-
   for (final package in const [
     'dartway_starter_server',
     'dartway_starter_flutter',
   ]) {
     test('$package: the image copies every package it depends on', () {
       final dockerfile = File(p.join(template.path, package, 'Dockerfile'));
-      final pubspec = File(p.join(template.path, package, 'pubspec.yaml'));
       expect(dockerfile.existsSync(), isTrue, reason: dockerfile.path);
 
-      final copied = copiedBy(dockerfile);
+      final copied = readsOf(dockerfile).directories;
       expect(
         copied,
         contains(package),
@@ -106,19 +57,7 @@ void main() {
 
       // Transitive: the client is a path dependency of flutter, and whatever
       // the client itself pulls in by path has to be in the context too.
-      final pending = <String>{...pathDepsOf(pubspec)};
-      final needed = <String>{};
-      while (pending.isNotEmpty) {
-        final name = pending.first;
-        pending.remove(name);
-        if (!needed.add(name)) {
-          continue;
-        }
-        final nested = File(p.join(template.path, name, 'pubspec.yaml'));
-        if (nested.existsSync()) {
-          pending.addAll(pathDepsOf(nested));
-        }
-      }
+      final needed = packagesNeededBy(template, package);
 
       expect(
         needed.difference(copied),
@@ -145,14 +84,12 @@ void main() {
       // source; the images are built by `dartway deploy`, on a server, by a
       // person. So the loud failure went unheard for as long as nobody
       // deployed a fresh skeleton.
-      final admitted = admittedByIgnoreFile(
-        File(p.join(template.path, '.dockerignore')),
-      );
+      final admitted = admittedBy(File(p.join(template.path, '.dockerignore')));
       if (admitted == null) return;
 
-      final copied = copiedBy(
+      final copied = readsOf(
         File(p.join(template.path, package, 'Dockerfile')),
-      );
+      ).directories;
 
       expect(
         copied.difference(admitted),
@@ -174,7 +111,9 @@ void main() {
       'dartway_starter_flutter',
     ]) {
       expect(
-        pathDepsOf(File(p.join(template.path, package, 'pubspec.yaml'))),
+        pathDependenciesOf(
+          File(p.join(template.path, package, 'pubspec.yaml')),
+        ),
         contains('dartway_starter_shared'),
         reason: package,
       );


### PR DESCRIPTION
Closes #158.

## The class

Images are built from the project root and copy package directories **by name**. That writes the package list down twice more than the pubspec does — the `COPY` lines, and the allow-list of a `.dockerignore` that denies by default — and the three have to agree, with nothing making them.

- A package the Dockerfile never names does not enter the context, and `pub get` inside the image fails as **exit code 66**, three layers from the cause, pointing at neither the Dockerfile nor the package.
- A package the ignore file never admits fails at the `COPY` itself. Louder, and still only on the machine that builds the image.

**It is silent for a structural reason.** Repository checks compile the server and build the app *inside the checkout*, where the path resolves; the images are built only by `dartway deploy`, on the server. So a project stays green and cannot ship, and the two facts do not meet until somebody deploys — for the project that hit this, hours after the package landed on master and several merges on top of it. #178 was the same class arriving through the third copy, in this repository's own template.

## The check

`docker-context-packages` — local stage, **error** severity. It sits next to `docker-context`, which stays a warning: that one judges how much is sent to the daemon, this one whether the build can happen at all.

The two cases #158 asks to decide, both decided and both tested:

- **`COPY . .`** reads as taking the whole context and passes — it is a Dockerfile that cannot miss a package, not one that names none. What the ignore file admits still decides what "everything" contains, so that half is still checked.
- **`COPY --from=<stage>`** reads an earlier stage's filesystem rather than the context, so it is not counted as a declaration. Counting it would let a multi-stage file claim directories that were never sent to the daemon.

Also handled: flags before the source (`COPY --chown=1:1 a/ b/ dest/`), several sources in one line, and a `.dockerignore` that does not deny by default — then everything is in the context already, there is nothing to admit, and the check has nothing to say.

## One parser, two readers

The reading moved out of `template_build_context_test.dart` into `packages/dartway_cli/lib/src/build_context.dart`, exactly as the issue proposed. The template's regression test now uses it instead of its own copy — an executable text does not get two copies, and this particular text had already been the thing that drifted.

The comparison itself (`buildContextProblems`) is a pure function over a directory, so the rule is tested against synthetic projects without standing up a deployment; the check is thin wiring over it.

## Green

`dart analyze` clean, **249 tests** in `dartway_cli` — 15 of them new, covering both named edge cases, the transitive walk, a dependency cycle, and each of the two failure directions separately.

## Two doc corrections found while writing this

`deploy check` was described as "**fourteen** assertions on the working copy". There were fifteen before this change — the number had already drifted, and this PR would have made it drift again. A hand-maintained count is a second copy of something the code knows, so it is gone rather than corrected: the page now points at what the command prints, which is the argument the page already makes about `dartway help` ("generated from the parser, so it cannot drift").

The paragraph describing the image checks said "two of the local assertions"; it now says three and explains what the new one reads.

## What this does not do

It compares the copies rather than removing one. Collapsing them — both Dockerfiles doing `COPY . .` with the ignore file as the single list — was measured and rejected: the server image's `COPY` lines name only `shared/` and `server/`, so a Flutter-only change leaves its `pub get` and `dart compile exe` cached today, and `COPY . .` would rebuild the server on every app-only deploy. Doing it without that cost needs `COPY --parents`, which requires `dockerfile:1.7-labs` on whatever machine builds — a customer's server. Not a bet worth making to remove a list that is now checked.

And a check is still not a build: nothing in this repository builds these images, which is why #178 lived unnoticed. That is #173.