### PR TITLE
fix(cli): the source answers whether it is a local checkout, and both callers ask it

### DIFF
--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -20,6 +20,11 @@
   existed has no manifest and is left alone rather than blocked, and an install from a local checkout
   records no channel — a working directory's branch says nothing about what a project should follow.
 
+  Whether the toolkit comes from a local checkout is now `MonorepoSource`'s answer rather than a
+  condition each caller re-derives: `--local-repo` and `DARTWAY_MONOREPO_DIR` both fold into it, so
+  nothing can disagree with what `resolve()` will do. Asking the argument instead was how a refusal
+  fired over a channel the run was never going to touch.
+
   The issue also asked the command to refuse when the incoming commit is an *ancestor* of the
   installed one. That is not implementable as asked: the monorepo cache is cloned `--depth 1` and has
   no history to compare with. The channel guard covers the case that actually happens.

--- a/packages/dartway_cli/lib/src/commands/create_command.dart
+++ b/packages/dartway_cli/lib/src/commands/create_command.dart
@@ -5,7 +5,6 @@ import 'package:path/path.dart' as p;
 
 import '../monorepo_source.dart';
 import '../project_layout.dart';
-import '../toolkit_manifest.dart';
 import '../toolkit_installer.dart';
 
 /// Creates a new DartWay project from the `template/` skeleton of the monorepo:
