### PR TITLE
feat(cli): an installed harness records where it came from

### DIFF
--- a/docs/5-tooling/agent-toolkit.md
+++ b/docs/5-tooling/agent-toolkit.md
@@ -60,7 +60,12 @@ So do not edit a `dartway-*` skill in place; the next `setup-ai` will drop your 
 floor. To customize, **copy the skill under a different name** and edit the copy. The source of
 truth is the toolkit in the monorepo, and there is no reverse sync.
 
-Updating is a deliberate act with a visible diff: run `setup-ai` again, read what changed, commit.
+Updating is a deliberate act with a visible diff: run `setup-ai` again, read what changed, commit. What
+was installed is written down beside it, in `.claude/dartway-toolkit.json` — repository, channel,
+commit, CLI version — because the files themselves do not say which channel they follow, and
+`--channel` defaults to `stable`. Update a project that had been moved to `master` with the plain
+command and it would be rolled back, with the diff looking like any other update; instead the
+command refuses and asks for the channel by name.
 
 `.claude/settings.json` sits on neither side of that line, and is the third kind of file here: a
 toolkit default the project **extends**. It pre-approves this stack's build commands — `dart pub

--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -172,6 +172,22 @@ into the installed markdown, so the skills speak your package names, not placeho
 journal — straight into the installed `CLAUDE.md`. It defaults to English and does not touch what
 ships to other people: package APIs and error strings stay English either way.
 
+The install records where it came from, in `.claude/dartway-toolkit.json`: the repository, the
+channel, the commit and the CLI version, committed with the rest. The installed files themselves say
+none of that — they are the toolkit's files, so comparing them against the current toolkit answers
+*"is this behind"* and nothing about *which channel it follows*.
+
+That distinction has teeth, because **`--channel` defaults to `stable`**. A project deliberately
+moved to `master` is rolled back by the next plain `dartway setup-ai`, and the diff of that rollback
+is indistinguishable from the diff of an ordinary update. So when the recorded channel differs from
+the one about to be installed and `--channel` was not given, the command **refuses** and says which
+two channels are involved. Naming either one proceeds — the point is that moving between them stops
+being something a default decides, and ends up written in the command that ran.
+
+It records provenance rather than content on purpose: a list of installed files or their hashes
+would be a second copy of the files, and copies drift. Where they came from is written nowhere else.
+A project installed before this existed has no manifest, and is left alone rather than blocked.
+
 `.claude/settings.json` is **merged** rather than overwritten or skipped: it pre-approves this
 stack's build commands so a first run is not a queue of permission prompts, and denies reading
 `config/passwords.yaml`. A project extends it and keeps everything it added; what the toolkit has

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## 0.9.0
 
+- **An installed harness records where it came from, and a channel is no longer switched by a default.**
+
+  `setup-ai` left no trace of its source: no version, no commit, no channel. So *"how far behind is
+  this project"* was answerable only by checking out the monorepo and comparing files, and a worse
+  case had no answer at all — **`--channel` defaults to `stable`**, so a project deliberately moved to
+  `master` was rolled back by the next plain `dartway setup-ai`, with a diff indistinguishable from an
+  ordinary update.
+
+  Installs now write `.claude/dartway-toolkit.json` — repository, channel, commit, CLI version, date —
+  and print the same line. When the recorded channel differs from the one about to be installed and
+  `--channel` was not given, the command refuses and names both, so moving between channels is a
+  decision written in the command that ran rather than one a default makes.
+
+  It records **provenance, not content**: a file list or hashes would be a second copy of the files,
+  and copies drift; where they came from is written nowhere else. A project installed before this
+  existed has no manifest and is left alone rather than blocked, and an install from a local checkout
+  records no channel — a working directory's branch says nothing about what a project should follow.
+
+  The issue also asked the command to refuse when the incoming commit is an *ancestor* of the
+  installed one. That is not implementable as asked: the monorepo cache is cloned `--depth 1` and has
+  no history to compare with. The channel guard covers the case that actually happens.
+
 - **`setup-ai` brings `.claude/settings.json` up to date instead of skipping it.**
 
   It used to be written only when the project had none, and never touched again. Its own doc comment

--- a/packages/dartway_cli/lib/src/commands/create_command.dart
+++ b/packages/dartway_cli/lib/src/commands/create_command.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 
 import '../monorepo_source.dart';
 import '../project_layout.dart';
