### PR TITLE
feat(toolkit): dartway-on-device — what only a real phone will tell you

### DIFF
--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## 0.9.0
 
+- **New skill `dartway-on-device`: what only a real phone will tell you.**
+
+  Three findings from one week shared no topic and one provenance — each was invisible in the iOS
+  simulator, in a desktop browser and in a widget test, and appeared for the first time on a device.
+  They had been scattered into three homes that were about something else: the keyboard's travel into
+  the UI-kit skill, whose subject is that the kit owns styles; the gesture rule into feature
+  scaffolding, whose subject is that a feature is a folder with one public file; the web shell into
+  the harness constitution, whose subject is the layout of `lib/`. Each host took a paragraph that
+  was not about it, and the next such finding would have gone to a fourth.
+
+  So they now sit together, by provenance rather than by topic: the keyboard reported as a step
+  change while it travels for 250 ms, WebKit raising the keyboard only for a focus inside the
+  gesture, and the web shell that has to pin the document or the first focused field carries the
+  canvas off screen. Mechanism and workaround for each.
+
+  **Admission is a rule, not a habit**, because a skill like this becomes a junk drawer otherwise: an
+  entry needs to reproduce on a device, be invisible in the simulator, a desktop browser and a widget
+  test, and have a written-down workaround. Anything assertable in a test belongs in a test.
+
+  The laws stayed where laws belong — the kit still forbids a raw `viewInsets`, and `CLAUDE.md` still
+  says the web shell is part of the application. What moved is the explanation of why the platform
+  makes them necessary.
+
+  Also: the skill list in `toolkit/CLAUDE.md` is now compared against the directories that ship. The
+  installer walks the folder rather than reading the list, so the two could part with nothing
+  failing — a skill shipped but unnamed is one no agent knows to load.
+
 - **`dartway-run` names the one migration that erases a table, and the route around it.**
 
   Adding a non-nullable column without a default to a table that already has rows makes

--- a/packages/dartway_cli/test/toolkit_skill_list_test.dart
+++ b/packages/dartway_cli/test/toolkit_skill_list_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// The skills `toolkit/CLAUDE.md` names are the skills that exist.
+///
+/// The harness constitution lists them so an agent knows what it may reach
+/// for, and the installer ships whatever directories are there — it walks
+/// `toolkit/skills/` rather than reading the list. So the two can part without
+/// anything failing: a skill that ships and is never named is a skill nobody
+/// loads, and a name with no directory behind it sends an agent looking for a
+/// file that is not installed.
+///
+/// Neither shows up as an error anywhere. This is the only thing that compares
+/// them.
+void main() {
+  final toolkit = () {
+    var dir = Directory.current.absolute;
+    while (true) {
+      final candidate = Directory(p.join(dir.path, 'toolkit', 'skills'));
+      if (candidate.existsSync()) {
+        return Directory(p.join(dir.path, 'toolkit'));
+      }
+      final up = dir.parent;
+      if (up.path == dir.path) {
+        throw StateError('no toolkit/ above ${Directory.current.path}');
+      }
+      dir = up;
+    }
+  }();
+
+  test('CLAUDE.md names every shipped skill, and only those', () {
+    final onDisk = Directory(p.join(toolkit.path, 'skills'))
+        .listSync()
+        .whereType<Directory>()
+        .map((directory) => p.basename(directory.path))
+        .where((name) => name.startsWith('dartway-'))
+        .toSet();
+
+    // The line that lists them: a run of `dartway-*` in backticks on the
+    // "Skills (`.claude/skills/`)" bullet.
+    final line = File(p.join(toolkit.path, 'CLAUDE.md'))
+        .readAsLinesSync()
+        .firstWhere(
+          (line) => line.contains('Skills (`.claude/skills/`)'),
+          orElse: () => throw StateError('no skills line in toolkit/CLAUDE.md'),
+        );
+    final named = RegExp(
+      r'`(dartway-[a-z-]+)`',
+    ).allMatches(line).map((match) => match.group(1)!).toSet();
+
+    expect(
+      named.difference(onDisk),
+      isEmpty,
+      reason: 'named in toolkit/CLAUDE.md but not shipped',
+    );
+    expect(
+      onDisk.difference(named),
+      isEmpty,
+      reason:
+          'shipped but not named in toolkit/CLAUDE.md — an agent will not '
+          'know it exists, and the installer ships it anyway',
+    );
+  });
+}

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -350,10 +350,7 @@ Live migrations (delete an entry once no project is on the old shape):
 
 **Task lifecycle:** `dartway-requirements` (analyze the spec → questions → options) → `dartway-plan` (a step-by-step plan + risks) → implementation (the layer skills) → `dartway-finish` (audit + reconciling the specs and doc comments with the code + tests before the PR).
 
