### PR TITLE
docs(run): the route is yours, the destination is not

### DIFF
--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -18,8 +18,9 @@
   is silent: the server never compares the live schema against the definition, and the next
   `create-migration` diffs against the definition rather than against the database.
 
-  It is a rule, not a mechanism. Nothing stops a destructive migration from being committed, and
-  nothing takes a dump before one is applied — that is issue #180.
+  `dartway-finish` gained the reading that goes with it: a new folder under `migrations/` is grepped
+  for `DROP TABLE` before the pull request, and a hit is a stop rather than a note. Legitimate ones
+  exist — a table genuinely removed, a module's first migration — so it is a reading and not a ban.
 
 - **`deploy check` reads the package graph, so a project learns before the deploy that an image cannot build.**
 

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 0.9.0
 
+- **`dartway-run` names the one migration that erases a table, and the route around it.**
+
+  Adding a non-nullable column without a default to a table that already has rows makes
+  `serverpod create-migration` emit `DROP TABLE ... CASCADE` followed by `CREATE TABLE`. It warns and
+  aborts, which reads as a safety net working — and `--force`, which everywhere else means "I have
+  read the warning", writes a migration whose first statement destroys the table. The file then looks
+  like every other generated migration and is applied on boot by a server that asks nobody anything.
+
+  The skill now separates the two things `--force` produces: `migration.sql` is the **route** and is
+  yours to rewrite into add-nullable / backfill / `SET NOT NULL`; `definition.json` and
+  `definition.sql` are the **destination** and are never touched — the destination is correct either
+  way, since the column ends up `NOT NULL` however you get there. With how to prove it afterwards
+  (the rows are still there, the column matches the line in `definition.sql`) and why a wrong rewrite
+  is silent: the server never compares the live schema against the definition, and the next
+  `create-migration` diffs against the definition rather than against the database.
+
+  It is a rule, not a mechanism. Nothing stops a destructive migration from being committed, and
+  nothing takes a dump before one is applied — that is issue #180.
+
 - **`deploy check` reads the package graph, so a project learns before the deploy that an image cannot build.**
 
   Images are built from the project root and copy package directories **by name**, which writes the

--- a/toolkit/skills/dartway-finish/SKILL.md
+++ b/toolkit/skills/dartway-finish/SKILL.md
@@ -125,6 +125,18 @@ is verified through the public kit widget. A test of a private composition → a
 - **Analyze the whole package, without a path argument.** `dart analyze lib` looks faster and "good enough", but `test/` is not included in it — and tests reference the code by paths and names, which is exactly where the consequences of moves and API changes settle. A green `dart analyze lib` with 59 compilation errors in `test/` is a case that actually happened.
 - **`dart run custom_lint` in the Flutter package is mandatory.** `flutter analyze` does NOT run its rules, and it is `dartway_lints` that catches the ban on raw `Color`/`TextStyle`/`BorderRadius` outside ui_kit and the other conventions. A green `flutter analyze` with a red `custom_lint` is a classic trap.
 - **A generated-code diff wider than the models the task touched is almost never a real change.** If `git diff --stat` over `__SERVER_PKG__/lib/src/generated/` or `__CLIENT_PKG__/lib/src/protocol/` names files the task has nothing to do with, the cause is a formatter mismatch, not new behaviour: `serverpod generate` writes through the `dart_style` bundled with the Serverpod CLI, and the repository holds code formatted by the project's SDK. Do not read those files line by line looking for what changed, and do not commit them — run `dart format` over **both** paths and re-check, remembering that `create-migration` regenerates, so the format pass has to be the last step of the three (`dartway-models`). `dartway check` reports the state as `generatedCodeUnformatted`. What survives the format pass is the real diff, and that is what gets reviewed.
