### PR TITLE
fix(core): an upload object name that neither collides nor enumerates

### DIFF
--- a/docs/4-server/uploads.md
+++ b/docs/4-server/uploads.md
@@ -19,6 +19,24 @@ forms exist when you need more: `pickAndUploadImage()` returns a `DwCloudFile` (
 `uploadXFileToServer(xFile:)` takes a file you already have — from a camera, a drop target, a share
 intent.
 
+Every one of them takes an optional `path` — the folder inside the bucket the object lands in, `avatars` or
+`chat/$roomId`. Omit it and the object sits at the bucket root.
+
+## The object name
+
+You do not name the object; the framework does, and the name is 16 secure random bytes behind a
+readable timestamp. **The randomness is not decoration.** The bucket serves anonymous `GetObject`,
+so a name anyone can guess from a neighbouring one is a file anyone can read — withholding the
+listing protects nothing when the keys enumerate themselves. A guessable name is also a name two
+uploads can collide on, and an overwrite in object storage leaves no trace on either side: the first
+file simply stops existing.
+
+`path` is therefore the knob to reach for when you want uploads grouped or scoped; the name itself is
+not. If you do replace `DwFileUploadHandler.defaultUploadNameTemplate`, keep a random segment in it,
+and leave the extension off — the upload call appends the extension of the bytes it actually sends,
+which is not always the extension of the file that was picked (most images are converted to JPEG on
+the way).
+
 Wrap it in `dw.action`: an upload is slow, and `DwActionBuilder` supplies the `busy` flag and blocks
 the second tap for free.
 

--- a/example/dartway_example_flutter/lib/app/profile/profile_page/widgets/profile_settings_widget.dart
+++ b/example/dartway_example_flutter/lib/app/profile/profile_page/widgets/profile_settings_widget.dart
@@ -64,8 +64,12 @@ class ProfileSettingsWidget extends HookConsumerWidget {
           Center(
             child: DwActionBuilder(
               action: dw.action((_) async {
+                // `path` is the folder in the bucket; the object's own name
+                // is the framework's business and is random by design.
                 final imageUrl =
-                    await DwFileUploadHandler.pickAndUploadImageUrl();
+                    await DwFileUploadHandler.pickAndUploadImageUrl(
+                      path: 'avatars',
+                    );
                 // Null means the picker was dismissed — not a failure.
                 if (imageUrl == null) return;
                 await dw.repo.saveModel(

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -12,7 +12,7 @@
   The name now carries 16 secure random bytes, and that is what makes it unique; the timestamp stays
   as a readable prefix and moved to `HH`.
 
-  **The two name templates no longer carry the file extension** — `uploadXFileToServer` and
+  **Breaking: the two name templates no longer carry the file extension** — `uploadXFileToServer` and
   `uploadPlatformFileToServer` append it, because only they know what was uploaded: the `XFile` path
   converts most images to JPEG, so the picked file's extension described the source rather than the
   bytes, and the server derives the recorded mime type from this name. An app that replaced

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## 0.12.0
 
+- **An upload is no longer named after a calendar second.** `DwFileUploadHandler` named every object
+  `yyyy-MM-dd hh:mm:ss` — a 12-hour clock with nothing marking AM from PM, so one in the afternoon
+  and one in the morning were the same key. Two uploads addressing one object needed no concurrency
+  at all, the later one replaced the earlier, and nothing on either side reported it. The key space
+  being a calendar second also meant that one public URL let anyone walk the neighbouring seconds:
+  withholding the bucket listing protects nothing when the keys enumerate themselves.
+
+  The name now carries 16 secure random bytes, and that is what makes it unique; the timestamp stays
+  as a readable prefix and moved to `HH`.
+
+  **The two name templates no longer carry the file extension** — `uploadXFileToServer` and
+  `uploadPlatformFileToServer` append it, because only they know what was uploaded: the `XFile` path
+  converts most images to JPEG, so the picked file's extension described the source rather than the
+  bytes, and the server derives the recorded mime type from this name. An app that replaced
+  `defaultUploadNameTemplate` or `defaultPlatformUploadNameTemplate` with one that adds its own
+  extension will now get it twice.
+
+- **`pickAndUploadImage` and `pickAndUploadImageUrl` take `path`**, as `uploadXFileToServer` already
+  did. Picking a file and deciding where it lands are unrelated choices; taking the first forfeited
+  the second, so every picked image went to the bucket root and the workaround was to stop using the
+  convenient call.
+
 - **Breaking: the auth key is kept by a plugin, not by the core.** `DwAuthenticationKeyManager` asked
   `shared_preferences` directly through its own `SharedPreferenceStorage`, which was a second
   implementation of what `dartway_shared_preferences` already did — agreeing with it only because

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_file_upload_handler.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/utils/dw_file_upload_handler.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
+import 'dart:math' show Random;
 import 'dart:typed_data';
 
 import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
@@ -13,26 +15,58 @@ import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 class DwFileUploadHandler {
-  static String Function(XFile file) defaultUploadNameTemplate = (XFile file) =>
-      DateFormat('yyyy-MM-dd hh:mm:ss').format(DateTime.now());
+  static final Random _random = Random.secure();
 
-  // The PlatformFile counterpart: it carries an extension but no usable name
-  static String Function(PlatformFile file)
-  defaultPlatformUploadNameTemplate = (PlatformFile file) =>
-      '${DateFormat('yyyy-MM-dd hh:mm:ss').format(DateTime.now())}${file.extension != null ? '.${file.extension!.toLowerCase()}' : ''}';
+  /// A name no other upload can take, whatever the clock says.
+  ///
+  /// The timestamp is a prefix for humans reading the bucket; the random
+  /// segment is what makes the name unique, and it is the only thing that
+  /// does. Naming an object after a calendar second made two uploads in the
+  /// same second address one key — the second silently replaced the first —
+  /// and it made every key guessable from a neighbouring one, which a bucket
+  /// serving anonymous `GetObject` has nothing else to hide behind.
+  static String _uniqueObjectName() {
+    final stamp = DateFormat('yyyy-MM-dd HH:mm:ss').format(DateTime.now());
+    final bytes = List<int>.generate(16, (_) => _random.nextInt(256));
+    final suffix = base64Url.encode(bytes).replaceAll('=', '');
+    return '$stamp $suffix';
+  }
+
+  /// Names the object an [XFile] is uploaded as, **without an extension**.
+  ///
+  /// The extension is appended by [uploadXFileToServer], which is the only
+  /// place that knows it: that method converts most images to JPEG, so the
+  /// picked file's own extension describes the source rather than the bytes
+  /// that reach the bucket — and the server reads the recorded mime type off
+  /// this name.
+  static String Function(XFile file) defaultUploadNameTemplate =
+      (XFile file) => _uniqueObjectName();
+
+  /// The [PlatformFile] counterpart, on the same terms: no extension here,
+  /// [uploadPlatformFileToServer] appends it. That path uploads the bytes it
+  /// was given, so there the source extension is the uploaded one.
+  static String Function(PlatformFile file) defaultPlatformUploadNameTemplate =
+      (PlatformFile file) => _uniqueObjectName();
 
   // -----------------------------
   //  EXISTING IMAGE UPLOAD LOGIC
   // -----------------------------
 
+  /// [path] is the folder the object is placed in, as in
+  /// [uploadXFileToServer]. Picking a file and deciding where it lands are
+  /// unrelated choices, and taking the first used to forfeit the second:
+  /// every picked image went to the bucket root.
   static Future<String?> pickAndUploadImageUrl({
     ImageSource imageSource = ImageSource.gallery,
+    String? path,
   }) async => pickAndUploadImage(
     imageSource: imageSource,
+    path: path,
   ).then((media) => media?.publicUrl);
 
   static Future<DwCloudFile?> pickAndUploadImage({
     ImageSource imageSource = ImageSource.gallery,
+    String? path,
   }) async {
     final file = await ImagePicker().pickImage(source: imageSource);
 
@@ -41,7 +75,7 @@ class DwFileUploadHandler {
       return null;
     }
 
-    return await uploadXFileToServer(xFile: file);
+    return await uploadXFileToServer(xFile: file, path: path);
   }
 
   static Future<String?> uploadXFileToServerUrl({
@@ -64,9 +98,13 @@ class DwFileUploadHandler {
 
     final bytesToUpload = jpegBytes ?? originalBytes;
 
-    final uploadPath = path == null
-        ? defaultUploadNameTemplate(xFile)
-        : '$path/${defaultUploadNameTemplate(xFile)}';
+    // The bytes decide the extension, not the picked file: a HEIC that was
+    // converted is uploaded as JPEG, and the server derives the recorded mime
+    // type from this name.
+    final uploadedExtension = jpegBytes != null ? '.jpg' : fileExtension;
+
+    final name = '${defaultUploadNameTemplate(xFile)}$uploadedExtension';
+    final uploadPath = path == null ? name : '$path/$name';
 
     return uploadBytesToServer(bytes: bytesToUpload, path: uploadPath);
   }
@@ -103,9 +141,15 @@ class DwFileUploadHandler {
 
     final bytesToUpload = bytes;
 
-    final uploadPath = path == null
-        ? defaultPlatformUploadNameTemplate(platformFile)
-        : '$path/${defaultPlatformUploadNameTemplate(platformFile)}';
+    // Nothing converts here, so the picked file's extension is the uploaded
+    // one.
+    final uploadedExtension = platformFile.extension != null
+        ? '.${platformFile.extension!.toLowerCase()}'
+        : '';
+
+    final name =
+        '${defaultPlatformUploadNameTemplate(platformFile)}$uploadedExtension';
+    final uploadPath = path == null ? name : '$path/$name';
 
     return uploadBytesToServer(bytes: bytesToUpload, path: uploadPath);
   }

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_file_upload_name_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_file_upload_name_test.dart
@@ -1,0 +1,58 @@
+import 'package:dartway_serverpod_core_flutter/src/utils/dw_file_upload_handler.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
+
+/// The object name is the whole of the protection here: the bucket serves
+/// anonymous `GetObject`, so a key that can be guessed is a key that can be
+/// read, and a key that can collide is a file that can be overwritten with no
+/// trace on either side. Both properties are asserted against the two
+/// templates, because those are what every upload goes through.
+void main() {
+  final xFile = XFile('/tmp/photo.heic');
+  final platformFile = PlatformFile(
+    name: 'photo.png',
+    size: 1,
+    path: '/tmp/photo.png',
+  );
+
+  group('the default object name does not come from the clock', () {
+    test('a thousand names taken back to back are all different', () {
+      // A calendar second was the whole key: two uploads inside one second
+      // addressed one object, and the later one replaced the earlier.
+      final names = List.generate(1000, (_) => DwFileUploadHandler.defaultUploadNameTemplate(xFile));
+
+      expect(names.toSet(), hasLength(names.length));
+    });
+
+    test('the PlatformFile template is unique on the same terms', () {
+      final names = List.generate(
+        1000,
+        (_) => DwFileUploadHandler.defaultPlatformUploadNameTemplate(platformFile),
+      );
+
+      expect(names.toSet(), hasLength(names.length));
+    });
+
+    test('neither template carries the extension — the upload appends it', () {
+      // Split deliberately: `uploadXFileToServer` converts most images to
+      // JPEG, so only it knows what the uploaded bytes are.
+      expect(DwFileUploadHandler.defaultUploadNameTemplate(xFile), isNot(contains('.')));
+      expect(
+        DwFileUploadHandler.defaultPlatformUploadNameTemplate(platformFile),
+        isNot(contains('.')),
+      );
+    });
+  });
+
+  test('the readable prefix is a 24-hour timestamp of now', () {
+    // `hh` printed the same string at 01:05 and at 13:05. Uniqueness no longer
+    // rests on this — the random segment carries it — but a name a human reads
+    // off the bucket should not name two different moments.
+    final name = DwFileUploadHandler.defaultUploadNameTemplate(xFile);
+    final stamp = DateFormat('yyyy-MM-dd HH:mm:ss').parse(name.substring(0, 19));
+
+    expect(DateTime.now().difference(stamp).inMinutes, lessThan(5));
+  });
+}

--- a/template/dartway_starter_flutter/lib/app/profile/profile_page/widgets/profile_settings_widget.dart
+++ b/template/dartway_starter_flutter/lib/app/profile/profile_page/widgets/profile_settings_widget.dart
@@ -64,8 +64,12 @@ class ProfileSettingsWidget extends HookConsumerWidget {
           Center(
             child: DwActionBuilder(
               action: dw.action((_) async {
+                // `path` is the folder in the bucket; the object's own name
+                // is the framework's business and is random by design.
                 final imageUrl =
-                    await DwFileUploadHandler.pickAndUploadImageUrl();
+                    await DwFileUploadHandler.pickAndUploadImageUrl(
+                      path: 'avatars',
+                    );
                 // Null means the picker was dismissed — not a failure.
                 if (imageUrl == null) return;
                 await dw.repo.saveModel(

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -718,6 +718,10 @@ From then on the link lives as an ordinary model field and travels the same CRUD
 
 Neighbouring forms: `pickAndUploadImage()` (returns a `DwCloudFile` with size and mime), `uploadXFileToServer(xFile:)` — when the file is already obtained (camera, drag-n-drop).
 
+Every one of them takes an optional `path` — the folder inside the bucket (`avatars`, `chat/$roomId`). Omit it and the object sits at the root.
+
+**Do not name the object yourself.** The framework names it after 16 secure random bytes behind a readable timestamp, and that is a guarantee, not a style: the bucket serves anonymous `GetObject`, so a guessable name is a readable file, and two uploads that collide overwrite each other with no trace on either side. Group uploads with `path`; leave the name alone.
+
 **Wrap it in `dw.action`** — the upload is long, and `DwActionBuilder` will suppress a repeated tap by itself and hand back `busy` for the indicator.
 
 **What is needed on the server:** `cloudStorageConfig` in `DwCore.init` (in the project these are the `dwCloudStorage*` keys in `config/passwords.yaml`, and in development the `minio` service from `docker-compose.yaml`). If storage is not configured, the upload will honestly say so instead of failing silently.


### PR DESCRIPTION
Closes #149.

## What was wrong

`DwFileUploadHandler` named every object after a calendar second, `yyyy-MM-dd hh:mm:ss`. Three things followed, and the third is not in the issue:

1. **`hh` is the 12-hour clock**, with nothing marking AM from PM. `2026-08-27 01:05:07` is the key at 01:05:07 *and* at 13:05:07, so a collision needs no concurrency — one upload lands on an object written twelve hours earlier. Real concurrency (two people saving a photo in the same second) does the same thing faster. The second write replaces the first, and object storage reports nothing on either side: the file simply stops existing.
2. **The key space is a calendar second**, so it enumerates. A bucket configured the usual way — anonymous `GetObject`, no `ListBucket` — is not protected by withholding the listing when one public URL gives you the neighbouring keys.
3. **`pickAndUploadImage` / `pickAndUploadImageUrl` took no `path`**, while `uploadXFileToServer` and `uploadPlatformFileToServer` did. So the two calls the docs and the toolkit skill teach were the two that could not choose a folder, and the workaround two applications reached for independently — build the path by hand — was unavailable through them.

## What this changes

- The name carries **16 bytes from `Random.secure()`**, and that is the only thing making it unique. The timestamp stays as a readable prefix for whoever reads the bucket, and moves to `HH`.
- **`pickAndUploadImage` and `pickAndUploadImageUrl` take `path`**, additively.
- **The name templates no longer carry the extension**; `uploadXFileToServer` and `uploadPlatformFileToServer` append it. Only they know what was sent: the `XFile` path converts most images to JPEG, so the picked file's extension described the source rather than the bytes — and the server derives `DwCloudFile.mimeType` from this name, which until now was `null` for every image uploaded through that path, since the name had no extension at all.

## What it does not change

The server still signs an upload description for whatever path the client asks for (`DwUploadEndpoint.getUploadDescription`), with no check that the object is free or that the caller owns the prefix. Accidental collisions are gone; a signed-in user deliberately naming someone else's key is not, and `verifyUpload` would then record them as the owner of the row. That is a separate change — it moves the naming decision to the server, alters the shape of public URLs and breaks applications that build the path by hand — and it was deliberately left out of this one.

## Acceptance

`packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_file_upload_name_test.dart`: a thousand names taken back to back are all distinct, through both templates, and neither carries an extension. The uniqueness assertions were confirmed to go red against the old clock-only name before the fix went in.

`tool/checks.sh` green.

## Synchronisation

`example/` and `template/` now pass `path: 'avatars'` on the profile photo, which both demonstrates the parameter and stops the skeleton's own uploads landing at the bucket root; `docs/4-server/uploads.md` and `toolkit/skills/dartway-data-layer` state that the object name is the framework's business and why; `CHANGELOG.md` under the pending `0.12.0`. The version is not moved — `master` is already at `0.12.0` against `0.11.0` on `stable`, and the carets in `example/` and `template/` are `^0.12.0`.