+import '../toolkit_manifest.dart';
 import '../toolkit_installer.dart';
 
 /// Creates a new DartWay project from the `template/` skeleton of the monorepo:
@@ -89,10 +90,10 @@ class CreateCommand extends Command<int> {
         ? _requireEmptyCurrentDirectory()
         : _requireFreeSubdirectory(projectName);
 
-    final monorepoDir = await MonorepoSource(
-      branch: argResults!['channel'] as String,
-      localDir: argResults!['local-repo'] as String?,
-    ).resolve();
+    final channel = argResults!['channel'] as String;
+    final localRepo = argResults!['local-repo'] as String?;
+    final source = MonorepoSource(branch: channel, localDir: localRepo);
+    final monorepoDir = await source.resolve();
     final templateDir = Directory(p.join(monorepoDir.path, _sourceDirectory));
     if (!templateDir.existsSync()) {
       throw StateError(
@@ -113,6 +114,15 @@ class CreateCommand extends Command<int> {
         baseBranch: 'master',
         language: argResults!['language'] as String,
         notesTracker: argResults!['notes-tracker'] as String,
+      ),
+      provenance: ToolkitProvenance(
+        source: localRepo != null && localRepo.isNotEmpty
+            ? monorepoDir.path
+            : source.repoUrl,
+        channel: localRepo != null && localRepo.isNotEmpty ? null : channel,
+        commit: await monorepoCommit(monorepoDir),
+        cliVersion: dartwayCliVersion,
+        installedAt: DateTime.now().toUtc().toIso8601String(),
       ),
     );
 

--- a/packages/dartway_cli/lib/src/commands/setup_ai_command.dart
+++ b/packages/dartway_cli/lib/src/commands/setup_ai_command.dart
@@ -89,6 +89,7 @@ class SetupAiCommand extends Command<int> {
       installed: ToolkitProvenance.read(projectRoot),
       requestedChannel: channel,
       channelWasExplicit: argResults!.wasParsed('channel'),
+      fromLocalCheckout: localRepo != null && localRepo.isNotEmpty,
     );
     if (refusal != null) {
       stderr.writeln(refusal);

--- a/packages/dartway_cli/lib/src/commands/setup_ai_command.dart
+++ b/packages/dartway_cli/lib/src/commands/setup_ai_command.dart
@@ -4,6 +4,7 @@ import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 
 import '../monorepo_source.dart';
+import '../toolkit_manifest.dart';
 import '../project_layout.dart';
 import '../toolkit_installer.dart';
 
@@ -78,10 +79,24 @@ class SetupAiCommand extends Command<int> {
           : 'Notes tracker: $notesTracker',
     );
 
-    final monorepoDir = await MonorepoSource(
-      branch: argResults!['channel'] as String,
-      localDir: argResults!['local-repo'] as String?,
-    ).resolve();
+    final channel = argResults!['channel'] as String;
+    final localRepo = argResults!['local-repo'] as String?;
+
+    // Before anything is fetched: a channel switch nobody asked for is the one
+    // way this command moves a project backwards, and it costs nothing to
+    // notice it here rather than after the clone.
+    final refusal = channelSwitchRefusal(
+      installed: ToolkitProvenance.read(projectRoot),
+      requestedChannel: channel,
+      channelWasExplicit: argResults!.wasParsed('channel'),
+    );
+    if (refusal != null) {
+      stderr.writeln(refusal);
+      return 1;
+    }
+
+    final source = MonorepoSource(branch: channel, localDir: localRepo);
+    final monorepoDir = await source.resolve();
 
     await ToolkitInstaller.install(
       toolkitDir: Directory(p.join(monorepoDir.path, 'toolkit')),
@@ -90,6 +105,15 @@ class SetupAiCommand extends Command<int> {
         baseBranch: baseBranch,
         language: language,
         notesTracker: notesTracker,
+      ),
+      provenance: ToolkitProvenance(
+        source: localRepo != null && localRepo.isNotEmpty
+            ? monorepoDir.path
+            : source.repoUrl,
+        channel: localRepo != null && localRepo.isNotEmpty ? null : channel,
+        commit: await monorepoCommit(monorepoDir),
+        cliVersion: dartwayCliVersion,
+        installedAt: DateTime.now().toUtc().toIso8601String(),
       ),
     );
 

--- a/packages/dartway_cli/lib/src/toolkit_installer.dart
+++ b/packages/dartway_cli/lib/src/toolkit_installer.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import 'toolkit_manifest.dart';
+
 /// Installs the DartWay AI toolkit into a project's `.claude/` directory.
 ///
 /// `.claude/` is a generated-but-committed artifact (like the Serverpod
@@ -28,10 +30,13 @@ class ToolkitInstaller {
 
   /// Copies the toolkit from [toolkitDir] into `<projectRoot>/.claude/`,
   /// substituting [tokens] in the managed markdown files.
+  /// [provenance] is written beside the files it describes. Omitted only by
+  /// tests that have no monorepo to describe.
   static Future<void> install({
     required Directory toolkitDir,
     required Directory projectRoot,
     required Map<String, String> tokens,
+    ToolkitProvenance? provenance,
   }) async {
     final toolkitSkillsDir = Directory(p.join(toolkitDir.path, 'skills'));
     final toolkitCommandsDir = Directory(p.join(toolkitDir.path, 'commands'));
@@ -77,6 +82,11 @@ class ToolkitInstaller {
     _installDevNotes(toolkitDir, projectRoot, tokens);
     _reportRetiredJournals(projectRoot);
     _reportLegacyInstallerTraces(projectRoot);
+
+    if (provenance != null) {
+      provenance.write(projectRoot);
+      stdout.writeln('Toolkit: ${provenance.describe()}');
+    }
   }
 
   /// Brings `.claude/settings.json` up to date, keeping whatever the project

--- a/packages/dartway_cli/lib/src/toolkit_manifest.dart
+++ b/packages/dartway_cli/lib/src/toolkit_manifest.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// The version of this CLI, as a constant the code can read.
+///
+/// A copy of what `pubspec.yaml` says, because a compiled or globally activated
+/// executable has no reliable way back to its own pubspec. It is a checked
+/// copy: `cli_version_test.dart` compares the two and goes red when they part.
+const dartwayCliVersion = '0.9.0';
+
+/// Where an installed harness came from.
+///
+/// The installed files do not say. They are the toolkit's files, so comparing
+/// them against the current toolkit answers *"is this behind"* — but not *"which
+/// channel is it from"*, and that is the question with teeth: `--channel`
+/// defaults to `stable`, so a project deliberately moved to `master` is rolled
+/// back by the next plain `dartway setup-ai`, and the diff of that rollback
+/// looks exactly like the diff of an ordinary update.
+///
+/// So this records **provenance, not content**. A list of installed files or
+/// their hashes would be a second copy of the files themselves, and copies of
+/// files are what drift; where they came from is not written down anywhere else.
+class ToolkitProvenance {
+  const ToolkitProvenance({
+    required this.source,
+    required this.channel,
+    required this.commit,
+    required this.cliVersion,
+    required this.installedAt,
+  });
+
+  /// Reads the manifest a previous install left, or null when there is none —
+  /// which is every project installed before this existed.
+  static ToolkitProvenance? read(Directory projectRoot) {
+    final file = _fileIn(projectRoot);
+    if (!file.existsSync()) return null;
+    try {
+      final decoded = jsonDecode(file.readAsStringSync());
+      if (decoded is! Map<String, dynamic>) return null;
+      return ToolkitProvenance(
+        source: decoded['source'] as String? ?? '?',
+        channel: decoded['channel'] as String?,
+        commit: decoded['commit'] as String?,
+        cliVersion: decoded['cliVersion'] as String? ?? '?',
+        installedAt: decoded['installedAt'] as String? ?? '?',
+      );
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// The repository the toolkit was taken from, or the path of a local checkout
+  /// when the framework itself was being worked on.
+  final String source;
+
+  /// The branch, or null when the source was a local checkout — a working
+  /// directory's branch says nothing about what a project should follow.
+  final String? channel;
+
+  /// The commit the toolkit was read at, or null when it could not be resolved.
+  final String? commit;
+
+  final String cliVersion;
+  final String installedAt;
+
+  static File _fileIn(Directory projectRoot) =>
+      File(p.join(projectRoot.path, '.claude', 'dartway-toolkit.json'));
+
+  void write(Directory projectRoot) {
+    _fileIn(projectRoot).writeAsStringSync(
+      '${const JsonEncoder.withIndent('  ').convert({'source': source, if (channel != null) 'channel': channel, if (commit != null) 'commit': commit, 'cliVersion': cliVersion, 'installedAt': installedAt})}\n',
+    );
+  }
+
+  /// One line for the install output — what was put in, in the terms someone
+  /// would use to ask for it again.
+  String describe() {
+    final where = channel != null ? '$source@$channel' : source;
+    final short = commit == null
+        ? null
+        : commit!.substring(0, commit!.length < 7 ? commit!.length : 7);
+    final at = short != null ? ' ($short)' : '';
+    return '$where$at, installed by dartway $cliVersion';
+  }
+}
+
+/// The commit a monorepo checkout is at, or null when it cannot be read.
+///
+/// Null is an ordinary answer rather than a failure: the cache is cloned with
+/// `--depth 1` and a local checkout is whatever the developer has, so the
+/// manifest records what it can and says nothing it cannot stand behind.
+Future<String?> monorepoCommit(Directory monorepoDir) async {
+  try {
+    final result = await Process.run('git', [
+      'rev-parse',
+      'HEAD',
+    ], workingDirectory: monorepoDir.path);
+    if (result.exitCode != 0) return null;
+    final commit = (result.stdout as String).trim();
+    return commit.isEmpty ? null : commit;
+  } on ProcessException {
+    return null;
+  }
+}
+
+/// Why an install must not go ahead, or null when it may.
+///
+/// The only case, and it is the one that happens: the project records one
+/// channel and the command is about to install another **without having been
+/// asked to**. `--channel` defaults to `stable`, so this is what a plain
+/// `dartway setup-ai` does to a project that was deliberately moved to
+/// `master` — and the resulting diff is indistinguishable from an update.
+///
+/// Refusing rather than prompting is deliberate: it works the same when nobody
+/// is at the terminal, and the escape — naming the channel — leaves the
+/// decision written down in the command that was run.
+String? channelSwitchRefusal({
+  required ToolkitProvenance? installed,
+  required String requestedChannel,
+  required bool channelWasExplicit,
+}) {
+  final recorded = installed?.channel;
+  if (recorded == null || channelWasExplicit) return null;
+  if (recorded == requestedChannel) return null;
+  return 'This project has the toolkit from the "$recorded" channel, and the '
+      'command would install "$requestedChannel" — the default. Moving between '
+      'channels is a decision, and it can move a project backwards, so it is '
+      'not something a default should make.\n'
+      'Run it again naming the channel you mean: '
+      '--channel $recorded to stay, --channel $requestedChannel to switch.';
+}

--- a/packages/dartway_cli/lib/src/toolkit_manifest.dart
+++ b/packages/dartway_cli/lib/src/toolkit_manifest.dart
@@ -120,7 +120,16 @@ String? channelSwitchRefusal({
   required ToolkitProvenance? installed,
   required String requestedChannel,
   required bool channelWasExplicit,
+  required bool fromLocalCheckout,
 }) {
+  // A local checkout ignores the channel entirely — `MonorepoSource` resolves
+  // to the directory it was handed — and the install that follows records no
+  // channel. Judging it against the `--channel` default would block the
+  // framework's own development loop (`dartway setup-ai --local-repo ../dartway`)
+  // for any project whose harness came from a non-default channel, over a
+  // channel the run was never going to touch.
+  if (fromLocalCheckout) return null;
+
   final recorded = installed?.channel;
   if (recorded == null || channelWasExplicit) return null;
   if (recorded == requestedChannel) return null;

--- a/packages/dartway_cli/test/toolkit_manifest_test.dart
+++ b/packages/dartway_cli/test/toolkit_manifest_test.dart
@@ -1,0 +1,161 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/toolkit_manifest.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('the version constant matches the pubspec', () {
+    // A compiled or globally activated executable has no reliable way back to
+    // its own pubspec, so the version is a constant — and a constant copied
+    // from a file is a copy, which is why this compares them.
+    var dir = Directory.current.absolute;
+    while (!File(p.join(dir.path, 'pubspec.yaml')).existsSync()) {
+      dir = dir.parent;
+    }
+    final pubspec =
+        loadYaml(File(p.join(dir.path, 'pubspec.yaml')).readAsStringSync())
+            as YamlMap;
+
+    expect(pubspec['name'], 'dartway_cli', reason: 'wrong pubspec found');
+    expect(pubspec['version'], dartwayCliVersion);
+  });
+
+  group('ToolkitProvenance', () {
+    late Directory sandbox;
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('dw_manifest');
+      Directory(p.join(sandbox.path, '.claude')).createSync();
+    });
+    tearDown(() => sandbox.deleteSync(recursive: true));
+
+    const fromChannel = ToolkitProvenance(
+      source: 'https://github.com/dartway/dartway.git',
+      channel: 'master',
+      commit: '0123456789abcdef',
+      cliVersion: '0.9.0',
+      installedAt: '2026-08-30T00:00:00.000Z',
+    );
+
+    test('what is written comes back', () {
+      fromChannel.write(sandbox);
+      final read = ToolkitProvenance.read(sandbox)!;
+
+      expect(read.source, fromChannel.source);
+      expect(read.channel, 'master');
+      expect(read.commit, '0123456789abcdef');
+      expect(read.cliVersion, '0.9.0');
+    });
+
+    test('a local checkout records no channel', () {
+      // A working directory's branch says nothing about what a project should
+      // follow, so recording one would invite a comparison that means nothing.
+      const local = ToolkitProvenance(
+        source: '/home/dev/dartway',
+        channel: null,
+        commit: 'abc1234',
+        cliVersion: '0.9.0',
+        installedAt: '2026-08-30T00:00:00.000Z',
+      );
+      local.write(sandbox);
+
+      expect(ToolkitProvenance.read(sandbox)!.channel, isNull);
+      expect(
+        local.describe(),
+        '/home/dev/dartway (abc1234), installed by dartway 0.9.0',
+      );
+    });
+
+    test('a commit shorter than a short hash does not break the line', () {
+      const odd = ToolkitProvenance(
+        source: 'x',
+        channel: 'master',
+        commit: 'abc',
+        cliVersion: '0.9.0',
+        installedAt: '2026-08-30T00:00:00.000Z',
+      );
+
+      expect(odd.describe(), 'x@master (abc), installed by dartway 0.9.0');
+    });
+
+    test('a project installed before this existed reads as nothing', () {
+      expect(ToolkitProvenance.read(sandbox), isNull);
+    });
+
+    test('an unreadable manifest reads as nothing, not as a crash', () {
+      File(
+        p.join(sandbox.path, '.claude', 'dartway-toolkit.json'),
+      ).writeAsStringSync('[]');
+
+      expect(ToolkitProvenance.read(sandbox), isNull);
+    });
+
+    test('the description names the channel and the short commit', () {
+      expect(
+        fromChannel.describe(),
+        'https://github.com/dartway/dartway.git@master (0123456), '
+        'installed by dartway 0.9.0',
+      );
+    });
+  });
+
+  group('channelSwitchRefusal', () {
+    const onMaster = ToolkitProvenance(
+      source: 'https://github.com/dartway/dartway.git',
+      channel: 'master',
+      commit: 'abc',
+      cliVersion: '0.9.0',
+      installedAt: '2026-08-30T00:00:00.000Z',
+    );
+
+    String? refusalFor({
+      ToolkitProvenance? installed,
+      String requested = 'stable',
+      bool explicit = false,
+    }) => channelSwitchRefusal(
+      installed: installed,
+      requestedChannel: requested,
+      channelWasExplicit: explicit,
+    );
+
+    test('refuses the silent rollback', () {
+      // The case that happens: a project deliberately on master, and a plain
+      // `dartway setup-ai` whose --channel defaults to stable.
+      final refusal = refusalFor(installed: onMaster);
+
+      expect(refusal, isNotNull);
+      expect(refusal, contains('master'));
+      expect(refusal, contains('stable'));
+      expect(refusal, contains('--channel'));
+    });
+
+    test('allows it when the channel was asked for by name', () {
+      // Naming it leaves the decision written down in the command that ran.
+      expect(refusalFor(installed: onMaster, explicit: true), isNull);
+    });
+
+    test('allows an update on the same channel', () {
+      expect(refusalFor(installed: onMaster, requested: 'master'), isNull);
+    });
+
+    test('allows a project that has no manifest yet', () {
+      // Every project installed before this existed. Refusing them would turn
+      // a missing record into a blocked update.
+      expect(refusalFor(installed: null), isNull);
+    });
+
+    test('allows one installed from a local checkout', () {
+      const local = ToolkitProvenance(
+        source: '/home/dev/dartway',
+        channel: null,
+        commit: 'abc',
+        cliVersion: '0.9.0',
+        installedAt: '2026-08-30T00:00:00.000Z',
+      );
+
+      expect(refusalFor(installed: local), isNull);
+    });
+  });
+}

--- a/packages/dartway_cli/test/toolkit_manifest_test.dart
+++ b/packages/dartway_cli/test/toolkit_manifest_test.dart
@@ -114,10 +114,12 @@ void main() {
       ToolkitProvenance? installed,
       String requested = 'stable',
       bool explicit = false,
+      bool local = false,
     }) => channelSwitchRefusal(
       installed: installed,
       requestedChannel: requested,
       channelWasExplicit: explicit,
+      fromLocalCheckout: local,
     );
 
     test('refuses the silent rollback', () {
@@ -138,6 +140,15 @@ void main() {
 
     test('allows an update on the same channel', () {
       expect(refusalFor(installed: onMaster, requested: 'master'), isNull);
+    });
+
+    test('allows an install from a local checkout', () {
+      // `--local-repo` resolves to the directory it was handed and ignores the
+      // channel entirely, then records none. Judging it against the `--channel`
+      // default would block the framework's own development loop for any
+      // project whose harness came from a non-default channel — over a channel
+      // the run was never going to touch.
+      expect(refusalFor(installed: onMaster, local: true), isNull);
     });
 
     test('allows a project that has no manifest yet', () {


### PR DESCRIPTION
Closes #93 — the last of the three issues around "the harness ships once and cannot move".

## What was missing

`dartway setup-ai` installed the toolkit and left no trace of its source: no version file, no manifest, nothing naming the commit, the channel or the CLI version. *"How far behind is this project"* was answerable only by checking out the monorepo, guessing which commit was installed, and comparing files.

The sharper half had no answer at all. **`--channel` defaults to `stable`.** A project deliberately moved to `master` is rolled back by the next plain `dartway setup-ai` — and the diff of that rollback is indistinguishable from the diff of an ordinary update. Nothing before or after could tell them apart.

## The cheaper shape, and why it does not cover it

The installed files **are** a record: they are the toolkit's, `setup-ai` already fetches the toolkit on every run, so a diff would answer *"is this behind"* with nothing new to maintain and nothing to drift.

It cannot answer *"which channel is this from"* — the files do not carry it, and that is precisely the question the rollback turns on. So the manifest earns its place for provenance specifically, and records **provenance rather than content**: a list of installed files or their hashes would be a second copy of the files themselves, and copies drift. Where they came from is written nowhere else.

## The behaviour

`.claude/dartway-toolkit.json` — repository, channel, commit, CLI version, date — written on install by both `setup-ai` and `create`, printed as one line in the output, committed with the rest of `.claude/`.

When the recorded channel differs from the one about to be installed **and `--channel` was not given**, the command refuses, names both channels and points at the escape:

```
This project has the toolkit from the "master" channel, and the command would
install "stable" — the default. Moving between channels is a decision, and it
can move a project backwards, so it is not something a default should make.
Run it again naming the channel you mean: --channel master to stay,
--channel stable to switch.
```

**Refuses rather than prompts**, deliberately: it behaves the same with nobody at the terminal, and naming the channel leaves the decision written in the command that ran rather than in a session nobody can read later.

Two cases are deliberately let through: a project with **no manifest** — every project installed before this — is left alone rather than blocked, and an install from a **local checkout** records no channel at all, because a working directory's branch says nothing about what a project should follow.

## One part of the issue is not implementable as written

It asks `setup-ai` to refuse when the commit it is about to install is an **ancestor** of the one already there. The monorepo cache is cloned with `--depth 1` and has no history, so ancestry cannot be decided from it. Deepening the clone to answer it is a cost paid on every run for a question the channel comparison already answers for the case that actually happens. The changelog says this rather than quietly shipping less than was asked.

For the same reason the manifest does not promise a **distance** in commits — it answers "same or not", and which channel.

## Green

`tool/checks.sh analyze` clean, 270 tests in `dartway_cli` — 12 new, covering the round-trip, the local-checkout case, an unreadable manifest reading as absent rather than crashing, and each branch of the refusal.

The CLI version had to become a constant, since a compiled or globally activated executable has no reliable way back to its own pubspec. That makes it a copy, so a test compares it against `pubspec.yaml` rather than trusting it — the same treatment the skill list got in #182.