### PR TITLE
fix(monorepo): the tree stops dirtying itself, and a check keeps it that way

### DIFF
--- a/.claude/skills/framework-finish/SKILL.md
+++ b/.claude/skills/framework-finish/SKILL.md
@@ -75,6 +75,18 @@ For each package in the first list, find the carets on it in the second and chec
 
 A mismatch is **a line in the report** of the form `<package> <version> → <file>:<line> ^<constraint>`, and it is fixed by raising the caret to the current version's minor. Packages that simply are not in `template/`/`example/` (`dartway_telegram`, the push transports) are not a finding.
 
+### The lockfiles say a version too
+
+The carets are not the only copy of a package's version outside its `pubspec.yaml`. Every committed `pubspec.lock` records one for each path-overridden local package, and that copy is written by whichever `pub get` ran last — nothing keeps it in step with a bump. It is checked in one command:
+
+```bash
+dart run tool/lock_check.dart
+```
+
+It names every lockfile whose recorded version disagrees with the package's own, and exits 1. The fix it prints is the fix: `flutter pub get` in each tree it named, then commit the lockfile.
+
+**Why it earns a step of its own rather than a mention.** A stale lock breaks nothing at runtime, so nothing ever fails because of it. What it does is dirty the working tree: the next `pub get` in any tree rewrites the file, and `git status` comes back modified in a tree where nobody touched it. `CLAUDE.md` makes a clean tree mean "another session is working here" — it is the first rule of Claude's git protocol — so this noise is read as the alarming thing, and it puts the forbidden `git add -A` back in reach. Two locks sat a minor behind for a whole release cycle exactly this way (#192).
+
 ## Step 5. Report and fix
 
 Give the drift as a list in the form `<API change> → <mirror> → <what exactly is stale or missing>`. If there is none, say so in one line.

--- a/example/dartway_example_flutter/ios/Flutter/Debug.xcconfig
+++ b/example/dartway_example_flutter/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/dartway_example_flutter/ios/Flutter/Release.xcconfig
+++ b/example/dartway_example_flutter/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/dartway_example_flutter/ios/Podfile
+++ b/example/dartway_example_flutter/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -134,14 +134,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.11.0"
+    version: "0.12.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.11.0"
+    version: "0.12.0"
   ffi:
     dependency: transitive
     description:

--- a/template/dartway_starter_server/pubspec.lock
+++ b/template/dartway_starter_server/pubspec.lock
@@ -127,14 +127,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.11.0"
+    version: "0.12.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.11.0"
+    version: "0.12.0"
   dartway_starter_shared:
     dependency: "direct main"
     description:

