### PR TITLE
ci: analyze every package and run every suite that needs no services

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,50 @@
+name: Checks
+
+# Analyze every package and run every suite that needs no services.
+#
+# It exists because neither was run anywhere. Twenty-one suites, a thousand
+# tests, and the three workflows beside this one read a diff, forward a verdict
+# and build two web targets — so a change to one package could break a suite in
+# another and reach master green. That is not hypothetical: #165 made
+# `DwAuthConfig.normalizeIdentifier` required, updated the two application call
+# sites, and missed a third in a test that builds its own config. The author ran
+# what they touched; the suite that broke belonged to a package they had no
+# reason to open. It sat on master for a day.
+#
+# The automated review cannot close this gap either — it reads the diff, and
+# that call site was not in it, so it passed the pull request correctly.
+#
+# Both jobs run `tool/checks.sh`, which is also what you run locally. One set of
+# checks rather than two, so "I ran the tests" and "CI ran the tests" stop being
+# different claims.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  push:
+    branches: [master]
+
+concurrency:
+  group: checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Separate jobs so a red one says which half failed without reading a
+        # log, and so the faster of the two answers first.
+        mode: [analyze, test]
+    name: ${{ matrix.mode }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.0
+          channel: stable
+
+      - run: tool/checks.sh ${{ matrix.mode }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ These are not suggestions: each item closes off a way for one session to destroy
 4. **Create the branch at the start of the task, not at the end.** While a branch has no commits, any collision between sessions is resolved by splitting files; after the first foreign commit lands on your branch, only `cherry-pick` and manual surgery remain.
 5. **Never branch from someone else's HEAD.** Branch from an explicit point: `git switch -c <name> master`. Otherwise a foreign commit rides into your PR.
 6. **Push and open PRs only when asked directly.** Never merge a PR, never push to `master` directly, never touch `stable` without an explicit instruction.
-7. **Before offering a PR** — `framework-finish`, analyze and tests all green.
+7. **Before offering a PR** — `framework-finish`, then `tool/checks.sh`, all green. That script is what CI runs, so running it here is not a rehearsal of the gate but the gate itself, answered earlier. Running only the suites you touched is what let a broken one reach `master`.
 8. **Clean up your worktree:** `git worktree remove ../dartway-wt/<slug>` once the branch is merged. Abandoned worktrees hold branches checked out, and the next session cannot switch to them.
 9. **Everything that travels to GitHub is written in English:** branch name, commit message, PR title and description, PR comments. Re-read the title before `gh pr create` — it becomes a commit on `master` and is not editable afterwards. That the task was discussed in Russian makes no difference — see "Language".
 
@@ -136,10 +136,11 @@ These are not suggestions: each item closes off a way for one session to destroy
 
 ### CI
 
-Three workflows in `.github/workflows/`:
+Four workflows in `.github/workflows/`:
 
 | File | When | What it does |
 |---|---|---|
+| `checks.yml` | A PR is opened, updated, or taken out of draft, and on push to `master` | Runs `tool/checks.sh` — `dart analyze` over every resolution root, and every suite that needs no services (eighteen of the twenty-one; the three that want a database are a second tier). It exists because none of that was run anywhere: a change to one package could break a suite in another and reach `master` green, which is what #165 did for a day. The review cannot close that gap — it reads the diff, and the call site that broke was not in it |
 | `claude-review.yml` | A PR is opened, updated, or taken out of draft | Reviews the diff automatically. Beyond ordinary bugs it checks three things specific to this repository: the synchronisation law, the presence of the hand-written `manualDeserialization` patch in the generated `protocol.dart`, and the absence of project literals in `toolkit/` |
 | `telegram-notify.yml` | A review finishes | Sends the verdict and a link to the PR to Telegram — the one notification that asks for a decision. Signals meant for the team (merges, promotion to `stable`) are deliberately absent: that is a separate task addressing a different audience |
 | `web-compile.yml` | A PR is opened or updated, and on push to `master` | Builds the web targets (`example/` and the `dartway_offline_flutter` harness). dart2js rejects code the VM accepts — an integer literal a JavaScript double cannot hold exactly is the standing case — and **unit tests on the VM cannot see that class of error at all**. A package no example and no template depends on is compiled nowhere else, which is how two such literals reached a consumer's release build |

--- a/tool/checks.sh
+++ b/tool/checks.sh
@@ -19,6 +19,18 @@ cd "$(dirname "$0")/.."
 MODE="${1:-all}"
 FAILED=()
 
+# A mistyped mode must not look like a clean run. This script is invoked by hand
+# as well as by CI, and "tool/checks.sh tests" printing "everything green"
+# without having run anything is the worst answer a gate can give.
+case "$MODE" in
+  all|analyze|test) ;;
+  *)
+    echo "unknown mode: $MODE" >&2
+    echo "usage: tool/checks.sh [analyze|test]   (default: both)" >&2
+    exit 64
+    ;;
+esac
+
 # Suites this script deliberately does not run, each with its reason. A package
 # is skipped only by being named here — anything new with a `test/` directory is
 # picked up and run, which is the direction that fails loudly rather than