-**"It works in the simulator and not on my phone"** — `dartway-on-device`: what the iOS simulator, a
-desktop browser and a widget test all fail to reproduce, with the mechanism and the workaround. Read
-it by the symptom rather than by the phase — the keyboard not coming up, the screen jumping when a
-field is tapped, a sheet that blinks and reopens.
+**"It works in the simulator and not on my phone"** — `dartway-on-device`: what the iOS simulator, a desktop browser and a widget test all fail to reproduce, with the mechanism and the workaround for each. Read it by the symptom rather than by the phase — the keyboard not coming up, the screen jumping when a field is tapped, a sheet that blinks and reopens.
 
 **Bringing the project up locally** (a fresh clone, "it won't start", after a model change) — `dartway-run`: DB, migrations, the first administrator, server, app, plus diagnostics for the typical failures. A liveness check is mandatory — report it as a fact (the API response code, the applied migrations), not as an assumption.
 

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -345,10 +345,15 @@ Live migrations (delete an entry once no project is on the old shape):
 
 ## Skills and commands
 
-- Skills (`.claude/skills/`): `dartway-run`, `dartway-requirements`, `dartway-plan`, `dartway-clean-code`, `dartway-navigation`, `dartway-feature-scaffold`, `dartway-crud-config`, `dartway-ui-kit`, `dartway-data-layer`, `dartway-models`, `dartway-push-delivery`, `dartway-testing`, `dartway-finish` — loaded by relevance to the task.
+- Skills (`.claude/skills/`): `dartway-run`, `dartway-requirements`, `dartway-plan`, `dartway-clean-code`, `dartway-navigation`, `dartway-feature-scaffold`, `dartway-crud-config`, `dartway-ui-kit`, `dartway-data-layer`, `dartway-models`, `dartway-push-delivery`, `dartway-testing`, `dartway-on-device`, `dartway-finish` — loaded by relevance to the task.
 - Commands (`.claude/commands/`): `/dartway-checkup` — the state of the project and what to take into work next (whole project by default, a path narrows it); `/commit` — a commit in the project's CI format.
 
 **Task lifecycle:** `dartway-requirements` (analyze the spec → questions → options) → `dartway-plan` (a step-by-step plan + risks) → implementation (the layer skills) → `dartway-finish` (audit + reconciling the specs and doc comments with the code + tests before the PR).
+
+**"It works in the simulator and not on my phone"** — `dartway-on-device`: what the iOS simulator, a
+desktop browser and a widget test all fail to reproduce, with the mechanism and the workaround. Read
+it by the symptom rather than by the phase — the keyboard not coming up, the screen jumping when a
+field is tapped, a sheet that blinks and reopens.
 
 **Bringing the project up locally** (a fresh clone, "it won't start", after a model change) — `dartway-run`: DB, migrations, the first administrator, server, app, plus diagnostics for the typical failures. A liveness check is mandatory — report it as a fact (the API response code, the applied migrations), not as an assumption.
 