+- **A migration in the diff is read, not counted.** If `git status` shows a new folder under
+  `__SERVER_PKG__/migrations/`, grep its SQL before anything else:
+  `grep -n 'DROP TABLE' __SERVER_PKG__/migrations/*/migration.sql`. A hit is a stop, not a note.
+  `serverpod create-migration` emits `DROP TABLE ... CASCADE` + `CREATE TABLE` whenever a
+  non-nullable column without a default is added to an existing table, and `--force` — which reads
+  as "I have read the warning" — writes exactly that file. It then looks like every other generated
+  migration and is applied on boot by a server that asks nobody anything, so this is the last
+  reading before the rows are gone. Legitimate hits exist (a table genuinely removed, a module's
+  first migration); the illegitimate one is a `DROP TABLE` of a table the task was only adding a
+  column to. Rewrite `migration.sql` into add-nullable / backfill / `SET NOT NULL` and leave
+  `definition.json` and `definition.sql` untouched — `dartway-run`, "When `create-migration`
+  refuses", has the shape and how to prove it landed.
 - **`flutter test` was actually run, not "the tests probably weren't touched".** The analyzer proves that the code compiles and says nothing about behavior: an overflow in a narrow layout, an uninitialized `dw`, a layout that fell apart — all of that is only visible in a run. A test failing after a refactoring starts with the hypothesis "I broke it", and only after checking against HEAD becomes "the test was red before me".
 
 ### A.6 Findings that outlive this task

--- a/toolkit/skills/dartway-run/SKILL.md
+++ b/toolkit/skills/dartway-run/SKILL.md
@@ -211,9 +211,10 @@ generate the following migration for a database that does not exist.
 Never hand-write `definition.json`. It is not a record of what happened; it is the premise of the
 next diff.
 
-**None of this is enforced.** It is a rule you are reading, and a destructive migration that gets
-past it is applied to production with no dump taken first. If you are about to do this against real
-data, take one by hand.
+**The net is one reading, and it is in `dartway-finish`.** Finishing a task greps every new
+migration for `DROP TABLE` before the PR, which is the last point at which this is cheap. Backups of
+a deployed database are not the application's business — but nothing between that grep and the rows
+will stop you, so the grep is not a formality.
 
 Then: a `DwCrudConfig` for the new model + registration in `crudConfigurations`,
 a default instance in `default_models.dart`, and only after that the screen.

--- a/toolkit/skills/dartway-run/SKILL.md
+++ b/toolkit/skills/dartway-run/SKILL.md
@@ -102,6 +102,7 @@ identifier from `bootstrapAdminIdentifier` yields the admin; any other number yi
 | The admin panel is not in the navigation after signing in | The account is a regular user | `bootstrapAdminIdentifier` is unset, or it does not match the identifier that registered. The comparison is case-insensitive but otherwise exact — no country-code guessing. Fix the key and restart the server: the promotion happens on boot |
 | The client does not see a new model field | Generation was not run after editing `.spy.yaml` | `serverpod generate`, then `serverpod create-migration`, then `dart format` over both generated paths, then apply the migrations ("After a model change" below) |
 | Generation rewrote dozens of files the task never touched | The generator's `dart_style` is not the project's, and `create-migration` regenerates | Run `dart format` over both generated paths **after** `create-migration`, not before ("After a model change" below) |
+| `create-migration` aborts: "the complete table will be deleted and recreated" | A non-nullable column without a default was added to a table that already has rows | **Do not just add `--force`.** It writes a migration that starts with `DROP TABLE ... CASCADE`, and the file looks ordinary afterwards. Use it to get the artifacts, then rewrite `migration.sql` into add-nullable / backfill / `SET NOT NULL` — see "When `create-migration` refuses" below |
 | Strange generation/protocol errors | The `serverpod_cli` version drifted from the `serverpod` pin in the project's pubspec | Compare `dart pub global list` with the version in `__SERVER_PKG__/pubspec.yaml`; the generator must match the runtime |
 | `Default Objects Repository doesn't contain a model of type X` | The new model has no registered default instance | Add `dw.repo.setupRepository(defaultModel: X(...))` in `__FLUTTER_PKG__/lib/core/default_models.dart` |
 | The API answers `notConfigured` | The model has no `DwCrudConfig`, or it is not registered | Create the config and add it to `crudConfigurations` (skill `dartway-crud-config`) |
