### PR TITLE
feat(core): a create onto a taken natural key becomes an update of that row

### DIFF
--- a/docs/2-core/crud-configs.md
+++ b/docs/2-core/crud-configs.md
@@ -132,6 +132,7 @@ The order, exactly as `DwSaveConfig.save` runs it:
 
 | # | Hook | Returns | Where |
 |---|---|---|---|
+| 0 | `resolveExistingRowForInsert` | `Future<T?>` | before the transaction, on inserts only |
 | 1 | `allowSave` | `Future<bool>` — **required** | before the transaction |
 | 2 | `validateSave` | `Future<String?>` | before the transaction |
 | 3 | `beforeSaveTransaction` | `Future<String?>` | **inside** the transaction |
@@ -139,6 +140,8 @@ The order, exactly as `DwSaveConfig.save` runs it:
 | 5 | `afterSaveTransaction` | `Future<String?>` | inside the transaction |
 | 6 | `afterSaveTransform` | `Future<String?>` | after commit |
 | 7 | `afterSaveSideEffects` | `Future<void>` | after commit, not awaited |
+
+Step 0 is the odd one out and is described below; the rest run on every save.
 
 All seven share one signature — `(Session session, DwSaveContext<T> saveContext)`. There is no
 `(initial, updated)` pair anywhere; both models live in the context, along with `currentUserId`,
@@ -217,6 +220,37 @@ last spot count the same four and both get in.
 transaction and `allowSave` / `validateSave` are evaluated against what was actually committed. It
 is opt-in so the default lifecycle is unchanged, and it does nothing on insert — there is no row to
 lock yet.
+
+**When the model has a natural key** — one person's answer to one question, one membership of one
+user in one chat — the client thinks in that key, not in the id, and sooner or later it sends a
+*create* for a row that already exists: its list lagged, the person answered from a second device,
+the first response never arrived. Left alone, that write reaches the unique index and comes back a
+database error — an alert for you, and for the caller a failure it can do nothing about, since what
+it sent is exactly what it wants stored.
+
+`resolveExistingRowForInsert` is step 0 for exactly this: on an insert it looks the row up by that
+key and returns the model to write instead — the incoming values carrying the stored id.
+
+```dart
+resolveExistingRowForInsert: (session, answer) async {
+  final stored = await UserQuizAnswer.db.findFirstRow(
+    session,
+    where: (t) =>
+        t.userProfileId.equals(answer.userProfileId) &
+        t.questionId.equals(answer.questionId),
+  );
+  return stored == null ? null : answer.copyWith(id: stored.id);
+},
+```
+
+From there the save is an ordinary update: `isInsert` is `false`, `initialModel` is the stored row,
+and every hook after step 0 sees the save that is actually happening. Returning `null` leaves the
+insert an insert.
+
+It runs before the transaction, so it does not settle a race between two simultaneous creates — both
+can find nothing and both insert, and the unique index answers the second one. Guard that in
+`beforeSaveTransaction` if it matters; step 0 is about the client that is simply behind, which is
+the case that actually happens.
 
 **A `scope=serverOnly` column is not overwritten by a client save, and there is nothing to switch on
 for that.** Such a field does not exist on the client class, so it is never in the JSON a client

--- a/example/dartway_example_server/test/integration/dw_save_config_integration_test.dart
+++ b/example/dartway_example_server/test/integration/dw_save_config_integration_test.dart
@@ -406,6 +406,83 @@ void main() {
           await Future<void>.delayed(const Duration(milliseconds: 50));
         },
       );
