### PR TITLE
fix(cli): settings.json is merged on update, not written once and abandoned

### DIFF
--- a/docs/5-tooling/agent-toolkit.md
+++ b/docs/5-tooling/agent-toolkit.md
@@ -62,14 +62,20 @@ truth is the toolkit in the monorepo, and there is no reverse sync.
 
 Updating is a deliberate act with a visible diff: run `setup-ai` again, read what changed, commit.
 
-`.claude/settings.json` sits on the other side of that line: it is written once, when the project
-has none, and never touched again. It pre-approves this stack's build commands — `dart pub get`,
-`docker compose up`, `serverpod generate`, the test runners — so a first run is not a queue of
+`.claude/settings.json` sits on neither side of that line, and is the third kind of file here: a
+toolkit default the project **extends**. It pre-approves this stack's build commands — `dart pub
+get`, `docker compose up`, `serverpod generate`, the test runners — so a first run is not a queue of
 permission prompts, and it denies reading `config/passwords.yaml`, which turns a rule the skills
 merely state into one the harness enforces. Nothing destructive is on the allow list: `docker
-compose down`, commits and pushes still ask. A project adds its own permissions there, and an
-update will not take them away — the price being that a changed default reaches an existing project
-only if someone deletes the file first.
+compose down`, commits and pushes still ask.
+
+An update **merges** it: entries the toolkit has and the project lacks are added, everything the
+project added stays, and every added entry is printed. It used to be written once and never touched,
+which sounds like the safe choice and is only half of one — a changed default then reached an
+existing project only if somebody deleted the file first, and a new `deny` rule reached none of
+them, which is precisely the half the harness is supposed to enforce rather than state. The one cost
+of merging is an entry a project removed on purpose coming back; that is why every addition is named
+in the output rather than applied quietly.
 
 That is also why a finding about the framework leaves the project entirely. A rule that did not catch
 a mistake, two skills that disagree, an API the app had to work around — none of that can be fixed in

--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -172,10 +172,11 @@ into the installed markdown, so the skills speak your package names, not placeho
 journal — straight into the installed `CLAUDE.md`. It defaults to English and does not touch what
 ships to other people: package APIs and error strings stay English either way.
 
-`.claude/settings.json` is written only when the project has none, and never touched again: it
-pre-approves this stack's build commands so a first run is not a queue of permission prompts, and
-denies reading `config/passwords.yaml`. A project extends it; an update will not take those edits
-away, at the price of an old default staying put until someone deletes the file.
+`.claude/settings.json` is **merged** rather than overwritten or skipped: it pre-approves this
+stack's build commands so a first run is not a queue of permission prompts, and denies reading
+`config/passwords.yaml`. A project extends it and keeps everything it added; what the toolkit has
+gained since is added and printed, entry by entry. Written once and never touched again — what it
+used to do — meant a new `deny` rule reached no existing project at all.
 
 One thing lands outside `.claude/`: **`docs/dev_notes/`**, where this project's own findings live —
 a risk, a pin that trails, a config written down twice, one file per finding. It is **tracked, not

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## 0.9.0
 
+- **`setup-ai` brings `.claude/settings.json` up to date instead of skipping it.**
+
+  It used to be written only when the project had none, and never touched again. Its own doc comment
+  admitted the consequence — "changes here reach existing projects only if someone deletes the file
+  first" — and the never-overwrite reasoning covers only half of the case. Adding a pre-approved
+  build command and losing it on an update would be bad; **a new `deny` rule reaching no existing
+  project at all** is worse, because that is the half the harness is supposed to enforce rather than
+  merely state.
+
+  The file is a third kind, which is why neither of the installer's two rules fitted: a *managed*
+  file is the toolkit's and is overwritten, a *project* file is the project's and is never touched,
+  and this one is a toolkit default the project **extends**. It is now merged — entries the template
+  has and the project lacks are added, everything the project added stays, and a value the project
+  already set is never replaced.
+
+  **Every added entry is printed.** Merging has exactly one real cost — an entry a project removed on
+  purpose comes back — and naming each addition in the output turns that into something visible in
+  the same run rather than a discovery months later. A `settings.json` that is not valid JSON is
+  reported and left exactly as it was.
+
 - **New skill `dartway-on-device`: what only a real phone will tell you.**
 
   Three findings from one week shared no topic and one provenance — each was invisible in the iOS