@@ -135,6 +136,84 @@ has produced a 29-file, 1900-line diff. And `create-migration` runs the generati
 schema, so formatting placed before it is silently undone. Generate, migrate, then format — once, in
 that order, over **both** packages. `git diff --stat` afterwards should name only the models you
 touched; if it names more, one of the two rules above was broken.
+
+### When `create-migration` refuses: the route is yours, the destination is not
+
+Adding a **non-nullable column without a default** to a model whose table already has rows makes the
+generator emit `DROP TABLE ... CASCADE` followed by `CREATE TABLE`. It warns, and then aborts:
+
+```
+ • One or more columns are added to table "user_profile" which cannot be added
+in a table migration. The complete table will be deleted and recreated.
+Migration aborted. Use --force to ignore warnings.
+```
+
+**Read that as "this table has rows", not as "a safety net worked".** The abort is the last thing
+between the change and an erased table, and the flag that lifts it does not say so: `--force`
+everywhere else means "I have read the warning, proceed", while here it writes a migration whose
+first statement destroys the table. The file then looks like every other generated migration, is
+committed like every other one, and is applied on boot by a server that asks nobody anything. On a
+tracker that had recorded months of work, one added integer column would have erased all of it.
+
+**`--force` is still how you proceed** — banning it would leave you with nothing. What it produces is
+two different things, and only one of them is wrong:
+
+| file | what it is | yours? |
+|---|---|---|
+| `migration.sql` | the **route** — the statements that run | **rewrite it** |
+| `definition.json`, `definition.sql` | the **destination** — the schema that must exist afterwards | never touch |
+
+The destination is correct either way: the column exists and is `NOT NULL` however you got there. Only
+the route is destructive, and the safe route is short, standard, and the one this case always wants:
+
+```sql
+-- replaces the generated DROP TABLE / CREATE TABLE block
+ALTER TABLE "user_profile" ADD COLUMN "plan_id" bigint;
+UPDATE "user_profile" SET "plan_id" = 1 WHERE "plan_id" IS NULL;
+ALTER TABLE "user_profile" ALTER COLUMN "plan_id" SET NOT NULL;
+```
+
+So the cycle for this case is the ordinary one with **one step inserted between generating and
+committing**:
+
+```bash
+serverpod create-migration            # aborts — the table has rows
+serverpod create-migration --force    # get the artifacts, do not ship them
+# open migrations/<version>/migration.sql, replace the DROP/CREATE block with the three
+# statements above, and leave the two definition files exactly as generated
+dart bin/main.dart --apply-migrations --role maintenance   # against a copy that has rows
+```
+
+**Prove the destination, do not assume it.** Two questions, and both have answers you can read.
+Did the rows survive, and did the column land exactly as the definition declares it:
+
+```sql
+SELECT count(*) FROM "user_profile";              -- same as before the migration
+
+SELECT column_name, data_type, is_nullable
+  FROM information_schema.columns
+ WHERE table_name = 'user_profile' AND column_name = 'plan_id';
+--  plan_id | bigint | NO      ← compare against the line for this column in
+--                               migrations/<version>/definition.sql
+```
+
+`definition.sql` in the same folder is the full schema the migration promises, so it is what the
+answer is checked against — read the column's line there rather than trusting the rewrite. (A whole
+`pg_dump --schema-only` will not diff against it usefully: the two are the same schema written by
+different tools, and the noise buries the one line that matters.)
+
+Rows still there and the column as declared means the route changed and the destination did not. A
+mismatch means the hand-written SQL and the definition have parted, and **nothing downstream will
+notice**: the server never compares the live schema against the definition, and the next
+`create-migration` diffs against the definition rather than against the database — so it would
+generate the following migration for a database that does not exist.
+
+Never hand-write `definition.json`. It is not a record of what happened; it is the premise of the
+next diff.
+
+**None of this is enforced.** It is a rule you are reading, and a destructive migration that gets
+past it is applied to production with no dump taken first. If you are about to do this against real
+data, take one by hand.
 
 Then: a `DwCrudConfig` for the new model + registration in `crudConfigurations`,
 a default instance in `default_models.dart`, and only after that the screen.