@@ -90,9 +89,10 @@ class CreateCommand extends Command<int> {
         ? _requireEmptyCurrentDirectory()
         : _requireFreeSubdirectory(projectName);
 
-    final channel = argResults!['channel'] as String;
-    final localRepo = argResults!['local-repo'] as String?;
-    final source = MonorepoSource(branch: channel, localDir: localRepo);
+    final source = MonorepoSource(
+      branch: argResults!['channel'] as String,
+      localDir: argResults!['local-repo'] as String?,
+    );
     final monorepoDir = await source.resolve();
     final templateDir = Directory(p.join(monorepoDir.path, _sourceDirectory));
     if (!templateDir.existsSync()) {
@@ -115,15 +115,7 @@ class CreateCommand extends Command<int> {
         language: argResults!['language'] as String,
         notesTracker: argResults!['notes-tracker'] as String,
       ),
-      provenance: ToolkitProvenance(
-        source: localRepo != null && localRepo.isNotEmpty
-            ? monorepoDir.path
-            : source.repoUrl,
-        channel: localRepo != null && localRepo.isNotEmpty ? null : channel,
-        commit: await monorepoCommit(monorepoDir),
-        cliVersion: dartwayCliVersion,
-        installedAt: DateTime.now().toUtc().toIso8601String(),
-      ),
+      provenance: await source.provenance(monorepoDir),
     );
 
     if (argResults!['git'] as bool) {

--- a/packages/dartway_cli/lib/src/commands/setup_ai_command.dart
+++ b/packages/dartway_cli/lib/src/commands/setup_ai_command.dart
@@ -80,23 +80,27 @@ class SetupAiCommand extends Command<int> {
     );
 
     final channel = argResults!['channel'] as String;
-    final localRepo = argResults!['local-repo'] as String?;
+    final source = MonorepoSource(
+      branch: channel,
+      localDir: argResults!['local-repo'] as String?,
+    );
 
     // Before anything is fetched: a channel switch nobody asked for is the one
     // way this command moves a project backwards, and it costs nothing to
-    // notice it here rather than after the clone.
+    // notice it here rather than after the clone. The source is asked whether
+    // this is a local checkout, because it is the only thing that knows —
+    // `--local-repo` and `DARTWAY_MONOREPO_DIR` both end up in it.
     final refusal = channelSwitchRefusal(
       installed: ToolkitProvenance.read(projectRoot),
       requestedChannel: channel,
       channelWasExplicit: argResults!.wasParsed('channel'),
-      fromLocalCheckout: localRepo != null && localRepo.isNotEmpty,
+      fromLocalCheckout: source.isLocalCheckout,
     );
     if (refusal != null) {
       stderr.writeln(refusal);
       return 1;
     }
 
-    final source = MonorepoSource(branch: channel, localDir: localRepo);
     final monorepoDir = await source.resolve();
 
     await ToolkitInstaller.install(
@@ -107,15 +111,7 @@ class SetupAiCommand extends Command<int> {
         language: language,
         notesTracker: notesTracker,
       ),
-      provenance: ToolkitProvenance(
-        source: localRepo != null && localRepo.isNotEmpty
-            ? monorepoDir.path
-            : source.repoUrl,
-        channel: localRepo != null && localRepo.isNotEmpty ? null : channel,
-        commit: await monorepoCommit(monorepoDir),
-        cliVersion: dartwayCliVersion,
-        installedAt: DateTime.now().toUtc().toIso8601String(),
-      ),
+      provenance: await source.provenance(monorepoDir),
     );
 
     stdout.writeln(

--- a/packages/dartway_cli/lib/src/monorepo_source.dart
+++ b/packages/dartway_cli/lib/src/monorepo_source.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import 'toolkit_manifest.dart';
+
 /// Resolves a checkout of the DartWay monorepo to read `toolkit/` and
 /// `template/` from.
 ///
@@ -10,16 +12,34 @@ import 'package:path/path.dart' as p;
 ///    used when developing the framework itself;
 /// 2. a shallow clone of [branch] cached in `~/.dartway/monorepo`.
 class MonorepoSource {
-  MonorepoSource({required this.branch, String? localDir})
-    : localDir = (localDir != null && localDir.isNotEmpty)
-          ? localDir
-          : Platform.environment['DARTWAY_MONOREPO_DIR'];
+  /// [environment] is injectable because the fallback below is a seam that has
+  /// already produced one bug: a caller that checked the `--local-repo`
+  /// argument instead of asking this object got a different answer whenever
+  /// `DARTWAY_MONOREPO_DIR` was the thing in play.
+  MonorepoSource({
+    required this.branch,
+    String? localDir,
+    Map<String, String>? environment,
+  }) : localDir = (localDir != null && localDir.isNotEmpty)
+           ? localDir
+           : (environment ?? Platform.environment)['DARTWAY_MONOREPO_DIR'];
 
   static const defaultRepoUrl = 'https://github.com/dartway/dartway.git';
   static const defaultBranch = 'stable';
 
   final String branch;
   final String? localDir;
+
+  /// Whether the toolkit comes from a checkout on this machine rather than
+  /// from a channel.
+  ///
+  /// **The single answer to that question.** Both entry points — the
+  /// `--local-repo` argument and the `DARTWAY_MONOREPO_DIR` variable — are
+  /// already folded into [localDir] by the constructor, so anything that asks
+  /// here cannot disagree with what [resolve] will actually do. Asking the
+  /// argument instead is how a channel refusal fired over a channel that was
+  /// never going to be touched.
+  bool get isLocalCheckout => localDir != null && localDir!.isNotEmpty;
 
   String get repoUrl =>
       Platform.environment['DARTWAY_REPO_URL'] ?? defaultRepoUrl;
@@ -31,6 +51,20 @@ class MonorepoSource {
         '.';
     return Directory(p.join(home, '.dartway', 'monorepo'));
   }
+
+  /// Where an install from this source came from, for the manifest.
+  ///
+  /// Built here rather than at each call site: the two commands used to repeat
+  /// the same ternaries over the raw argument, and repeating a condition is how
+  /// the two copies of it stopped agreeing.
+  Future<ToolkitProvenance> provenance(Directory resolved) async =>
+      ToolkitProvenance(
+        source: isLocalCheckout ? resolved.path : repoUrl,
+        channel: isLocalCheckout ? null : branch,
+        commit: await monorepoCommit(resolved),
+        cliVersion: dartwayCliVersion,
+        installedAt: DateTime.now().toUtc().toIso8601String(),
+      );
 
   /// Returns the monorepo root, cloning or updating the cache if needed.
   Future<Directory> resolve() async {

--- a/packages/dartway_cli/test/toolkit_manifest_test.dart
+++ b/packages/dartway_cli/test/toolkit_manifest_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:dartway_cli/src/monorepo_source.dart';
 import 'package:dartway_cli/src/toolkit_manifest.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -167,6 +168,61 @@ void main() {
       );
 
       expect(refusalFor(installed: local), isNull);
+    });
+  });
+
+  group('MonorepoSource.isLocalCheckout', () {
+    test('the argument makes it local', () {
+      expect(
+        MonorepoSource(
+          branch: 'stable',
+          localDir: '/home/dev/dartway',
+          environment: const {},
+        ).isLocalCheckout,
+        isTrue,
+      );
+    });
+
+    test('so does the environment variable, with no argument', () {
+      // The half that was missed: a caller checking the `--local-repo`
+      // argument disagreed with what `resolve()` would actually do, and
+      // refused a channel switch over a channel nothing was going to touch.
+      expect(
+        MonorepoSource(
+          branch: 'stable',
+          environment: const {'DARTWAY_MONOREPO_DIR': '/home/dev/dartway'},
+        ).isLocalCheckout,
+        isTrue,
+      );
+    });
+
+    test('the argument wins over the variable', () {
+      expect(
+        MonorepoSource(
+          branch: 'stable',
+          localDir: '/from/argument',
+          environment: const {'DARTWAY_MONOREPO_DIR': '/from/env'},
+        ).localDir,
+        '/from/argument',
+      );
+    });
+
+    test('an empty argument falls through to the variable', () {
+      expect(
+        MonorepoSource(
+          branch: 'stable',
+          localDir: '',
+          environment: const {'DARTWAY_MONOREPO_DIR': '/from/env'},
+        ).localDir,
+        '/from/env',
+      );
+    });
+
+    test('neither means a channel', () {
+      expect(
+        MonorepoSource(branch: 'stable', environment: const {}).isLocalCheckout,
+        isFalse,
+      );
     });
   });
 }