+
+      // `settingKey` is unique, so a create for a key that is already taken is
+      // the natural-key case: without the hook that write reaches the index and
+      // comes back a database error the caller can do nothing about.
+      test(
+        'a create onto a taken natural key updates that row instead',
+        () async {
+          final session = sessionBuilder.build();
+          final stored = await AppSetting.db.insertRow(
+            session,
+            AppSetting(
+              settingKey: '${_testKeyPrefix}natural_key',
+              settingValue: 'initial',
+            ),
+          );
+
+          DwSaveContext<AppSetting>? allowContext;
+
+          final response =
+              await DwSaveConfig<AppSetting>(
+                resolveExistingRowForInsert: _resolveSettingByKey,
+                allowSave: (session, context) async {
+                  allowContext = context;
+                  return true;
+                },
+              ).save(
+                session,
+                AppSetting(
+                  settingKey: '${_testKeyPrefix}natural_key',
+                  settingValue: 'from a client that had not seen the row',
+                ),
+              );
+
+          expect(response.isOk, isTrue);
+
+          // The hooks are told what is actually happening: an update, with the
+          // stored row as the initial model.
+          expect(allowContext?.isInsert, isFalse);
+          expect(allowContext?.initialModel?.id, stored.id);
+          expect(allowContext?.initialModel?.settingValue, 'initial');
+
+          final rows = await AppSetting.db.find(
+            session,
+            where: (t) => t.settingKey.equals('${_testKeyPrefix}natural_key'),
+          );
+          expect(rows, hasLength(1));
+          expect(rows.single.id, stored.id);
+          expect(
+            rows.single.settingValue,
+            'from a client that had not seen the row',
+          );
+        },
+      );
+
+      test('a create onto a free natural key stays an insert', () async {
+        final session = sessionBuilder.build();
+        DwSaveContext<AppSetting>? allowContext;
+
+        final response =
+            await DwSaveConfig<AppSetting>(
+              resolveExistingRowForInsert: _resolveSettingByKey,
+              allowSave: (session, context) async {
+                allowContext = context;
+                return true;
+              },
+            ).save(
+              session,
+              AppSetting(
+                settingKey: '${_testKeyPrefix}natural_key_free',
+                settingValue: 'inserted',
+              ),
+            );
+
+        expect(response.isOk, isTrue);
+        expect(allowContext?.isInsert, isTrue);
+        expect(allowContext?.initialModel, isNull);
+      });
     },
     rollbackDatabase: RollbackDatabase.disabled,
     testServerOutputMode: testServerOutputMode,
@@ -443,6 +520,20 @@ Future<_HeldRowLock> _holdUpdatedSettingRow(
   });
   await held.future;
   return _HeldRowLock(release, completion);
