### PR TITLE
chore(tooling): one entry point for "is this repository what it says it is"

### DIFF
--- a/.claude/skills/framework-finish/SKILL.md
+++ b/.claude/skills/framework-finish/SKILL.md
@@ -75,29 +75,26 @@ For each package in the first list, find the carets on it in the second and chec
 
 A mismatch is **a line in the report** of the form `<package> <version> → <file>:<line> ^<constraint>`, and it is fixed by raising the caret to the current version's minor. Packages that simply are not in `template/`/`example/` (`dartway_telegram`, the push transports) are not a finding.
 
-### And pub.dev has the last word
+### Step 4b. Ask the repository whether it is what it says it is
 
-Both checks above read the tree. Neither can see the thing that actually breaks a stranger: the caret in `template/` is compared with the **local** `packages/*/pubspec.yaml`, and those two move in the same pull request. The check is therefore green in exactly the situation that hurts — local version 0.12.0, caret `^0.12.0`, pub.dev 0.11.0 — because `dependency_overrides` mean pub never reads the constraint here at all, and `dartway create` strips the block on the way out.
+Three of the facts this repository states about itself are copies of something else, and a copy goes stale in silence:
 
-```bash
-dart run tool/caret_check.dart
-```
+- **the lockfiles** record a version for each path-overridden local package, written by whichever `pub get` ran last — stale ones dirty every working tree on the next resolve, and a tree that dirties itself makes "dirty means another session is here" meaningless (#192, #172);
+- **the carets** in `template/`/`example/` are compared, everywhere else, against the **local** `packages/*/pubspec.yaml` — and those two move in the same pull request, so that comparison is green exactly when the skeleton has become uninstallable for a stranger (#143);
+- **the git settings** `CLAUDE.md` names live in `.git/config`, per clone and per machine, and nothing sets them or notices they are missing (#170).
 
-It asks pub.dev for each `dartway_*` the skeleton depends on and names every caret the published version does not satisfy, with the file and line. **Its exit code has three values, and the third matters:** `0` all satisfied, `1` findings listed, `2` pub.dev could not be asked. A lost connection reported as a finding would read as "the release is broken" and be believed, so it is kept separate.
-
-A finding here is not fixed by editing the caret — it is fixed by publishing, which is a release decision. Report it and say which packages lag.
-
-### The lockfiles say a version too
-
-The carets are not the only copy of a package's version outside its `pubspec.yaml`. Every committed `pubspec.lock` records one for each path-overridden local package, and that copy is written by whichever `pub get` ran last — nothing keeps it in step with a bump. It is checked in one command:
+One command asks all three:
 
 ```bash
-dart run tool/lock_check.dart
+dart run tool/self_check.dart            # everything
+dart run tool/self_check.dart --offline  # skip the check that needs pub.dev
 ```
 
-It names every lockfile whose recorded version disagrees with the package's own, and exits 1. The fix it prints is the fix: `flutter pub get` in each tree it named, then commit the lockfile.
+**Its exit code has three values, and the third is the point:** `0` clean, `1` something is not what we say it is, `2` a check could not be carried out — pub.dev unreachable, most likely. A check that could not run is not a check that failed; reporting the two the same way is how people learn to skim a gate.
 
-**Why it earns a step of its own rather than a mention.** A stale lock breaks nothing at runtime, so nothing ever fails because of it. What it does is dirty the working tree: the next `pub get` in any tree rewrites the file, and `git status` comes back modified in a tree where nobody touched it. `CLAUDE.md` makes a clean tree mean "another session is working here" — it is the first rule of Claude's git protocol — so this noise is read as the alarming thing, and it puts the forbidden `git add -A` back in reach. Two locks sat a minor behind for a whole release cycle exactly this way (#192).
+**What a finding means differs by check, so read the summary rather than the count.** A stale lockfile is fixed by `flutter pub get` and a commit. A missing git setting is fixed by the `git config` line it prints, and it is yours alone — setting it here sets it for nobody else. **A caret finding is not fixed by editing the caret:** it means the packages are not published yet, which is a release decision. Report it and name the packages that lag.
+
+This is deliberately not in `tool/checks.sh`, and therefore not in CI: two of the three would be red on every runner by construction — a fresh clone has none of the git settings, and the carets are unsatisfied for as long as a release is pending. A gate that is red by design is a gate people stop reading.
 
 ## Step 5. Report and fix
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,17 @@ These are not suggestions: each item closes off a way for one session to destroy
 
 **Protection.** `master` and `stable` are covered by the `protect-trunk` ruleset: force-pushes and deletion are forbidden, with no bypass. A fast-forward push (promotion included) goes through normally. Needing to rewrite the trunk's history is a reason to stop and discuss, not to switch the rule off.
 
-**Hygiene.** A branch is deleted automatically when its PR merges (`deleteBranchOnMerge`). Locally: `fetch.prune=true` (dead remote references stop piling up), `pull.rebase=true`, `rerere.enabled=true`. In this repository `user.email` is set locally to the work address, because the repository is public.
+**Hygiene.** A branch is deleted automatically when its PR merges (`deleteBranchOnMerge`). In this repository `user.email` is set locally to the work address, because the repository is public.
+
+Three local settings are expected, and **they do not travel with the code** — they live in `.git/config`, per clone and per machine. Run them once after cloning:
+
+```bash
+git config fetch.prune true      # dead remote references stop piling up
+git config pull.rebase true      # no merge commits from a pull
+git config rerere.enabled true   # a conflict resolved once is remembered
+```
+
+This used to be written here as a statement of fact about a clone, and it was not one: a real clone worked in daily for months had one of the three. Without `fetch.prune`, remote-tracking refs outlive the branches they track and read as unfinished work — three of them were investigated one at a time before it turned out all three had been merged. `dart run tool/self_check.dart` is what notices now.
 
 ### CI
 

--- a/tool/caret_check.dart
+++ b/tool/caret_check.dart
@@ -23,9 +23,20 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'check_result.dart';
+
 const _host = 'pub.dev';
 
 void main() async {
+  final report = await checkCarets();
+  report.findings.forEach(stdout.writeln);
+  final sink = report.outcome == CheckOutcome.unavailable ? stderr : stdout;
+  sink.writeln(report.summary);
+  if (report.exitCode != 0) exit(report.exitCode);
+}
+
+Future<CheckReport> checkCarets() async {
+  const title = 'carets against $_host';
   final constraints = <_Constraint>[];
   for (final tree in ['template', 'example']) {
     final directory = Directory(tree);
@@ -37,11 +48,11 @@ void main() async {
   }
 
   if (constraints.isEmpty) {
-    stderr.writeln(
+    return const CheckReport.unavailable(
+      title,
       'No dartway_* carets found under template/ or example/. '
       'Run this from the repository root.',
     );
-    exit(2);
   }
 
   final published = <String, _Published>{};
@@ -49,8 +60,10 @@ void main() async {
     try {
       published[name] = await _latestOf(name);
     } on _Unreachable catch (failure) {
-      stderr.writeln('Could not ask $_host about $name: ${failure.reason}');
-      exit(2);
+      return CheckReport.unavailable(
+        title,
+        'Could not ask $_host about $name: ${failure.reason}',
+      );
     }
   }
 
@@ -82,20 +95,20 @@ void main() async {
   }
 
   if (findings.isEmpty) {
-    stdout.writeln(
+    return CheckReport.ok(
+      title,
       '✓ all ${constraints.length} dartway carets are satisfied by $_host',
     );
-    return;
   }
 
-  findings.forEach(stdout.writeln);
-  stdout.writeln(
-    '\n${findings.length} caret${findings.length == 1 ? '' : 's'} a stranger '
+  return CheckReport.findings(
+    title,
+    findings,
+    '${findings.length} caret${findings.length == 1 ? '' : 's'} a stranger '
     'cannot resolve. Fix: publish the packages, or lower the carets to what is '
     'published. Inside the monorepo nothing will fail either way — '
     'dependency_overrides hide this until `dartway create`.',
   );
-  exit(1);
 }
 
 /// Every `dartway_*: ^X.Y.Z` a pubspec states as a real dependency.

--- a/tool/check_result.dart
+++ b/tool/check_result.dart
@@ -1,0 +1,46 @@
+// What a self-check answers, so that one entry point can aggregate several.
+//
+// Three outcomes rather than two, because one of the checks asks the network:
+// "I could not find out" has to stay distinguishable from "I found out, and it
+// is wrong". Collapsing them makes a dropped connection read as a broken
+// release — and be believed.
+
+enum CheckOutcome {
+  /// Nothing to report.
+  ok,
+
+  /// Real findings, listed in [CheckReport.findings].
+  findings,
+
+  /// The check could not be carried out at all. Not a finding.
+  unavailable,
+}
+
+class CheckReport {
+  const CheckReport.ok(this.title, this.summary)
+    : outcome = CheckOutcome.ok,
+      findings = const [];
+
+  const CheckReport.findings(this.title, this.findings, this.summary)
+    : outcome = CheckOutcome.findings;
+
+  const CheckReport.unavailable(this.title, this.summary)
+    : outcome = CheckOutcome.unavailable,
+      findings = const [];
+
+  final String title;
+  final CheckOutcome outcome;
+  final List<String> findings;
+
+  /// One line: what the check concluded, and — when there are findings — how
+  /// they are fixed. Printed whether or not anything was found.
+  final String summary;
+
+  /// The exit code this check would use on its own: 0 clean, 1 findings,
+  /// 2 could not be carried out.
+  int get exitCode => switch (outcome) {
+    CheckOutcome.ok => 0,
+    CheckOutcome.findings => 1,
+    CheckOutcome.unavailable => 2,
+  };
+}

--- a/tool/git_config_check.dart
+++ b/tool/git_config_check.dart
@@ -1,0 +1,82 @@
+// Are the local git settings the constitution states actually set?
+//
+// `CLAUDE.md` used to say, as a statement of fact: "Locally: `fetch.prune=true`,
+// `pull.rebase=true`, `rerere.enabled=true`." It was not one. These live in
+// `.git/config`, per clone and per machine; they do not travel with the code,
+// so cloning the repository and reading that sentence gave you a repository
+// that did not do what the sentence said, with nothing anywhere setting them or
+// noticing they were missing.
+//
+// The cost is the quiet kind. Without `fetch.prune` a remote-tracking ref
+// survives the branch it tracks — `deleteBranchOnMerge` is on and GitHub does
+// delete them, but a clone that never prunes keeps showing them, and they read
+// as unfinished work, because that is exactly what an unmerged branch looks
+// like. Three were investigated one at a time before it became clear all three
+// had been merged and the refs were simply dead.
+//
+// Usage: dart run tool/git_config_check.dart   (from the repository root)
+
+import 'dart:io';
+
+import 'check_result.dart';
+
+/// The settings `CLAUDE.md` states, and why each is worth a line.
+const _expected = <String, ({String value, String because})>{
+  'fetch.prune': (value: 'true', because: 'dead remote refs stop piling up'),
+  'pull.rebase': (value: 'true', because: 'no merge commits from a pull'),
+  'rerere.enabled': (
+    value: 'true',
+    because: 'a conflict resolved once is remembered',
+  ),
+};
+
+void main() {
+  final report = checkGitConfig();
+  report.findings.forEach(stdout.writeln);
+  stdout.writeln(report.summary);
+  if (report.exitCode != 0) exit(report.exitCode);
+}
+
+CheckReport checkGitConfig() {
+  const title = 'git settings';
+
+  if (!Directory('.git').existsSync() && !File('.git').existsSync()) {
+    return const CheckReport.unavailable(
+      title,
+      'No .git here — run this from the repository root.',
+    );
+  }
+
+  final findings = <String>[];
+  for (final entry in _expected.entries) {
+    final actual = _configured(entry.key);
+    if (actual == entry.value.value) continue;
+    findings.add(
+      '${entry.key} is ${actual == null ? 'not set' : actual} — '
+      'want ${entry.value.value} (${entry.value.because}); '
+      'fix: git config ${entry.key} ${entry.value.value}',
+    );
+  }
+
+  if (findings.isEmpty) {
+    return const CheckReport.ok(
+      title,
+      '✓ this clone has the git settings CLAUDE.md states',
+    );
+  }
+  return CheckReport.findings(
+    title,
+    findings,
+    '${findings.length} of ${_expected.length} git settings are not what '
+    'CLAUDE.md says they are. They are per-clone and per-machine: setting them '
+    'here does not set them for anyone else.',
+  );
+}
+
+/// `null` when the key is unset. `git config --get` exits 1 for that, which is
+/// not an error and must not be reported as one.
+String? _configured(String key) {
+  final result = Process.runSync('git', ['config', '--get', key]);
+  if (result.exitCode != 0) return null;
+  return (result.stdout as String).trim();
+}

--- a/tool/lock_check.dart
+++ b/tool/lock_check.dart
@@ -10,10 +10,21 @@
 //
 // Usage: dart run tool/lock_check.dart   (from the repository root)
 // Exits 1 and names every stale entry; exits 0 and says so when there are none.
+// `tool/self_check.dart` runs this together with its siblings.
 
 import 'dart:io';
 
+import 'check_result.dart';
+
 void main() {
+  final report = checkLockfiles();
+  report.findings.forEach(stdout.writeln);
+  stdout.writeln(report.summary);
+  if (report.exitCode != 0) exit(report.exitCode);
+}
+
+CheckReport checkLockfiles() {
+  const title = 'lockfiles';
   final root = Directory.current;
   final locks =
       root
@@ -50,16 +61,18 @@ void main() {
   }
 
   if (stale.isEmpty) {
-    stdout.writeln('✓ every lockfile agrees with the packages it locks');
-    return;
+    return const CheckReport.ok(
+      title,
+      '✓ every lockfile agrees with the packages it locks',
+    );
   }
 
-  stale.forEach(stdout.writeln);
-  stdout.writeln(
-    '\n${stale.length} stale entr${stale.length == 1 ? 'y' : 'ies'}. '
+  return CheckReport.findings(
+    title,
+    stale,
+    '${stale.length} stale entr${stale.length == 1 ? 'y' : 'ies'}. '
     'Fix: `flutter pub get` in each tree above and commit the lockfile.',
   );
-  exit(1);
 }
 
 /// The lockfile entries resolved through a local path, one record each.

--- a/tool/self_check.dart
+++ b/tool/self_check.dart
@@ -1,0 +1,82 @@
+// One question, asked once: is what this repository says about itself true?
+//
+// Four times in a row the answer was no, in four different places — the
+// lockfiles recorded a version the packages had left behind (#192), the carets
+// stated a release that was never published (#143), the working tree rewrote
+// files it had committed (#172), and `CLAUDE.md` described git settings a clone
+// does not have (#170). Each was found by a person, late, and each was answered
+// with a script of its own. A fourth separate script would have been the habit
+// rather than the fix: three commands to remember, called one at a time, and a
+// `framework-finish` growing a list.
+//
+// So the scripts stay one per subject — they are read when they fail, and a
+// file per subject is what makes that readable — and the entry point is shared.
+//
+// Usage:
+//   dart run tool/self_check.dart              every check
+//   dart run tool/self_check.dart --offline    everything that needs no network
+//
+// Exit codes, aggregated: 0 all clean · 1 something is not what we say it is ·
+// 2 nothing is wrong, but a check could not be carried out. The last is its own
+// code for the reason `caret_check` gave it one — a check that could not run is
+// not a check that failed, and reporting it as failure trains people to skim.
+
+import 'dart:io';
+
+import 'caret_check.dart';
+import 'check_result.dart';
+import 'git_config_check.dart';
+import 'lock_check.dart';
+
+void main(List<String> arguments) async {
+  final unknown = arguments.where((a) => a != '--offline');
+  if (unknown.isNotEmpty) {
+    stderr.writeln('Unknown argument: ${unknown.first}');
+    stderr.writeln('Usage: dart run tool/self_check.dart [--offline]');
+    exit(64);
+  }
+  final offline = arguments.contains('--offline');
+
+  final reports = <CheckReport>[checkGitConfig(), checkLockfiles()];
+  if (offline) {
+    stdout.writeln('— carets against pub.dev: skipped (--offline)');
+  } else {
+    reports.add(await checkCarets());
+  }
+
+  for (final report in reports) {
+    stdout.writeln('— ${report.title}');
+    for (final finding in report.findings) {
+      stdout.writeln('  $finding');
+    }
+    stdout.writeln('  ${report.summary}');
+  }
+
+  final failed = reports.where((r) => r.outcome == CheckOutcome.findings);
+  final unavailable = reports.where(
+    (r) => r.outcome == CheckOutcome.unavailable,
+  );
+
+  stdout.writeln();
+  if (failed.isEmpty && unavailable.isEmpty) {
+    stdout.writeln('✓ the repository is what it says it is');
+    return;
+  }
+
+  // Findings outrank an unavailable check: something being wrong is the more
+  // useful of the two answers, and the summary above already named the one
+  // that could not run.
+  if (failed.isNotEmpty) {
+    stdout.writeln(
+      '✗ ${failed.length} of ${reports.length} checks found something: '
+      '${failed.map((r) => r.title).join(', ')}',
+    );
+    exit(1);
+  }
+  stdout.writeln(
+    '? ${unavailable.length} check could not be carried out: '
+    '${unavailable.map((r) => r.title).join(', ')}. Nothing is known to be '
+    'wrong, and nothing is confirmed right either.',
+  );
+  exit(2);
+}

--- a/tool/self_check.dart
+++ b/tool/self_check.dart
@@ -38,11 +38,7 @@ void main(List<String> arguments) async {
   final offline = arguments.contains('--offline');
 
   final reports = <CheckReport>[checkGitConfig(), checkLockfiles()];
-  if (offline) {
-    stdout.writeln('— carets against pub.dev: skipped (--offline)');
-  } else {
-    reports.add(await checkCarets());
-  }
+  if (!offline) reports.add(await checkCarets());
 
   for (final report in reports) {
     stdout.writeln('— ${report.title}');
@@ -51,6 +47,9 @@ void main(List<String> arguments) async {
     }
     stdout.writeln('  ${report.summary}');
   }
+  // Last, so the skipped check keeps the place it would have occupied. A note
+  // that jumps to the top reads as something that happened first.
+  if (offline) stdout.writeln('— carets against pub.dev: skipped (--offline)');
 
   final failed = reports.where((r) => r.outcome == CheckOutcome.findings);
   final unavailable = reports.where(
@@ -74,9 +73,9 @@ void main(List<String> arguments) async {
     exit(1);
   }
   stdout.writeln(
-    '? ${unavailable.length} check could not be carried out: '
-    '${unavailable.map((r) => r.title).join(', ')}. Nothing is known to be '
-    'wrong, and nothing is confirmed right either.',
+    '? ${unavailable.length} check${unavailable.length == 1 ? '' : 's'} could '
+    'not be carried out: ${unavailable.map((r) => r.title).join(', ')}. '
+    'Nothing is known to be wrong, and nothing is confirmed right either.',
   );
   exit(2);
 }


### PR DESCRIPTION
Closes #170, and folds the answer together with the two scripts that came before it.

## The issue itself

`CLAUDE.md` said, as a statement of fact: *"Locally: `fetch.prune=true`, `pull.rebase=true`, `rerere.enabled=true`."* Checked in a clone worked in daily for months:

```
fetch.prune      = (not set)
pull.rebase      = true
rerere.enabled   = (not set)
```

These live in `.git/config` — per clone, per machine. They do not travel with the code, so cloning the repository and reading that sentence gave you a repository that did not do what the sentence said. The sentence is now the three `git config` lines that make it true, with the reason beside each.

The cost is the quiet kind, and the issue documents it: without `fetch.prune`, remote-tracking refs outlive the branches they track. `deleteBranchOnMerge` is on and GitHub does delete them, but a clone that never prunes keeps showing them, and they read as unfinished work — three were investigated one at a time before it turned out all three had been merged.

## Why this is more than a third script

This is the **fourth** time in a row the repository stated something about itself that nothing verified: the lockfiles (#192), the carets (#143), the working tree (#172), now the git settings. Three of the four were answered today, each with a script of its own. A fourth separate script would have been the habit rather than the fix — three commands to remember, called one at a time, and a `framework-finish` growing a list.

So the scripts stay **one per subject** — they get read at the moment they fail, and a file per subject is what makes that readable — and the entry point is shared:

```
$ dart run tool/self_check.dart
— git settings
  fetch.prune is not set — want true (dead remote refs stop piling up); fix: git config fetch.prune true
  rerere.enabled is not set — want true (a conflict resolved once is remembered); fix: git config rerere.enabled true
  2 of 3 git settings are not what CLAUDE.md says they are. They are per-clone and per-machine: setting them here does not set them for anyone else.
— lockfiles
  ✓ every lockfile agrees with the packages it locks
— carets against pub.dev
  ... 16 findings ...

✗ 2 of 3 checks found something: git settings, carets against pub.dev
```

`lock_check` and `caret_check` now expose the check itself and keep a thin `main`, so each still runs alone; `check_result.dart` is the shared shape.

## Not in `dartway doctor`, and the difference matters

The issue proposes `dartway doctor` as the home, since it already reports git identity — the same class of fact. It is the wrong home: **`doctor` ships to every project built on the framework**, and these three settings are rules for developing *the framework*. A doctor that scolds a stranger about our `.git/config` is worse than no check. `tool/` is for what this repository does to itself; that line is now drawn.

## Not in CI, on purpose

`tool/self_check.dart` is deliberately absent from `tool/checks.sh`. Two of its three checks would be red on every runner by construction — a fresh clone has none of the git settings, and the carets stay unsatisfied for as long as a release is pending. A gate that is red by design is a gate people stop reading, which is the failure #184 describes and the one #194 was shaped around.

## Three exit codes, aggregated

`0` clean · `1` something is not what we say it is · `2` a check could not be carried out.

The third is not decoration: `caret_check` needs the network, and a dropped connection reported as a finding reads as "the release is broken" and gets believed. `self_check` keeps that distinction when aggregating, and findings outrank an unavailable check.

## Verification

Every path exercised, not argued:

| case | result |
|---|---|
| this clone, everything | git settings + carets report, `✗ 2 of 3`, exit 1 |
| `--offline` | carets skipped, `✗ 1 of 2`, exit 1 |
| scratch repo with the three settings set | git settings green |
| scratch repo with no `template/`/`example/` | `? 1 check could not be carried out`, exit 2 — **not** reported as a failure |
| `--nope` | usage on stderr, exit 64 |

`tool/checks.sh` green.