### PR DESCRIPTION
Follow-up to #187, fixing the second finding its review raised. It reached `master` because I read the review and merged in the same step — this is the fix, not a defence of the sequence.

## The bug

`MonorepoSource` treats **two** things as a local checkout, folded together in its constructor:

```dart
localDir = (localDir != null && localDir.isNotEmpty)
    ? localDir
    : (environment ?? Platform.environment)['DARTWAY_MONOREPO_DIR'];
```

The channel guard checked only the `--local-repo` argument. So an install driven by `DARTWAY_MONOREPO_DIR` alone was judged against a channel `resolve()` would then ignore — refused over something the run was never going to touch — and the manifest it would write recorded a repository URL and a channel for a toolkit that had come from a directory on disk.

Same class as the first finding, one entry point further along.

## The fix, and why it is not another condition

The question now has **one answer**, on the object that already knows it:

```dart
/// Whether the toolkit comes from a checkout on this machine rather than
/// from a channel.
bool get isLocalCheckout => localDir != null && localDir!.isNotEmpty;
```

Both entry points are already folded into `localDir` by the constructor, so anything asking here cannot disagree with what `resolve()` will do. Building the provenance moved onto the same object too: the two commands had each been repeating the same pair of ternaries over the raw argument, which is how two copies of one condition ended up disagreeing with a third.

The environment lookup is injectable now — that fallback is the seam that produced this, and a test can state what the variable holds instead of the process having to.

## Green

`tool/checks.sh analyze` clean, **276** tests in `dartway_cli` — 5 new, covering both entry points, the argument winning over the variable, an empty argument falling through to it, and neither meaning a channel.