@@ -394,7 +399,12 @@ Nothing else may sit at the top level, and nothing may carry one of those names 
   Not mechanically enforced outside the kit, and deliberately so: telling `'Issues'` from `'issues/board'` or `'dd.MM'` takes reading the meaning, which no regex or lint rule does. `/dartway-checkup` looks for it. Inside `ui_kit/` the guess is safe — a kit file has no content to speak of — and `dartway check` reports it as `uiKitContainsText`. A typeface is not content: strings in the `fontFamily` and `fontFamilyFallback` positions are exempt, because the platform's font matcher reads them and nobody else does, and the kit is exactly where a font belongs.
 - **Navigation:** the DartWay Router — enum routes, enum parameters, transitions through context extensions (`context.goNamed`/`pushTo`/`replaceWith`, not `router.go()`), guards centralized. Skill — `dartway-navigation`.
 - **Specials:** notifications — `dw.notify.*` (not `SnackBar`); the profile — `ref.watchUserProfile`/`readUserProfile` (not `watchModel<UserProfile>`); actions from the UI — `dw.action`; sign-out — `signOut()`.
-- **The web shell (`web/index.html`) is part of the app, not scaffolding.** The skeleton ships it with a scroll lock (`viewport-scroll-lock-style` / `-script`), and the app depends on that block. Without it, focusing a text field on iOS takes the app off the screen: the engine parks its own DOM input and restores it ~100 ms later at a position computed before the layout knew about the keyboard, WebKit scrolls the document to bring that position into view, and the Flutter canvas — exactly one layout viewport tall — travels up with it. What is left on screen is the canvas's bottom edge. Nothing fails and nothing is logged; from Dart the widget tree is intact, so the search goes to the sheet's own markup, where the bug is not. Neither the iOS simulator nor a desktop browser reproduces it, and a phone in a browser is how a staging build gets shown — so this is found by the person you are showing it to. Anything that regenerates the shell (`flutter create .`, a splash-screen tool) drops the block silently: `grep -q 'focusin' web/index.html` is the check.
+- **The web shell (`web/index.html`) is part of the app, not scaffolding.** It is outside `lib/`,
+  which is the only reason it reads as something the build generates. The skeleton ships it with a
+  scroll lock (`viewport-scroll-lock-style` / `-script`) that the app depends on: without that block,
+  focusing a text field on iOS takes the app off the screen, silently and only on a real phone.
+  Anything that regenerates the shell drops it — `grep -q 'focusin' web/index.html` is the check, and
+  `dartway-on-device` has the mechanism.
 
 ## Shared (the optional `*_shared`)
 