### PR DESCRIPTION
Closes #140.

## The trap

Adding a **non-nullable column without a default** to a model whose table already has rows makes `serverpod create-migration` emit `DROP TABLE ... CASCADE` followed by `CREATE TABLE`. It warns, and then aborts — which reads as a safety net working:

```
 • One or more columns are added to table "user_profile" which cannot be added
in a table migration. The complete table will be deleted and recreated.
Migration aborted. Use --force to ignore warnings.
```

The trap is the flag. `--force` everywhere else means "I have read the warning, proceed"; here it writes a migration whose **first statement destroys the table**. The file then looks like every other generated migration, is committed like every other one, and is applied on boot by a server that asks nobody anything. On the project that met this, one added integer column would have erased a tracker's entire history.

## Why the fix is a rule and not code

Everything #140 proposes — reword the warning, split the flag, name the alternative — lives in **Serverpod's** CLI, not ours. We cannot change it, and `CLAUDE.md` says Serverpod is being removed after v1. What *is* ours is the silence: the safe route is short, standard and known in advance, and the harness never mentioned it.

Banning `--force` would leave nothing to do instead — it is also the only way to get the artifacts. So the rule separates the two things it produces:

| file | what it is | yours? |
|---|---|---|
| `migration.sql` | the **route** — the statements that run | rewrite it |
| `definition.json`, `definition.sql` | the **destination** — the schema that must exist afterwards | never touch |

The destination is correct either way: the column ends up `NOT NULL` however you got there. Only the route is destructive, and the safe one is add-nullable → backfill → `SET NOT NULL`.

## Two skills, and they do different jobs

- **`dartway-run`** explains the case where it is met: what the abort means, why `--force` is not the safety net it reads as, the three statements, and how to prove the rewrite landed where the definition says.
- **`dartway-finish`** is the reading that catches it when nobody remembered: a new folder under `migrations/` is grepped for `DROP TABLE` before the pull request, and a hit is a stop rather than a note. It reads rather than bans — the statement is legitimate for a table genuinely removed and for a module's first migration; what is not legitimate is dropping a table the task was only adding a column to.

## Checked, not assumed — and one claim rewritten because checking it failed

Per the rule that a claim written into documentation is an acceptance criterion too:

- **The server never compares the live schema against the definition.** `migration_manager.dart` (3.4.11) selects versions from the registry and executes their SQL; there is no comparison in it.
- **`create-migration` diffs the last definition, not the database** — `generateDatabaseMigration(databaseSource: databaseDefinitionLatest, …)`. So a hand-written route landing somewhere other than the definition is invisible in both directions, and the *next* migration is generated for a database that does not exist.
- **The acceptance step was wrong and is now right.** It was going to be `pg_dump --schema-only | diff - definition.sql`. Those are the same schema written by two different tools; the diff is noise and would have buried the one line that matters. It is now a row count plus one `information_schema` row, compared against that column's line in `definition.sql` — and the skill says why the whole-dump diff is not the check.

## What this deliberately does not do

Detection, not recovery. **#180** proposed a dump before the migration step of `deploy run` and was closed by decision: taking and keeping dumps of a deployed database is the operator's job, not the application's — a framework that starts snapshotting a customer's production database takes on retention, disk, credentials and restore correctness, none of which the deploy command can own without owning the outcome.

So the skill says plainly that nothing between the grep and the rows will stop you, rather than implying a net that is not there.

No code, nothing of Serverpod's touched, and it reaches existing projects through the harness.