+}
+
+/// The natural key of [AppSetting]: one row per `settingKey`, held by a unique
+/// index. Returns the incoming values carrying the stored row's id, which is
+/// what turns the insert into an update of that row.
+Future<AppSetting?> _resolveSettingByKey(
+  Session session,
+  AppSetting model,
+) async {
+  final existing = await AppSetting.db.findFirstRow(
+    session,
+    where: (table) => table.settingKey.equals(model.settingKey),
+  );
+  return existing == null ? null : model.copyWith(id: existing.id);
 }
 
 Future<void> _waitForLockedSettingReader(Session session) async {

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 0.12.0
 
+- **`DwSaveConfig.resolveExistingRowForInsert` — a create onto a taken natural key becomes an
+  update of that row.**
+
+  A model with a natural key besides its id — one person's answer to one question, one membership
+  of one user in one chat — gets *created* by clients that have not seen the stored row: the list
+  lagged, the person acted from a second device, the first response never arrived. That write hit
+  the unique index and came back a database error: an alert for the team, and for the caller a
+  failure it could do nothing about, because what it sent was exactly what it wanted stored.
+
+  The new hook runs before everything else on an insert, looks the row up by that key and returns
+  the model to write instead — the incoming values carrying the stored id. From there it is an
+  ordinary update, so `isInsert`, `initialModel` and every later hook describe the save that is
+  actually happening. Opt-in; return `null` and the insert stays an insert.
+
+  It runs before the transaction, so two simultaneous creates can still both find nothing and race
+  to the unique index — guard that in `beforeSaveTransaction` where it matters.
+
 - **Breaking: `DwAuthConfig.normalizeIdentifier` is required.**
 
   It arrived a release earlier with a default that changed nothing, on the reasoning that folding

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/domain/crud/model_configs/dw_save_config.dart
@@ -10,6 +10,8 @@ import '../../../private/dw_singleton.dart';
 /// happens around the write.
 ///
 /// The lifecycle, in order:
+/// 0. [resolveExistingRowForInsert] — an insert onto a natural key that is
+///                              already taken becomes an update of that row
 /// 1. [allowSave]             — permissions
 /// 2. [validateSave]          — validation
 /// 3. [beforeSaveTransaction] — prepare the model (inside the transaction)
@@ -41,6 +43,7 @@ class DwSaveConfig<T extends TableRow> {
   const DwSaveConfig({
     this.allowAnonymous = false,
     required this.allowSave,
+    this.resolveExistingRowForInsert,
     this.validateSave,
     this.beforeSaveTransaction,
     this.afterSaveTransaction,
@@ -64,6 +67,39 @@ class DwSaveConfig<T extends TableRow> {
 
   final Future<bool> Function(Session session, DwSaveContext<T> saveContext)
   allowSave;
+
+  /// Turns an insert onto an already taken natural key into an update of the
+  /// row that holds it.
+  ///
+  /// Some models have a second identity besides their id — one person's answer
+  /// to one question, one membership of one user in one chat — and it is the
+  /// one the caller thinks in. A client that has not seen the stored row (its
+  /// list lagged, it answered from another device, the first response never
+  /// arrived) sends a *create* for a row that already exists. Without this hook
+  /// that write reaches the unique index and comes back as a database error:
+  /// an alert for the team, and for the caller a failure it can do nothing
+  /// about — the value it sent is exactly the value it wants stored.
+  ///
+  /// Return the model to write: the incoming values carrying the stored row's
+  /// id. The save then continues on the update path, so [allowSave],
+  /// [validateSave] and every later hook see `isInsert == false` and the stored
+  /// row as [DwSaveContext.initialModel]. Return null to leave the insert an
+  /// insert.
+  ///
+  /// ```dart
+  /// resolveExistingRowForInsert: (session, answer) async {
+  ///   final stored = await _findByNaturalKey(session, answer);
+  ///   return stored == null ? null : answer.copyWith(id: stored.id);
+  /// },
+  /// ```
+  ///
+  /// Runs before the transaction opens, so it does not settle a race between
+  /// two simultaneous creates: both can find nothing, both insert, and the
+  /// unique index answers the second one. Where that race is worth guarding,
+  /// guard it in [beforeSaveTransaction] as well — this hook is about the
+  /// client that is simply behind, which is the common case.
+  final Future<T?> Function(Session session, T model)?
+  resolveExistingRowForInsert;
 
   /// Validates the model. Return the error text to reject the save, or null to
   /// let it through. Runs before the transaction opens — see the note on
@@ -203,28 +239,32 @@ class DwSaveConfig<T extends TableRow> {
 
   /// Saves [model], running the lifecycle described on [DwSaveConfig].
   Future<DwApiResponse<DwModelWrapper>> save(Session session, T model) async {
-    final isInsert = model.id == null;
+    // A create onto a taken natural key is an update of that row, and it is
+    // resolved here — before anything else looks at `isInsert`, so the whole
+    // lifecycle, row lock included, sees the save it actually is.
+    final modelToSave = await _resolvedForInsert(session, model);
+    final isInsert = modelToSave.id == null;
 
     // Opt-in serialisation: take the row lock before the rules read the row, so
     // a concurrent save of the same row cannot slip between check and write.
     // Inserts have no row to lock yet, so they keep the default lifecycle.
     if (!isInsert && lockInitialModelForUpdate) {
-      return _saveWithLockedInitialModel(session, model);
+      return _saveWithLockedInitialModel(session, modelToSave);
     }
 
     final initialModel = isInsert
         ? null
-        : await session.db.findById<T>(model.id!);
+        : await session.db.findById<T>(modelToSave.id!);
 
     if (initialModel == null && !isInsert) {
-      return _notFoundResponse(model.id!);
+      return _notFoundResponse(modelToSave.id!);
     }
 
     final saveContext = DwSaveContext<T>(
       currentUserId: session.signedInUserProfileId,
       isInsert: isInsert,
       initialModel: initialModel,
-      currentModel: model,
+      currentModel: modelToSave,
     );
 
     // --- allowSave ---
@@ -254,6 +294,21 @@ class DwSaveConfig<T extends TableRow> {
     }
 
     return _finishSave(session, saveContext);
+  }
+
+  /// The model this save actually writes: [model] itself, or — for an insert
+  /// whose natural key is already taken — what [resolveExistingRowForInsert]
+  /// returned, which carries the stored row's id and turns the save into an
+  /// update of that row.
+  ///
+  /// A hook that returns a model without an id changes nothing: it would leave
+  /// the save an insert, and the only reason to return a model at all is the id
+  /// on it.
+  Future<T> _resolvedForInsert(Session session, T model) async {
+    if (model.id != null || resolveExistingRowForInsert == null) return model;
+
+    final resolved = await resolveExistingRowForInsert!(session, model);
+    return resolved?.id == null ? model : resolved!;
   }
 
   /// The update path with the row held from the first read through the write.

--- a/toolkit/skills/dartway-crud-config/SKILL.md
+++ b/toolkit/skills/dartway-crud-config/SKILL.md
@@ -135,10 +135,27 @@ error anywhere. The full rule, and the three exits it covers, are in `dartway-da
 
 Execution order and signatures:
 
+0. `resolveExistingRowForInsert` → `Future<T?>` — inserts only, and only if the model has a natural key (see below)
 1. `allowSave` → `Future<bool>` — permissions, **required**
 2. `validateSave` → `Future<String?>` — the error text or null
 3. **the transaction opens:** `beforeSaveTransaction` → `Future<String?>` → insert/update → `afterSaveTransaction` → `Future<String?>`
 4. outside the transaction: `afterSaveTransform` → `Future<String?>` (awaited, can reject), then `afterSaveSideEffects` → `Future<void>` (non-blocking)
+
+**A model with a natural key gets *created* twice, and step 0 is the answer.** One person's answer to one question, one membership of one user in one chat: the client thinks in that key, and when it has not seen the stored row — its list lagged, the person acted from a second device, the first response never arrived — it sends a create for a row that exists. That write hits the unique index and comes back a database error: an alert for you, and for the caller a failure it can do nothing about. `resolveExistingRowForInsert` looks the row up by that key and returns the model to write instead:
+
+```dart
+resolveExistingRowForInsert: (session, answer) async {
+  final stored = await UserQuizAnswer.db.findFirstRow(
+    session,
+    where: (t) =>
+        t.userProfileId.equals(answer.userProfileId) &
+        t.questionId.equals(answer.questionId),
+  );
+  return stored == null ? null : answer.copyWith(id: stored.id);
+},
+```
+
+From there it is an ordinary update — `isInsert == false`, `initialModel` is the stored row — so every hook below sees the save that is actually happening. Return `null` and the insert stays an insert. It runs before the transaction, so two simultaneous creates can still race to the unique index; guard that in `beforeSaveTransaction` if it matters.
 
 **Both in-transaction hooks return `String?` — just like `validateSave`.** Returned text → the save is rejected, the transaction is rolled back, the text reaches the client; returned `null` → we move on. This is precisely how you reject on a rule that is only visible inside the transaction.
 


### PR DESCRIPTION
## Зачем

Модель с натуральным ключом (ответ одного человека на один вопрос, членство одного пользователя в одном чате) регулярно получает **create** на уже существующую строку: список у клиента отстал, человек ответил со второго устройства, первый ответ не доехал. Такая запись упиралась в уникальный индекс и возвращалась database error — алерт команде и отказ вызывающему, которому нечего с ним делать: он прислал ровно то значение, которое хочет видеть сохранённым.

## Что добавлено

`DwSaveConfig.resolveExistingRowForInsert` — шаг 0 сохранения, только для insert. Возвращает модель, которую надо записать (входящие значения + id хранимой строки), и дальше идёт обычный update: `isInsert == false`, `initialModel` — хранимая строка, опциональный row lock работает как для любого update. Вернул `null` — insert остаётся insert.

Хук резолвит **до** транзакции, поэтому не разруливает гонку двух одновременных create — оба могут не найти строку и оба уйти в insert. Это сказано в doc-комментарии, в `docs/2-core/crud-configs.md` и в скилле; место для такой защиты прежнее — `beforeSaveTransaction`.

Аддитивно: конфиг без хука ведёт себя ровно как раньше.

## Синхронизация (DoD)

- `docs/2-core/crud-configs.md` — шаг 0 в таблице жизненного цикла + раздел про натуральный ключ;
- `toolkit/skills/dartway-crud-config/SKILL.md` — то же для агента;
- `CHANGELOG.md` пакета — запись в 0.12.0;
- `example/` — два интеграционных теста на `AppSetting.settingKey` (уникальный ключ): create на занятый ключ обновляет ту же строку и отдаёт хукам `isInsert == false`, create на свободный остаётся insert. Прогнано: `dartway test test/integration/dw_save_config_integration_test.dart` — 11/11 зелёные.

Публичный API у `template/` не задет: хук опциональный, скелет его не использует.

## Откуда взялось

Прод клиентского проекта: пользователь не мог пройти опрос, потому что сервер отказывал на повторном create, а клиент показывал отказ как «нет интернета».