--- a/toolkit/skills/dartway-on-device/SKILL.md
+++ b/toolkit/skills/dartway-on-device/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: dartway-on-device
+description: >-
+  What only a real phone will tell you: platform behaviour that is invisible in the iOS simulator,
+  in a desktop browser and in a widget test, and shows up for the first time on a device — usually
+  the device you are showing a staging build on. Keyboard, focus, scroll and viewport behaviour on
+  iOS and iOS web, with the mechanism and the known workaround for each. Use when someone reports
+  "the keyboard does not come up", "the screen jumped / went blank when I tapped the field", "it
+  blinks and reopens", "it works in the simulator but not on my phone", "it works on desktop but not
+  on mobile" — and before writing anything that focuses a field, opens a sheet over the keyboard, or
+  is going to be opened from a phone browser.
+---
+
+# DartWay — what only the device tells you (`dartway-on-device`)
+
+Every entry here cost somebody a search in the wrong place. Not because the bug was subtle, but
+because **the environment that reproduces it is not the environment anybody develops in**: the iOS
+simulator raises keyboards fine, a desktop browser has no keyboard to raise, and a widget test has
+neither a browser nor a phone. The code looks right, the tests are green, and the report says "it
+does not work on my phone".
+
+So this skill is not a topic. It is a **provenance**: things the framework cannot tell you and the
+emulator will not show you.
+
+## What belongs here, and what does not
+
+An entry is admitted only if all three hold:
+
+1. it **reproduces on a real device**;
+2. it is **invisible** in the iOS simulator, in a desktop browser and in a widget test;
+3. it has a **known workaround**, written down.
+
+Anything visible in a test belongs in a test, not here — a rule you can assert is worth more than a
+rule you can read. Anything that is a matter of taste belongs in the design system
+(`dartway-ui-kit`). Anything about the structure of a feature belongs in `dartway-feature-scaffold`.
+Without this rule the file becomes the place things go when nobody wants to decide, and then nobody
+reads it.
+
+**Where the mechanism lives is here; where the law lives may be elsewhere.** The web shell being part
+of the application is a structural rule and it stays in the project's `CLAUDE.md`. Why iOS makes it
+necessary is here.
+
+---
+
+## The keyboard is not an instant, and iOS says it is
+
+**Symptom.** A bottom sheet with a text field snaps into its final geometry while the keyboard is
+still moving. It reads as "it blinked and reopened".
+
+**Mechanism.** The system reports the keyboard as a **step change** in `MediaQuery.viewInsets` — on
+iOS as two steps, first for the accessory bar above the keyboard and then for the keyboard itself —
+while the keyboard actually travels for about 250 ms. Layout computed straight from the raw inset is
+therefore correct and early, which looks like a glitch.
+
+**Workaround.** A smoother the whole layout reads through — the skeleton ships `AppKeyboardInset` in
+`lib/ui_kit/utils/`, a `TweenAnimationBuilder` over `MediaQuery.viewInsetsOf(context).bottom` with
+the keyboard's own duration and curve:
+
+```dart
+AppKeyboardInset(
+  builder: (_, keyboardInset) => Padding(
+    padding: EdgeInsets.only(bottom: 16 + keyboardInset),
+    child: child,
+  ),
+)
+```
+
+**The discipline is the part that matters.** Compute *everything* keyboard-dependent from the
+smoothed value — height, bottom padding, edges. Converting the padding and leaving the height on the
+raw inset is **worse than doing nothing**: the two halves visibly slide apart. It does not look like
+a violation on the page either — a raw `viewInsets` in layout is exactly what the Flutter
+documentation suggests — so the check is a grep:
+
+```bash
+grep -rn 'viewInsetsOf' lib/ui_kit    # any hit outside the smoother itself is one
+```
+
+Nothing animates on the first build: with no `begin` the tween starts at its end, so a sheet opened
+over an already-raised keyboard is in place rather than sliding into it.
+
+---
+
+## WebKit shows the keyboard only for a focus inside the gesture
+
+**Symptom.** On iOS web, a sheet opens with a text field, the field shows a caret — and no keyboard.
+The user taps the field a second time to get one.
+
+**Mechanism.** WebKit's rule: the keyboard is raised only by a `focus()` that happens
+**synchronously inside a user gesture**. At the moment of the tap the field does not exist yet — the
+sheet is built on the next frame, so its own focus request is post-frame, and the browser does not
+count that as a user action.
+
+**Writing it the broken way is what any documentation will suggest.** `autofocus`, or a
+`requestFocus` in `initState` or an `addPostFrameCallback`, is the natural answer to "the field is
+not mounted yet", and it is correct on every platform except this one.
+
+**Workaround — a primer field.** An always-mounted invisible input takes the focus *inside* the
+gesture, and hands it to the real field a frame later. Moving focus between fields while the
+keyboard is already up needs no gesture, so it simply stays up.
+
+- an app-level `FocusNode` provider, and an invisible `EditableText` bound to it, mounted once beside
+  the page shell;
+- **`EditableText`, not `TextField`** — the primer sits above `Scaffold`, where there is no
+  `Material` ancestor, and it needs `Material` only for drawing, which it never does;
+- **`Opacity(opacity: 0)`, not transparent colours** — whatever is typed during the single frame the
+  primer still holds focus would otherwise paint over the bottom bar;
+- wrapped in `ExcludeSemantics` + `IgnorePointer`;
+- the open-the-sheet handler calls `focusNode.requestFocus()` **synchronously in the tap**, then
+  opens the sheet; the real field takes focus on the next frame.
+
+It runs on every platform, and only WebKit has the gesture rule — elsewhere the keyboard would have
+come up anyway, one frame later. Keeping a second branch for that means keeping a half nothing
+exercises.
+
+**The check is a reading, not a grep:** a `requestFocus` inside an `addPostFrameCallback` in code
+reached by a tap.
+
+---
+
+## The web shell has to pin the document, or the first field takes the app off screen
+
+**Symptom.** On an iPhone — Safari and Chrome alike, one engine — focusing a text field scrolls the
+app off the screen. What is left is a blank backdrop. It does not happen a second time, because the
+document is already scrolled.
+
+**Mechanism.** The engine parks its own DOM input off screen and restores it ~100 ms later, at a
+position computed *before* the layout knew about the keyboard — underneath it. WebKit then does what
+it always does and scrolls the page to bring that position into view. The Flutter canvas is exactly
+one layout viewport tall, so it travels up with the document. Nothing fails and nothing is logged:
+from Dart the widget tree is intact, the sheet is built, the field has focus — so the search goes to
+the sheet's own markup, where the bug is not.
+
+**Workaround.** Give the document nothing to scroll, and return any residual scroll to zero across
+the whole travel rather than at one moment of it. The skeleton ships this in
+`web/index.html` as `viewport-scroll-lock-style` / `-script`: `html { overflow: hidden }`, a `body`
+fixed to the four edges with `overscroll-behavior: none`, and a `focusin` listener that pins the
+scroll immediately, on the next frame, at 150 ms and at 400 ms, plus the `visualViewport` events.
+
+It costs the app nothing — Flutter on web scrolls its own content and keeps the document exactly one
+window tall.
+
+**Anything that regenerates the shell drops the block silently** — `flutter create .`, a
+splash-screen tool. The check:
+
+```bash
+grep -q 'focusin' web/index.html
+```
+
+---
+
+## Before you show a build to anyone
+
+All three of these are met by the person you are showing a staging build to, because **a phone
+browser is how a staging build gets shown**. None of them is met by you, on the machine where you
+wrote it. If a change touches a field, a sheet or the shell, open it on a phone once — that is the
+whole test, and it is the only environment that runs it.