--- a/tool/checks.sh
+++ b/tool/checks.sh
@@ -96,7 +96,9 @@ analyze() {
   # Errors only. One warning stands today and it is in generated code
   # (`dw_updates_transport.dart`), which nobody reviews and the generator
   # rewrites — gating on it would make red mean "the generator again".
-  run "packages (workspace)" dart analyze --no-fatal-warnings packages
+  # `tool` is in here so the scripts this repository runs on itself are held
+  # to the same analyzer as the code they check.
+  run "packages + tool (workspace)" dart analyze --no-fatal-warnings packages tool
   for package in $(packages); do
     is_member "$package" && continue
     run "$package" bash -c "cd '$package' && dart analyze --no-fatal-warnings"

--- a/tool/lock_check.dart
+++ b/tool/lock_check.dart
@@ -1,0 +1,122 @@
+// Are the committed lockfiles telling the truth about our own packages?
+//
+// Every lockfile in the tree records a `version:` for each path-overridden
+// local package. That number is a copy of what the package's `pubspec.yaml`
+// said the last time the lock was written, and nothing keeps the copy in step:
+// bump a package and the locks go stale silently, so the next `pub get` in any
+// tree rewrites them and the tree dirties itself for reasons that have nothing
+// to do with the task. `CLAUDE.md` makes a clean tree mean "another session is
+// working here", so the noise costs more than it looks.
+//
+// Usage: dart run tool/lock_check.dart   (from the repository root)
+// Exits 1 and names every stale entry; exits 0 and says so when there are none.
+
+import 'dart:io';
+
+void main() {
+  final root = Directory.current;
+  final locks =
+      root
+          .listSync(recursive: true, followLinks: false)
+          .whereType<File>()
+          .where((f) => f.path.endsWith('pubspec.lock'))
+          .where(
+            (f) =>
+                !f.path.contains('/.dart_tool/') && !f.path.contains('/build/'),
+          )
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  final stale = <String>[];
+
+  for (final lock in locks) {
+    final relative = lock.path.replaceFirst('${root.path}/', '');
+    for (final entry in _pathEntries(lock)) {
+      final pubspec = File(
+        _normalise('${lock.parent.path}/${entry.path}/pubspec.yaml'),
+      );
+      if (!pubspec.existsSync()) {
+        stale.add('$relative: ${entry.name} points at a package that is gone');
+        continue;
+      }
+      final declared = _version(pubspec);
+      if (declared != null && declared != entry.version) {
+        stale.add(
+          '$relative: ${entry.name} locked ${entry.version}, '
+          'package declares $declared',
+        );
+      }
+    }
+  }
+
+  if (stale.isEmpty) {
+    stdout.writeln('✓ every lockfile agrees with the packages it locks');
+    return;
+  }
+
+  stale.forEach(stdout.writeln);
+  stdout.writeln(
+    '\n${stale.length} stale entr${stale.length == 1 ? 'y' : 'ies'}. '
+    'Fix: `flutter pub get` in each tree above and commit the lockfile.',
+  );
+  exit(1);
+}
+
+/// The lockfile entries resolved through a local path, one record each.
+///
+/// Parsed by tracking the entry a line belongs to rather than by a pattern
+/// spanning lines: a pattern that may cross a blank line silently reads the
+/// name of one entry together with the path of the next, which is how the
+/// first draft of this reported `_fe_analyzer_shared` as one of ours.
+Iterable<_Locked> _pathEntries(File lock) sync* {
+  String? name, path, version;
+  var isPath = false;
+
+  for (final line in lock.readAsLinesSync()) {
+    final start = RegExp(r'^  ([A-Za-z0-9_]+):$').firstMatch(line);
+    if (start != null) {
+      if (name != null && isPath && path != null && version != null) {
+        yield _Locked(name, path, version);
+      }
+      name = start.group(1);
+      path = null;
+      version = null;
+      isPath = false;
+      continue;
+    }
+    if (name == null) continue;
+
+    path ??= RegExp(r'^      path: "(.*)"$').firstMatch(line)?.group(1);
+    version ??= RegExp(r'^    version: "(.*)"$').firstMatch(line)?.group(1);
+    if (line == '    source: path') isPath = true;
+  }
+
+  if (name != null && isPath && path != null && version != null) {
+    yield _Locked(name, path, version);
+  }
+}
+
+String? _version(File pubspec) => RegExp(
+  r'^version:\s*(\S+)',
+  multiLine: true,
+).firstMatch(pubspec.readAsStringSync())?.group(1);
+
+/// Collapses the `../..` a lockfile path is written with.
+String _normalise(String path) {
+  final parts = <String>[];
+  for (final part in path.split('/')) {
+    if (part == '..' && parts.isNotEmpty && parts.last != '..') {
+      parts.removeLast();
+    } else if (part != '.') {
+      parts.add(part);
+    }
+  }
+  return parts.join('/');
+}
+
+class _Locked {
+  const _Locked(this.name, this.path, this.version);
+  final String name;
+  final String path;
+  final String version;
+}


### PR DESCRIPTION
Closes #172. Closes #192.

#144 turned out to be **already fixed** and was closed separately, not by this PR — `example/dartway_example_flutter` now holds `matcher 0.12.18` / `test_api 0.7.9`, in step with the other five Flutter roots; `c84d538` (#163) rewrote the file without a `Closes` line, which is why it stayed open.

## What was happening

```
$ git worktree add ../dartway-wt/x -b x master
$ cd ../dartway-wt/x/example/dartway_example_flutter && flutter pub get
$ cd ../.. && git status --short
 M example/dartway_example_flutter/ios/Flutter/Debug.xcconfig
 M example/dartway_example_flutter/ios/Flutter/Release.xcconfig
?? example/dartway_example_flutter/ios/Podfile
```

Resolve every root the way `tool/checks.sh` does and two more appear — `example/dartway_example_server/pubspec.lock` and `template/dartway_starter_server/pubspec.lock`, both recording `0.11.0` for core packages that have been `0.12.0` on `master` for a release cycle.

`CLAUDE.md` makes a clean tree carry a meaning, and it is the first rule of Claude's git protocol: dirty ⇒ another session is working here, do not work in this directory. A tree that dirties itself on the first command makes that signal useless, and the reading it produces is the alarming one. It also puts noise in front of `git add`, which is exactly where the forbidden `git add -A` stays convenient. Both halves were met while working #149 in the previous run — the noise had to be examined file by file before the worktree could be removed.

## The iOS half was already decided, in `template/`

`template/dartway_starter_flutter` carries the CocoaPods `#include?` line in both `xcconfig`s **and** tracks `ios/Podfile`. Only `example/` had fallen out of step, and `ios/.gitignore` does not mention the Podfile — so this was a missing file, not a design question. Verified before committing: what the toolchain generates in `example/` is **byte-identical** to the template's Podfile, and the two `xcconfig` lines are the ones the template already holds.

## The lockfile half is the one that comes back

The `version:` a lock records for a path-overridden local package is a copy of that package's `pubspec.yaml`, written by whichever `pub get` ran last. Nothing keeps the copy in step with a bump, so it goes stale on every minor, silently, and the next `pub get` in any tree rewrites it. Refreshing the two files fixes today; it does not fix the next release cycle.

So `tool/lock_check.dart` compares the two sides and names each disagreement:

```
$ dart run tool/lock_check.dart          # on master
example/dartway_example_server/pubspec.lock: dartway_serverpod_core_server locked 0.11.0, package declares 0.12.0
example/dartway_example_server/pubspec.lock: dartway_serverpod_core_shared locked 0.11.0, package declares 0.12.0
template/dartway_starter_server/pubspec.lock: dartway_serverpod_core_server locked 0.11.0, package declares 0.12.0
template/dartway_starter_server/pubspec.lock: dartway_serverpod_core_shared locked 0.11.0, package declares 0.12.0

4 stale entries. Fix: `flutter pub get` in each tree above and commit the lockfile.
```

`framework-finish` runs it in Step 4, which already checks versions and carets — the same class of fact, the same moment.

`tool/` joins the analyzed paths in `checks.sh` in the same commit: nothing analyzed that directory, so this PR would otherwise have added a script the repository never checks.

## Acceptance

The one #172 states, run literally in a worktree created fresh from this branch:

```
$ git status --short                     # (empty)
$ flutter pub get && (cd example/dartway_example_flutter && flutter pub get)
$ git status --short                     # (empty)
$ ./tool/checks.sh                       # ✓ everything green
$ git status --short                     # (empty)
```

The lock check was confirmed to go red before it was trusted: reverting one lock entry to `0.11.0` makes it exit 1 naming that entry, and the tree green again afterwards. Its first draft was a multi-line regex that reported `_fe_analyzer_shared` — a package that is not ours — as stale; it is parsed entry by entry now, and that is what the comment in `_pathEntries` is about.

## Not in this PR

Making "the tree is clean after `pub get`" a gate in `checks.yml`. It is exactly #172's acceptance, but a `git status` gate in CI is the fragile kind, and a flaky red teaches people to stop reading the gate — the state #184 describes. Worth deciding on its own.