--- a/packages/dartway_cli/lib/src/toolkit_installer.dart
+++ b/packages/dartway_cli/lib/src/toolkit_installer.dart
@@ -124,17 +124,16 @@ class ToolkitInstaller {
       return;
     }
 
-    final Map<String, dynamic> templateJson;
-    final Map<String, dynamic> projectJson;
-    try {
-      templateJson =
-          jsonDecode(template.readAsStringSync()) as Map<String, dynamic>;
-      projectJson =
-          jsonDecode(settings.readAsStringSync()) as Map<String, dynamic>;
-    } on FormatException catch (error) {
+    // Read as an object or not at all. `jsonDecode` answers `[]` and `42`
+    // without complaint, and casting those would throw a `TypeError` past the
+    // `FormatException` guard — a crash, which is the one outcome this whole
+    // branch exists to avoid.
+    final templateJson = _settingsObject(template);
+    final projectJson = _settingsObject(settings);
+    if (templateJson == null) return;
+    if (projectJson == null) {
       stdout.writeln(
-        '.claude/settings.json is not valid JSON and was left untouched: '
-        '${error.message}',
+        '.claude/settings.json is not a JSON object and was left untouched.',
       );
       return;
     }
@@ -148,6 +147,17 @@ class ToolkitInstaller {
     stdout.writeln('Updated .claude/settings.json:');
     for (final entry in added) {
       stdout.writeln('  + $entry');
+    }
+  }
+
+  /// The file's contents as a JSON object, or null when it is anything else —
+  /// unparseable, or parseable but a list, a number or a string.
+  static Map<String, dynamic>? _settingsObject(File file) {
+    try {
+      final decoded = jsonDecode(file.readAsStringSync());
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
     }
   }
 

--- a/packages/dartway_cli/lib/src/toolkit_installer.dart
+++ b/packages/dartway_cli/lib/src/toolkit_installer.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -7,8 +8,9 @@ import 'package:path/path.dart' as p;
 /// `.claude/` is a generated-but-committed artifact (like the Serverpod
 /// client). Only MANAGED files are overwritten: `CLAUDE.md`, skills named
 /// `dartway-*` and the `commit` / `dartway-checkup` commands. Project-own
-/// skills and commands are never touched, and `settings.json` is seeded once
-/// and then belongs to the project.
+/// skills and commands are never touched. `settings.json` is a third kind —
+/// a toolkit default the project extends — and is merged rather than
+/// overwritten or skipped; see [_installSettings].
 class ToolkitInstaller {
   /// Removed before every install, then re-copied from the toolkit — so a
   /// command that has been retired disappears from a project instead of
@@ -77,8 +79,8 @@ class ToolkitInstaller {
     _reportLegacyInstallerTraces(projectRoot);
   }
 
-  /// Puts a default `.claude/settings.json` in place, unless the project
-  /// already has one.
+  /// Brings `.claude/settings.json` up to date, keeping whatever the project
+  /// added to it.
   ///
   /// It pre-approves the build commands of this stack — `dart pub get`,
   /// `docker compose up`, `serverpod generate`, the test runners — so that
@@ -87,18 +89,122 @@ class ToolkitInstaller {
   /// state into one the harness enforces. Nothing destructive is on the list:
   /// `docker compose down`, commits and pushes still ask.
   ///
-  /// **Not a managed file** — unlike the skills it is never overwritten, since
-  /// a project adds its own permissions to it and losing those on an update
-  /// would be worse than shipping a stale default. The consequence: changes
-  /// here reach existing projects only if someone deletes the file first.
+  /// **The third kind of file, and the reason this is a merge.** The installer
+  /// otherwise deals in two: a *managed* file is the toolkit's and is
+  /// overwritten (`CLAUDE.md`, the skills — the project has nothing in them to
+  /// lose), and a *project* file is the project's and is never touched
+  /// (`docs/dev_notes/_coverage.md` — the toolkit has no opinion on its
+  /// contents). This one is neither: it is a toolkit default that the project
+  /// *extends*. Treating it as a project file, which is what it used to be,
+  /// picks one half of that and drops the other — a changed default reached
+  /// existing projects only if somebody deleted the file first, and a new
+  /// `deny` rule reached none of them at all, which is the half the harness is
+  /// supposed to enforce rather than merely state.
+  ///
+  /// So: entries the template has and the project lacks are added, everything
+  /// the project added stays, and **every added entry is printed**. That last
+  /// part is not decoration. The one real cost of merging is a project that
+  /// removed an entry *on purpose* — dropping `Bash(curl:*)`, say — and would
+  /// have it quietly returned. Printing turns that into something visible in
+  /// the same run rather than a discovery months later.
+  ///
+  /// A file that is not valid JSON is left exactly as it is and reported: an
+  /// installer that rewrites something it could not read is worse than one that
+  /// skips it.
   static void _installSettings(Directory toolkitDir, Directory claudeDir) {
     final template = File(p.join(toolkitDir.path, 'settings.json'));
+    if (!template.existsSync()) return;
+
     final settings = File(p.join(claudeDir.path, 'settings.json'));
-    if (!template.existsSync() || settings.existsSync()) {
+    if (!settings.existsSync()) {
+      template.copySync(settings.path);
+      stdout.writeln(
+        'Created .claude/settings.json (pre-approved dev commands)',
+      );
       return;
     }
-    template.copySync(settings.path);
-    stdout.writeln('Created .claude/settings.json (pre-approved dev commands)');
+
+    final Map<String, dynamic> templateJson;
+    final Map<String, dynamic> projectJson;
+    try {
+      templateJson =
+          jsonDecode(template.readAsStringSync()) as Map<String, dynamic>;
+      projectJson =
+          jsonDecode(settings.readAsStringSync()) as Map<String, dynamic>;
+    } on FormatException catch (error) {
+      stdout.writeln(
+        '.claude/settings.json is not valid JSON and was left untouched: '
+        '${error.message}',
+      );
+      return;
+    }
+
+    final added = _mergeSettings(templateJson, projectJson);
+    if (added.isEmpty) return;
+
+    settings.writeAsStringSync(
+      '${const JsonEncoder.withIndent('  ').convert(projectJson)}\n',
+    );
+    stdout.writeln('Updated .claude/settings.json:');
+    for (final entry in added) {
+      stdout.writeln('  + $entry');
+    }
+  }
+
+  /// Adds what [template] has and [project] lacks, in place, and answers with
+  /// what was added — `permissions.allow: Bash(...)` and the like.
+  ///
+  /// Lists are merged as sets while keeping the project's order first, so an
+  /// update reads as an addition rather than as a reshuffle. A value the
+  /// project already holds under a key is never replaced: the template seeds
+  /// defaults, it does not overrule decisions.
+  static List<String> _mergeSettings(
+    Map<String, dynamic> template,
+    Map<String, dynamic> project,
+  ) {
+    final added = <String>[];
+
+    void mergeInto(
+      Map<String, dynamic> from,
+      Map<String, dynamic> into,
+      String path,
+    ) {
+      for (final key in from.keys) {
+        final incoming = from[key];
+        final existing = into[key];
+        final where = path.isEmpty ? key : '$path.$key';
+
+        if (incoming is Map<String, dynamic>) {
+          if (existing is! Map<String, dynamic>) {
+            if (existing == null) {
+              into[key] = incoming;
+              added.add(where);
+            }
+            continue;
+          }
+          mergeInto(incoming, existing, where);
+        } else if (incoming is List) {
+          if (existing is! List) {
+            if (existing == null) {
+              into[key] = incoming;
+              added.add(where);
+            }
+            continue;
+          }
+          for (final value in incoming) {
+            if (existing.contains(value)) continue;
+            existing.add(value);
+            added.add('$where: $value');
+          }
+        } else if (existing == null) {
+          into[key] = incoming;
+          added.add('$where: $incoming');
+        }
+      }
+    }
+
+    mergeInto(template, project, '');
+    return added;
   }
 
   /// Creates `docs/dev_notes/` — the project's own findings, one file per

--- a/packages/dartway_cli/test/toolkit_settings_merge_test.dart
+++ b/packages/dartway_cli/test/toolkit_settings_merge_test.dart
@@ -176,6 +176,24 @@ void main() {
     );
   });
 
+  test(
+    'valid JSON that is not an object is left alone, not crashed on',
+    () async {
+      // `jsonDecode` accepts these without complaint, so the parse guard alone
+      // does not catch them — and the cast that used to follow threw past it,
+      // turning a malformed settings file into a failed `setup-ai`.
+      for (final content in ['[]', '42', '"oops"']) {
+        final root = await installInto(null, seed);
+        final file = File(p.join(root.path, '.claude', 'settings.json'));
+        file.writeAsStringSync(content);
+
+        await installInto(root, seed);
+
+        expect(file.readAsStringSync(), content, reason: content);
+      }
+    },
+  );
+
   test('a file that is not valid JSON is left exactly as it was', () async {
     // An installer that rewrites something it could not read is worse than one
     // that skips it: the unreadable file is still the project's only copy.

--- a/packages/dartway_cli/test/toolkit_settings_merge_test.dart
+++ b/packages/dartway_cli/test/toolkit_settings_merge_test.dart
@@ -1,0 +1,191 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dartway_cli/src/project_layout.dart';
+import 'package:dartway_cli/src/toolkit_installer.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// `.claude/settings.json` is the third kind of file the installer deals in: a
+/// toolkit default the project extends, rather than one the toolkit owns
+/// outright or one it has no opinion about.
+///
+/// It used to be treated as the project's, which meant a changed default
+/// reached an existing project only if somebody deleted the file first — and a
+/// new `deny` rule reached none of them at all, which is the half the harness is
+/// supposed to enforce rather than merely state. What is pinned here is both
+/// halves of the merge: the template's entries arrive, and the project's own
+/// survive.
+void main() {
+  late Directory sandbox;
+
+  setUp(() => sandbox = Directory.systemTemp.createTempSync('dw_settings'));
+  tearDown(() => sandbox.deleteSync(recursive: true));
+
+  ProjectLayout layoutIn(Directory root) => ProjectLayout(
+    root: root,
+    serverPackage: 'my_app_server',
+    clientPackage: 'my_app_client',
+    flutterPackage: 'my_app_flutter',
+  );
+
+  /// The minimum toolkit the installer insists on, plus the settings template
+  /// under test.
+  Directory writeToolkit(Map<String, dynamic> settings) {
+    final toolkitDir = Directory(p.join(sandbox.path, 'toolkit'))
+      ..createSync(recursive: true);
+    Directory(p.join(toolkitDir.path, 'skills')).createSync();
+    Directory(p.join(toolkitDir.path, 'commands')).createSync();
+    File(p.join(toolkitDir.path, 'CLAUDE.md')).writeAsStringSync('harness\n');
+    File(
+      p.join(toolkitDir.path, 'settings.json'),
+    ).writeAsStringSync(jsonEncode(settings));
+    return toolkitDir;
+  }
+
+  var installCount = 0;
+
+  Future<Directory> installInto(
+    Directory? projectRoot,
+    Map<String, dynamic> toolkitSettings,
+  ) async {
+    final root =
+        projectRoot ??
+        (Directory(p.join(sandbox.path, 'project${installCount++}'))
+          ..createSync(recursive: true));
+    await ToolkitInstaller.install(
+      toolkitDir: writeToolkit(toolkitSettings),
+      projectRoot: root,
+      tokens: layoutIn(root).toolkitTokens(baseBranch: 'master'),
+    );
+    return root;
+  }
+
+  Map<String, dynamic> settingsIn(Directory root) =>
+      jsonDecode(
+            File(
+              p.join(root.path, '.claude', 'settings.json'),
+            ).readAsStringSync(),
+          )
+          as Map<String, dynamic>;
+
+  List<String> allowIn(Directory root) =>
+      ((settingsIn(root)['permissions'] as Map<String, dynamic>)['allow']
+              as List)
+          .cast<String>();
+
+  const seed = {
+    'permissions': {
+      'allow': ['Bash(dart test:*)'],
+      'deny': ['Read(./**/config/passwords.yaml)'],
+    },
+  };
+
+  test('a project with no settings gets the template as it stands', () async {
+    final root = await installInto(null, seed);
+    expect(allowIn(root), ['Bash(dart test:*)']);
+  });
+
+  test('a default added later reaches a project installed before it', () async {
+    // The whole point. This used to require deleting the file by hand.
+    final root = await installInto(null, seed);
+    await installInto(root, {
+      'permissions': {
+        'allow': ['Bash(dart test:*)', 'Bash(flutter test:*)'],
+        'deny': ['Read(./**/config/passwords.yaml)'],
+      },
+    });
+
+    expect(allowIn(root), contains('Bash(flutter test:*)'));
+  });
+
+  test('a new deny rule reaches it too', () async {
+    // The half that matters most: a deny rule is something the harness is meant
+    // to enforce, and it used to reach no existing project at all.
+    final root = await installInto(null, seed);
+    await installInto(root, {
+      'permissions': {
+        'allow': ['Bash(dart test:*)'],
+        'deny': ['Read(./**/config/passwords.yaml)', 'Read(./**/*.pem)'],
+      },
+    });
+
+    final deny =
+        ((settingsIn(root)['permissions'] as Map<String, dynamic>)['deny']
+                as List)
+            .cast<String>();
+    expect(deny, contains('Read(./**/*.pem)'));
+  });
+
+  test('what the project added survives the update', () async {
+    final root = await installInto(null, seed);
+    final file = File(p.join(root.path, '.claude', 'settings.json'));
+    file.writeAsStringSync(
+      jsonEncode({
+        'permissions': {
+          'allow': ['Bash(dart test:*)', 'Bash(make deploy:*)'],
+          'deny': ['Read(./**/config/passwords.yaml)'],
+        },
+        'model': 'opus',
+      }),
+    );
+
+    await installInto(root, {
+      'permissions': {
+        'allow': ['Bash(dart test:*)', 'Bash(flutter test:*)'],
+        'deny': ['Read(./**/config/passwords.yaml)'],
+      },
+    });
+
+    expect(allowIn(root), contains('Bash(make deploy:*)'));
+    expect(allowIn(root), contains('Bash(flutter test:*)'));
+    // A key the template says nothing about is not the toolkit's to remove.
+    expect(settingsIn(root)['model'], 'opus');
+  });
+
+  test('the project keeps its own value where the template has one', () async {
+    final root = await installInto(null, seed);
+    final file = File(p.join(root.path, '.claude', 'settings.json'));
+    file.writeAsStringSync(
+      jsonEncode({
+        'permissions': {
+          'allow': ['Bash(dart test:*)'],
+          'deny': ['Read(./**/config/passwords.yaml)'],
+        },
+        'model': 'opus',
+      }),
+    );
+
+    await installInto(root, {...seed, 'model': 'sonnet'});
+
+    // The template seeds defaults; it does not overrule a decision already made.
+    expect(settingsIn(root)['model'], 'opus');
+  });
+
+  test('a second install with nothing new changes nothing', () async {
+    final root = await installInto(null, seed);
+    final before = File(
+      p.join(root.path, '.claude', 'settings.json'),
+    ).readAsStringSync();
+
+    await installInto(root, seed);
+
+    expect(
+      File(p.join(root.path, '.claude', 'settings.json')).readAsStringSync(),
+      before,
+    );
+  });
+
+  test('a file that is not valid JSON is left exactly as it was', () async {
+    // An installer that rewrites something it could not read is worse than one
+    // that skips it: the unreadable file is still the project's only copy.
+    final root = await installInto(null, seed);
+    final file = File(p.join(root.path, '.claude', 'settings.json'));
+    const broken = '{ "permissions": { "allow": [ ';
+    file.writeAsStringSync(broken);
+
+    await installInto(root, seed);
+
+    expect(file.readAsStringSync(), broken);
+  });
+}

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -13,7 +13,7 @@ skills/dartway-*/SKILL.md     # the DartWay methodology — 12 skills: requireme
                               #   feature-scaffold, models, crud-config, data-layer, navigation,
                               #   ui-kit, clean-code, push-delivery, finish
 commands/{commit,dartway-checkup}.md
-settings.json                 # default permissions, seeded once as .claude/settings.json
+settings.json                 # default permissions, merged into .claude/settings.json
 ```
 
 `CLAUDE.md` is installed as `.claude/CLAUDE.md` and committed with the project, which Claude Code automatically keeps in context — which is why a client repo needs no project `CLAUDE.md` files: the methodology rides in from the toolkit, and project knowledge lives in the code that holds it — `DwFeatureSpec`, doc comments, the registries of `lib/core/`.
@@ -27,7 +27,7 @@ The skills are **generic**: project-specific values are extracted into placehold
 | `__PROJECT_LANGUAGE__` | the language the project writes its own texts in | `--language`, default English |
 | `__NOTES_TRACKER__` | the GitHub repository framework findings are filed in as issues | `--notes-tracker`, the framework's own tracker by default; `none` opts out |
 
-`settings.json` is installed as `.claude/settings.json` **only when the project has none**, and is never overwritten afterwards — a project adds its own permissions to it, and losing those on an update would cost more than a stale default. It pre-approves this stack's build commands (`dart pub get`, `docker compose up`, `serverpod generate`, the test runners) so that bringing a fresh project up is not a queue of permission prompts, and it denies reading `config/passwords.yaml` — turning a rule the skills merely state into one the harness enforces. Nothing destructive is on the allow list: `docker compose down`, commits and pushes still ask.
+`settings.json` is installed as `.claude/settings.json` and **merged** on every later install: what the toolkit has and the project lacks is added and printed entry by entry, and everything the project added stays. It is the third kind of file here — neither the toolkit's outright like the skills, nor the project's outright like the dev-notes coverage table, but a default the project extends. Never touching it, which is what happened before, meant a new `deny` rule reached no existing project. It pre-approves this stack's build commands (`dart pub get`, `docker compose up`, `serverpod generate`, the test runners) so that bringing a fresh project up is not a queue of permission prompts, and it denies reading `config/passwords.yaml` — turning a rule the skills merely state into one the harness enforces. Nothing destructive is on the allow list: `docker compose down`, commits and pushes still ask.
 
 `docs/dev_notes/` is the one thing installed outside `.claude/`: the project's own findings — a risk, a pin that trails, a config written down twice — one **tracked** file per finding, so it travels out in a pull request and is visible in review. `README.md` there states the form and is refreshed on every install; `_coverage.md` is the project's own table of which features `/dartway-checkup` has read, and is written once and never overwritten. A finding about the **framework** gets no file at all — it is filed as an issue in the repository `__NOTES_TRACKER__` names.
 


### PR DESCRIPTION
Closes #133, closes #134 — one defect in one method, described twice.

## What was wrong

`ToolkitInstaller._installSettings` wrote `.claude/settings.json` only when the project had none:

```dart
if (!template.existsSync() || settings.existsSync()) return;
```

After the first install it was never touched again. `dartway setup-ai` refreshes `CLAUDE.md`, the `dartway-*` skills and the managed commands, and silently skipped this one — clean exit, no warning, nothing in the output saying the project runs an old default. Its own doc comment admitted it: *"changes here reach existing projects only if someone deletes the file first."*

The reasoning behind never-overwrite is real and covers **half** the case. Losing a permission a project added would cost more than a stale default. But the other half is a new `deny` rule reaching no existing project at all — and that is precisely the half the harness is meant to *enforce* rather than state. The current file denies reading `config/passwords.yaml`.

## The diagnosis both issues reach independently

The installer deals in two kinds of file, and this is a third:

| kind | whose | on update |
|---|---|---|
| managed — `CLAUDE.md`, `skills/dartway-*`, the managed commands | the toolkit's | overwritten; the project has nothing in it to lose |
| project — `docs/dev_notes/_coverage.md` | the project's | never touched; the toolkit has no opinion on its contents |
| **extended — `settings.json`** | **a toolkit default the project adds to** | **merged** |

Never-overwrite picked one half of the third and dropped the other. The kind now has a name in the installer rather than being handled by whichever of the two rules was reached for first — so the next file of this shape has somewhere to go.

## The behaviour

- entries the template has and the project lacks are **added**;
- everything the project added **stays**;
- a value the project already set is **never replaced** — the template seeds defaults, it does not overrule decisions;
- **every added entry is printed**, one per line.

That last point is not decoration. Merging has exactly one real cost: a project that removed an entry *deliberately* — dropping `Bash(curl:*)` for its own reasons — has it quietly returned. Naming each addition in the output makes that visible in the same run rather than months later.

A `settings.json` that is not valid JSON is reported and left exactly as it was. An installer that rewrites what it could not read is worse than one that skips it.

## An alternative that was checked and dropped

Hand `settings.json` to the toolkit outright (managed, overwritten) and send the project's own entries to `settings.local.json`. It removes the third category instead of naming it, which is tidier — and it argues with Claude Code's own convention, where `settings.json` is the shared, committed file and `.local` is personal. It would tell a team to keep shared permissions somewhere they are not shared.

## Green

`tool/checks.sh analyze` clean, 257 tests in `dartway_cli` — 7 new, pinning both halves of the merge, the deny-rule case specifically, an update that has nothing to add writing nothing at all, and the unreadable file left untouched.

## Adjacent, not in this

**#93** — an installed harness records no version, so *"how far behind is this project"* is still a forensic exercise, and `setup-ai` without `--channel` can still roll a project silently onto the other channel. The merge does not need it; the second half of this seam does.