--- a/toolkit/skills/dartway-ui-kit/SKILL.md
+++ b/toolkit/skills/dartway-ui-kit/SKILL.md
@@ -385,16 +385,10 @@ The numbered prefixes keep the kit sorted by usage frequency — the most needed
 - Don't breed variants by copy-paste — composition and extensions (see `dartway-clean-code`).
 - Don't put outer `padding`/`margin` inside a component — the parent sets the spacing.
 - Consistency beats visual hacks.
-- **Anything that depends on the keyboard is computed from the smoothed inset, never from
-  `MediaQuery.viewInsets` directly.** The system reports the keyboard as a step change — on iOS as
-  two steps, the accessory bar and then the keyboard — while it actually travels for about 250 ms, so
-  layout taken from the raw inset lands in its final geometry before the keyboard gets there and
-  reads as "it blinked and re-opened". `AppKeyboardInset` in `utils/` hands the same inset over at
-  the keyboard's own pace; `showAppBottomSheet` computes both its height and its bottom padding
-  through it. Compute **everything** keyboard-dependent from it: half the layout left on the raw
-  inset visibly slides apart from the other half, which is worse than the snap. It does not look like
-  a violation on the page — a raw `viewInsets` in layout is exactly what the Flutter documentation
-  suggests — so the check is a grep: `grep -rn 'viewInsetsOf' lib/ui_kit`, and any hit outside the
-  smoother itself is one.
+- **Anything that depends on the keyboard is computed from the smoothed inset** (`AppKeyboardInset`
+  in `utils/`), never from `MediaQuery.viewInsets` directly — and *everything* of it, because half
+  the layout left on the raw inset slides apart from the other half. Why the raw inset is wrong is
+  not a kit question but a platform one: `dartway-on-device`. The drift check is
+  `grep -rn 'viewInsetsOf' lib/ui_kit` — any hit outside the smoother is one.
 - Tempted by a "client-specific hack" inside a framework widget — that's a signal that an extension
   point is missing. Introduce it in the kit, don't fork `dartway_flutter`.