--- a/tool/checks.sh
+++ b/tool/checks.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Analyze every package and run every suite that needs no services.
+#
+# The same command locally and in CI, on purpose. "I ran the tests before
+# committing" and "CI runs the tests" were two different sets, and the gap
+# between them is exactly where a change to one package broke a suite in
+# another — the author ran what they touched, which was green, and the suite
+# that failed belonged to a package they had no reason to open.
+#
+# Nothing here needs Docker. The three suites that need a database are named
+# below and skipped; they are a second tier, not this one.
+#
+# Usage:  tool/checks.sh [analyze|test]      (default: both)
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:-all}"
+FAILED=()
+
+# Suites this script deliberately does not run, each with its reason. A package
+# is skipped only by being named here — anything new with a `test/` directory is
+# picked up and run, which is the direction that fails loudly rather than
+# quietly leaving a package uncovered.
+#
+# The three database ones are a second tier, not this one: `dartway test` makes
+# them runnable, but wiring them in brings Docker, an image pull and integration
+# suites whose timing is the fragile part. The lints fixture is not a `dart test`
+# suite at all — the files under its `test/` are written to violate the rules and
+# deliberately have no `main`; its own pubspec says `dart run custom_lint` is the
+# suite, and that runs below.
+# Kept as a plain list rather than an associative array: those need bash 4, and
+# macOS ships 3.2 — a script that only runs in CI is the thing this is trying to
+# stop being.
+SKIP="\
+example/dartway_example_server|needs a database
+template/dartway_starter_server|needs a database
+packages/dartway_push/dartway_push_server|needs a database and Redis (issue #174)
+packages/dartway_lints/example|verified by custom_lint, not by dart test"
+
+# The reason this package is skipped, or nothing if it is not.
+skip_reason() {
+  printf '%s\n' "$SKIP" | while IFS='|' read -r path reason; do
+    [ "$path" = "$1" ] && printf '%s' "$reason"
+  done
+}
+
+
+packages() {
+  find . -name pubspec.yaml \
+    -not -path '*/.dart_tool/*' -not -path '*/build/*' -not -path './pubspec.yaml' \
+    | sed 's|^\./||;s|/pubspec.yaml$||' | sort
+}
+
+# A workspace member resolves from the repository root; anything else carries
+# its own resolution and has to be fetched and analyzed where it stands.
+is_member() { grep -q '^resolution: workspace' "$1/pubspec.yaml"; }
+
+# `flutter test` needs a Flutter package; `dart test` fails on one. The pubspec
+# says which it is.
+runner_of() { grep -q 'flutter_test:' "$1/pubspec.yaml" && echo flutter || echo dart; }
+
+run() {
+  local label="$1"; shift
+  echo "── $label"
+  if ! "$@"; then
+    FAILED+=("$label")
+  fi
+}
+
+resolve() {
+  echo "══ resolving"
+  flutter pub get >/dev/null || { echo "root pub get failed"; exit 1; }
+  for package in $(packages); do
+    is_member "$package" && continue
+    (cd "$package" && flutter pub get >/dev/null) \
+      || { echo "pub get failed in $package"; exit 1; }
+  done
+}
+
+analyze() {
+  echo "══ analyze"
+  # Errors only. One warning stands today and it is in generated code
+  # (`dw_updates_transport.dart`), which nobody reviews and the generator
+  # rewrites — gating on it would make red mean "the generator again".
+  run "packages (workspace)" dart analyze --no-fatal-warnings packages
+  for package in $(packages); do
+    is_member "$package" && continue
+    run "$package" bash -c "cd '$package' && dart analyze --no-fatal-warnings"
+  done
+}
+
+test_suites() {
+  echo "══ test"
+  for package in $(packages); do
+    [ -d "$package/test" ] || continue
+    reason="$(skip_reason "$package")"
+    if [ -n "$reason" ]; then
+      echo "── $package — skipped: $reason"
+      continue
+    fi
+    run "$package" bash -c "cd '$package' && $(runner_of "$package") test"
+  done
+  # The linter's own suite, run the way its package declares.
+  run "packages/dartway_lints/example (custom_lint)" \
+    bash -c "cd packages/dartway_lints/example && dart run custom_lint"
+}
+
+resolve
+[ "$MODE" = all ] || [ "$MODE" = analyze ] && analyze
+[ "$MODE" = all ] || [ "$MODE" = test ] && test_suites
+
+echo
+if [ ${#FAILED[@]} -eq 0 ]; then
+  echo "✓ everything green"
+  exit 0
+fi
+echo "✗ failed: ${#FAILED[@]}"
+printf '  %s\n' "${FAILED[@]}"
+exit 1


### PR DESCRIPTION
Closes #173.

## What was missing

**Twenty-one suites, 1022 tests, and CI runs none of them.** The three existing workflows read a diff (`claude-review`), forward its verdict (`telegram-notify`) and build two web targets (`web-compile`). Neither `dart test` nor `dart analyze` runs over the server packages anywhere.

The consequence is not hypothetical. #165 made `DwAuthConfig.normalizeIdentifier` required, updated the two application call sites, and missed a third — in a test that builds its own config. The author ran what they touched and it was green; the suite that broke belonged to a package they had no reason to open. It sat on `master` for a day and was found by someone running the example's suite by hand.

**The review could not have caught it, and did not fail to.** It reads the diff, and that call site was not in the diff. Every review comment on yesterday's pull requests also says the same thing about itself: *"I was not able to run `dart analyze` / `dart test` in this environment."* The one mechanical gate the repository has verifies by reading and asks the PR body to be believed.

## A script, not steps in a YAML

`tool/checks.sh` is what the workflow runs and what you run locally. That is the point rather than a convenience: *"I ran the tests before committing"* and *"CI runs the tests"* were two different sets, and one command makes them one. `CLAUDE.md`'s protocol item 7 now names it.

How it decides, all of it read from the files rather than listed:

- **Membership.** A package with `resolution: workspace` resolves from the root; anything else is fetched and analyzed where it stands. This is not cosmetic — `dart analyze` from the repository root reports **467 errors**, every one of them `example/` and `template/` being unresolved. Walking the resolution roots gives one warning and two infos across the whole tree.
- **Runner.** `flutter_test:` in the pubspec means `flutter test`; its absence means `dart test`.
- **Skipping is by name; running is the default.** Anything new with a `test/` directory is picked up automatically. The four skips are named with their reasons — the direction that fails loudly rather than leaving a package quietly uncovered.
- **Errors, not warnings.** Exactly one warning stands today and it is in generated code the generator rewrites (`dw_updates_transport.dart`). Gating on it would make red mean "the generator again".

## The two things not in this tier, said out loud

- **Three suites need a database** (`example_server`, `template_server`, `push_server`). `dartway test` makes them runnable, but wiring them in brings Docker, an image pull and the integration suites, whose timing is the fragile part. Second tier. `push_server` also carries its own compose with Redis — #174.
- **Nothing here builds the Docker images**, so #177 — the skeleton that could not build at all — would still have got through. Third tier.

`packages/dartway_lints/example` is the fourth skip and a different kind of thing: the files under its `test/` are fixtures written to violate the rules, deliberately without a `main`, and its own pubspec says `dart run custom_lint` is that package's suite. The script runs it that way.

## Verified before shipping, in both directions

- **All eighteen are green today**, run one by one before the workflow was written. A gate that arrives red teaches people to stop reading it — the state a neighbouring project's CI has been in since 16 August, which is exactly how a non-compiling test reached its `master`.
- **The incident reproduces.** Deleting the `normalizeIdentifier` argument again turns the analyze pass red, naming `example/dartway_example_server`, exit 1.
- Portable to bash 3.2, because macOS ships it and a script that only runs in CI is the thing this is trying to stop being.