### PR DESCRIPTION
Closes #152, and rehouses the two findings that were closed before it.

## Why a new skill rather than a paragraph

Three findings from one investigation — #150, #151, #152 — share **no topic and one provenance**: each is invisible in the iOS simulator, in a desktop browser and in a widget test, and appears for the first time on a real device. That is what made them expensive. The code looks right, the tests are green, and the search goes to the file where the bug is not.

They had been scattered into three homes that are about something else:

| finding | where it landed | that host's actual subject |
|---|---|---|
| the keyboard travels for 250 ms while the system reports a step | `dartway-ui-kit`, Best practices | the kit is the only source of styles |
| WebKit raises the keyboard only for a focus inside the gesture | headed for `dartway-feature-scaffold` | a feature is a folder with one public file |
| the web shell must pin the document | `toolkit/CLAUDE.md`, Flutter section | the layout of `lib/` — and `web/` is not in it |

Each host absorbed a paragraph that was not about it; in `dartway-ui-kit` it was the longest bullet in the section and the only one about how hardware moves. The fourth such finding would have gone to a fourth place.

## What the skill is, and what keeps it from becoming a drawer

Named for the **provenance**, not a topic. "UX/UI" was the obvious name and is the wrong one: it overlaps `dartway-ui-kit`, whose subject is already taken, and a skill named after three subjects attracts everything nobody wants to place.

Admission is a written rule, and it is the load-bearing part. An entry needs all three:

1. reproduces on a real device;
2. invisible in the iOS simulator, in a desktop browser **and** in a widget test;
3. has a written-down workaround.

Anything assertable in a test belongs in a test — a rule you can assert is worth more than a rule you can read.

**Its description triggers on the symptom, not the topic** — "the keyboard does not come up", "the screen jumped when I tapped the field", "it works in the simulator but not on my phone". The topic is precisely what the person does not know yet; if the description named it, the skill would be a file that exists and is never opened, which is worse than a diluted paragraph.

## The laws stayed where laws belong

Only the *explanation* moved. `dartway-ui-kit` still forbids a raw `viewInsets` and keeps the greppable drift check, now pointing at the platform reason instead of restating it. `toolkit/CLAUDE.md` still says the web shell is part of the application, which is a structural rule about the project — and hands off the mechanism.

## Two things checked rather than assumed

- **The installer ships this automatically.** `toolkit_installer.dart` walks `toolkit/skills/` with `listSync()` rather than reading a list, so nothing needed registering.
- **And precisely because of that, the list in `toolkit/CLAUDE.md` was a copy nothing compared.** A skill shipped but unnamed is one no agent knows to load; a name with no directory sends an agent after a file that is not installed. Neither fails anywhere. `toolkit_skill_list_test.dart` now compares them, and it goes red both ways — removing the new name from the list reproduces `Actual: Set:['dartway-on-device']`.

## Green

`dart analyze` clean, 250 tests in `dartway_cli`.

## Note on the label

#152 carried `bug` + `impact:workaround`. Verified on `master`: `template/…/lib` contains no `requestFocus` and no `autofocus`, and `showAppBottomSheet` is not called from any screen of the skeleton — it is declared and tested, nothing more. So there was no defect in the framework to fix; what was missing was a rule, and the issue's literal proposal (ship a primer field in the template) would have put machinery in the skeleton with no caller, in the one tree nobody exercises daily. `impact:friction` is the honest label, and the work is the rule.