### PR TITLE
feat(push): a worker pass keeps to a deadline, and reads its message once

### DIFF
--- a/docs/4-server/push-delivery.md
+++ b/docs/4-server/push-delivery.md
@@ -288,6 +288,14 @@ while (DateTime.now().isBefore(deadline)) {
 `DwPushBatchResult.claimed` counts what the pass processed, so that loop ends on
 an empty queue rather than on a batch the deadline cut short.
 
+**The provider call happens outside a transaction.** A delivery is three steps —
+a short transaction that decides what to send (under the recipient's lock), the
+send itself with no database connection held, and a short transaction that
+writes the outcome, conditioned on the delivery row still being there. The
+consequence to know: a push already handed to the provider can land on the
+device of an account whose deletion began during that call, a window of one
+round-trip. Deleting an account still cancels everything still queued.
+
 Delivery is **at-least-once**: a crash right
 after the provider accepted a message can produce a duplicate — a deliberate,
 documented tradeoff, since for notifications a rare duplicate beats a silent

--- a/docs/4-server/push-delivery.md
+++ b/docs/4-server/push-delivery.md
@@ -266,7 +266,29 @@ await dwPush!.queue.enqueue(
 
 Your app schedules the worker with [`DwRecurringFutureCall`](recurring-jobs.md)
 and calls `dwPush!.processBatch(session)` and `dwPush!.cleanup(session)`. Several
-instances can run at once safely. Delivery is **at-least-once**: a crash right
+instances can run at once safely.
+
+**A job that drains in a loop passes its budget in**, as `processBatch(session,
+deadline: ...)`. Without it a pass runs to the end of its claimed batch however
+long the provider takes, and a loop that checks its own clock between passes is
+measuring the wrong thing — the pass it is inside of is the one that overran. A
+production app watched its 20-second drain budget produce 55-to-77-second runs
+exactly this way. Given a deadline the batch stops between concurrency chunks
+and hands the deliveries it did not reach back to the queue **unleased**, so the
+next pass takes them immediately instead of waiting out `leaseDuration`:
+
+```dart
+final deadline = DateTime.now().add(const Duration(seconds: 20));
+while (DateTime.now().isBefore(deadline)) {
+  final result = await dwPush!.processBatch(session, deadline: deadline);
+  if (result.claimed == 0) break;
+}
+```
+
+`DwPushBatchResult.claimed` counts what the pass processed, so that loop ends on
+an empty queue rather than on a batch the deadline cut short.
+
+Delivery is **at-least-once**: a crash right
 after the provider accepted a message can produce a duplicate — a deliberate,
 documented tradeoff, since for notifications a rare duplicate beats a silent
 drop. The attempt counter only advances on a real send, so recovering a crashed

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   dartway_serverpod_core_server: ^0.12.0
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.
-  dartway_push_server: ^0.3.0
+  dartway_push_server: ^0.4.0
 
   http: ^1.5.0
 

--- a/packages/dartway_push/dartway_push_server/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_server/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0
+## 0.4.0
 
 **A worker pass now respects a wall-clock deadline, and stops re-reading one
 message per delivery.**
@@ -22,6 +22,8 @@ per batch sees exactly what the per-delivery read saw.
 `DwPushBatchResult.claimed` now counts the deliveries the pass actually
 processed, not the ones it claimed — the two differ only when a deadline cut the
 pass short.
+
+## 0.3.0
 
 Web click-through no longer rests on the app's service worker alone, and a
 provider that was asked for and not finished now says so.

--- a/packages/dartway_push/dartway_push_server/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_server/CHANGELOG.md
@@ -19,6 +19,12 @@ account deletion cancels the recipient's queue — leaves nothing behind.
 land on the device of an account whose deletion started during that call. The
 window is one provider round-trip. Before, the deletion waited instead.
 
+The row lock no longer spans the provider call either, so a send that outlives
+`leaseDuration` — two minutes by default, against a ten-second provider timeout
+— can be reclaimed and re-sent by another worker while the first call is still
+out. Delivery was already at-least-once; this is one more way to reach it, and
+the margin between the two defaults is what keeps it rare.
+
 **A worker pass now respects a wall-clock deadline, and stops re-reading one
 message per delivery.**
 

--- a/packages/dartway_push/dartway_push_server/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_server/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## 0.3.0
 
+**A worker pass now respects a wall-clock deadline, and stops re-reading one
+message per delivery.**
+
+`DwPushWorker.processBatch` (and `DwPush.processBatch`) take an optional
+`deadline`. A caller that drains in a loop could only check its budget *between*
+passes, and the pass it was inside of was the one that overran it: a batch is
+`batchSize` deliveries at `maxConcurrentDeliveries` in flight, each waiting out a
+provider round-trip, which is minutes when the provider is slow. Observed on a
+production app: a 20-second drain budget producing runs of 55 to 77 seconds. With
+a deadline the batch stops between concurrency chunks and hands the deliveries it
+did not reach straight back to the queue — unleased, so the next pass can take
+them instead of waiting out `leaseDuration`.
+
+The batch also loads its messages in one query and passes them to the deliveries.
+A fan-out is thousands of deliveries of the *same* message, and each of them was
+re-reading that one row: on the same app, 11 to 13 thousand queries in a single
+pass. The row is written once at enqueue and never updated, so reading it once
+per batch sees exactly what the per-delivery read saw.
+
+`DwPushBatchResult.claimed` now counts the deliveries the pass actually
+processed, not the ones it claimed — the two differ only when a deadline cut the
+pass short.
+
 Web click-through no longer rests on the app's service worker alone, and a
 provider that was asked for and not finished now says so.
 

--- a/packages/dartway_push/dartway_push_server/CHANGELOG.md
+++ b/packages/dartway_push/dartway_push_server/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## 0.4.0
 
+**The provider call no longer happens inside a database transaction.**
+
+A delivery used to run as one transaction: take the recipient's advisory lock,
+read the row, call the provider, write the outcome. The provider call is the
+slow part, and holding a pooled connection through it is how one slow provider
+made every unrelated query in the app wait — measured on a production app as a
+uniform multi-second tail across queries that had nothing to do with push.
+
+A delivery is now three steps: a transaction that decides and commits what the
+send needs (under the same lock, so a recipient being deleted still either wins
+the race outright or waits for this short step), the send itself with no
+connection held, and a transaction that writes the outcome. The outcome write
+re-reads the row and is conditioned on it, so a delivery cancelled meanwhile —
+account deletion cancels the recipient's queue — leaves nothing behind.
+
+**What this gives up, deliberately:** a push already handed to the provider can
+land on the device of an account whose deletion started during that call. The
+window is one provider round-trip. Before, the deletion waited instead.
+
 **A worker pass now respects a wall-clock deadline, and stops re-reading one
 message per delivery.**
 

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push.dart
@@ -118,12 +118,20 @@ final class DwPush {
     },
   );
 
+  /// Claims and processes one batch. [deadline] bounds the pass in wall-clock
+  /// time — a caller draining in a loop passes its own budget, so the pass it is
+  /// inside of cannot overrun it. See [DwPushWorker.processBatch].
   Future<DwPushBatchResult> processBatch(
     Session session, {
     String workerName = 'default',
+    DateTime? deadline,
   }) async {
     await _ensureStorageSettings(session);
-    return worker.processBatch(session, workerName: workerName);
+    return worker.processBatch(
+      session,
+      workerName: workerName,
+      deadline: deadline,
+    );
   }
 
   /// Applies the recommended per-table autovacuum settings for the two

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
@@ -711,11 +711,11 @@ WHERE "id" = @deliveryId
           transaction: transaction,
         );
         final category = message?.category ?? '_missing_message';
-        // Строка уже учитывает эту попытку, если отправка началась: инкремент
-        // пишется и коммитится в первой фазе, до вызова провайдера. Раньше он
-        // жил в одной транзакции с вызовом и откатывался вместе с ним — отсюда
-        // и было «+1». Оставить его теперь значит считать каждую неудачную
-        // попытку дважды и вдвое сократить число ретраев.
+        // The row already counts this attempt once the send has started: the
+        // increment is written and committed in the first phase, before the
+        // provider is called. It used to share a transaction with that call and
+        // roll back with it, which is where the `+ 1` came from. Keeping it now
+        // would count every failed attempt twice, and halve the retries.
         final completedAttempts = delivery.attemptCount;
         final retryDelay = sendStarted
             ? _config.retryPolicy.delayAfterFailure(completedAttempts)
@@ -744,7 +744,7 @@ WHERE "id" = @deliveryId
           retryDelay,
           runtimeError,
           transaction,
-          // Ничего не переписываем: счётчик уже такой в строке.
+          // Nothing to rewrite: the row already holds this count.
           attemptCount: null,
         );
         return _DeliveryOutcome(

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
@@ -418,7 +418,11 @@ ORDER BY classified."availableAt", classified."id"
   }) async {
     var sendStarted = false;
     try {
-      final outcome = await session.db.transaction((transaction) async {
+      // Phase one: everything the send needs, decided under the recipient lock
+      // and committed before the provider is called. What the lock buys is
+      // unchanged here — a recipient being deleted either gets this transaction
+      // in first, and the delivery is gone before we look, or waits for it.
+      final prepared = await session.db.transaction((transaction) async {
         final recipientLockAcquired = await _recipientLock.tryAcquire(
           session,
           recipientId: claimed.recipientId,
@@ -431,7 +435,7 @@ ORDER BY classified."availableAt", classified."id"
             leaseId: leaseId,
             transaction: transaction,
           );
-          return const _DeliveryOutcome.ignored();
+          return const _PreparedDelivery.done(_DeliveryOutcome.ignored());
         }
         final delivery = await DwPushDelivery.db.findById(
           session,
@@ -440,7 +444,7 @@ ORDER BY classified."availableAt", classified."id"
           lockMode: LockMode.forUpdate,
         );
         if (delivery == null || delivery.leaseId != leaseId) {
-          return const _DeliveryOutcome.ignored();
+          return const _PreparedDelivery.done(_DeliveryOutcome.ignored());
         }
 
         final message =
@@ -456,10 +460,12 @@ ORDER BY classified."availableAt", classified."id"
             delivery,
             transaction: transaction,
           );
-          return const _DeliveryOutcome(
-            category: '_missing_message',
-            metric: DwPushMetricOutcome.failed,
-            removed: true,
+          return const _PreparedDelivery.done(
+            _DeliveryOutcome(
+              category: '_missing_message',
+              metric: DwPushMetricOutcome.failed,
+              removed: true,
+            ),
           );
         }
 
@@ -470,10 +476,12 @@ ORDER BY classified."availableAt", classified."id"
             delivery,
             transaction: transaction,
           );
-          return _DeliveryOutcome(
-            category: message.category,
-            metric: DwPushMetricOutcome.expired,
-            removed: true,
+          return _PreparedDelivery.done(
+            _DeliveryOutcome(
+              category: message.category,
+              metric: DwPushMetricOutcome.expired,
+              removed: true,
+            ),
           );
         }
 
@@ -489,10 +497,12 @@ ORDER BY classified."availableAt", classified."id"
             delivery,
             transaction: transaction,
           );
-          return _DeliveryOutcome(
-            category: message.category,
-            metric: DwPushMetricOutcome.skipped,
-            removed: true,
+          return _PreparedDelivery.done(
+            _DeliveryOutcome(
+              category: message.category,
+              metric: DwPushMetricOutcome.skipped,
+              removed: true,
+            ),
           );
         }
 
@@ -504,16 +514,56 @@ ORDER BY classified."availableAt", classified."id"
           transaction: transaction,
         );
         delivery.attemptCount = attemptNumber;
-        final attempt = DwPushDeliveryAttempt(
-          deliveryId: delivery.id!,
-          recipientId: delivery.recipientId,
-          attemptNumber: attemptNumber,
-          payload: payload,
-          targets: recipient.targets,
+        return _PreparedDelivery.send(
+          delivery: delivery,
+          category: message.category,
+          attempt: DwPushDeliveryAttempt(
+            deliveryId: delivery.id!,
+            recipientId: delivery.recipientId,
+            attemptNumber: attemptNumber,
+            payload: payload,
+            targets: recipient.targets,
+          ),
         );
-        sendStarted = true;
-        final transportResult = await _config.transport.send(session, attempt);
-        _verifyTransportResult(attempt, transportResult);
+      });
+
+      final earlyOutcome = prepared.outcome;
+      if (earlyOutcome != null) return earlyOutcome;
+
+      // Phase two: the provider call, with no database connection held. This is
+      // where a pass spends its wall clock, and holding a connection through it
+      // was what let one slow provider make every other query in the app wait.
+      final attempt = prepared.attempt!;
+      final delivery = prepared.delivery!;
+      final category = prepared.category!;
+      sendStarted = true;
+      final transportResult = await _config.transport.send(session, attempt);
+      _verifyTransportResult(attempt, transportResult);
+
+      // Phase three: write down what happened. The delivery row is re-read and
+      // every write is conditioned on it, so a recipient deleted during the send
+      // leaves nothing behind — the row is already gone and there is nothing to
+      // reschedule. The push itself is out by then, and that is the one thing
+      // the split gives up.
+      final outcome = await session.db.transaction((transaction) async {
+        final current = await DwPushDelivery.db.findById(
+          session,
+          delivery.id!,
+          transaction: transaction,
+          lockMode: LockMode.forUpdate,
+        );
+        if (current == null || current.leaseId != leaseId) {
+          return _DeliveryOutcome(
+            category: category,
+            metric: transportResult.wasDelivered
+                ? DwPushMetricOutcome.delivered
+                : DwPushMetricOutcome.failed,
+            delivered: transportResult.wasDelivered,
+            invalidTargets: transportResult.invalidTargets,
+            recipientId: delivery.recipientId,
+          );
+        }
+        current.attemptCount = delivery.attemptCount;
         await _rememberDiscoveredProviders(
           session,
           recipientId: delivery.recipientId,
@@ -521,59 +571,12 @@ ORDER BY classified."availableAt", classified."id"
           transaction: transaction,
         );
 
-        if (transportResult.wasDelivered) {
-          await DwPushDelivery.db.deleteRow(
-            session,
-            delivery,
-            transaction: transaction,
-          );
-          return _DeliveryOutcome(
-            category: message.category,
-            metric: DwPushMetricOutcome.delivered,
-            delivered: true,
-            removed: true,
-            invalidTargets: transportResult.invalidTargets,
-            recipientId: delivery.recipientId,
-          );
-        }
-
-        final policyDelay = transportResult.shouldRetry
-            ? _config.retryPolicy.delayAfterFailure(delivery.attemptCount)
-            : null;
-        final providerDelay = transportResult.retryAfter;
-        final retryDelay = policyDelay == null
-            ? null
-            : providerDelay != null && providerDelay > policyDelay
-            ? providerDelay
-            : policyDelay;
-        if (retryDelay != null) {
-          await _reschedule(
-            session,
-            delivery,
-            retryDelay,
-            _transportError(transportResult),
-            transaction,
-          );
-          return _DeliveryOutcome(
-            category: message.category,
-            metric: DwPushMetricOutcome.retryScheduled,
-            retried: true,
-            invalidTargets: transportResult.invalidTargets,
-            recipientId: delivery.recipientId,
-          );
-        }
-
-        await DwPushDelivery.db.deleteRow(
+        return _recordSendOutcome(
           session,
-          delivery,
+          delivery: current,
+          category: category,
+          transportResult: transportResult,
           transaction: transaction,
-        );
-        return _DeliveryOutcome(
-          category: message.category,
-          metric: DwPushMetricOutcome.failed,
-          removed: true,
-          invalidTargets: transportResult.invalidTargets,
-          recipientId: delivery.recipientId,
         );
       });
 
@@ -594,6 +597,70 @@ ORDER BY classified."availableAt", classified."id"
         sendStarted: sendStarted,
       );
     }
+  }
+
+  /// The write half of a finished send, inside the phase-three transaction.
+  Future<_DeliveryOutcome> _recordSendOutcome(
+    Session session, {
+    required DwPushDelivery delivery,
+    required String category,
+    required DwPushTransportResult transportResult,
+    required Transaction transaction,
+  }) async {
+    if (transportResult.wasDelivered) {
+      await DwPushDelivery.db.deleteRow(
+        session,
+        delivery,
+        transaction: transaction,
+      );
+      return _DeliveryOutcome(
+        category: category,
+        metric: DwPushMetricOutcome.delivered,
+        delivered: true,
+        removed: true,
+        invalidTargets: transportResult.invalidTargets,
+        recipientId: delivery.recipientId,
+      );
+    }
+
+    final policyDelay = transportResult.shouldRetry
+        ? _config.retryPolicy.delayAfterFailure(delivery.attemptCount)
+        : null;
+    final providerDelay = transportResult.retryAfter;
+    final retryDelay = policyDelay == null
+        ? null
+        : providerDelay != null && providerDelay > policyDelay
+        ? providerDelay
+        : policyDelay;
+    if (retryDelay != null) {
+      await _reschedule(
+        session,
+        delivery,
+        retryDelay,
+        _transportError(transportResult),
+        transaction,
+      );
+      return _DeliveryOutcome(
+        category: category,
+        metric: DwPushMetricOutcome.retryScheduled,
+        retried: true,
+        invalidTargets: transportResult.invalidTargets,
+        recipientId: delivery.recipientId,
+      );
+    }
+
+    await DwPushDelivery.db.deleteRow(
+      session,
+      delivery,
+      transaction: transaction,
+    );
+    return _DeliveryOutcome(
+      category: category,
+      metric: DwPushMetricOutcome.failed,
+      removed: true,
+      invalidTargets: transportResult.invalidTargets,
+      recipientId: delivery.recipientId,
+    );
   }
 
   Future<void> _releaseLeaseAfterLockContention(
@@ -863,6 +930,33 @@ WHERE "id" = @deliveryId
 
   static String _truncate(String value, int maximum) =>
       value.length <= maximum ? value : value.substring(0, maximum);
+}
+
+/// What phase one of a delivery decided: either the whole outcome, because the
+/// delivery ended before any provider was called, or everything phase two needs
+/// to make the call.
+final class _PreparedDelivery {
+  const _PreparedDelivery.done(_DeliveryOutcome this.outcome)
+    : delivery = null,
+      category = null,
+      attempt = null;
+
+  const _PreparedDelivery.send({
+    required DwPushDelivery this.delivery,
+    required String this.category,
+    required DwPushDeliveryAttempt this.attempt,
+  }) : outcome = null;
+
+  /// Set when the delivery is already finished and nothing is sent.
+  final _DeliveryOutcome? outcome;
+
+  /// The claimed row, with its attempt counter already advanced and committed.
+  final DwPushDelivery? delivery;
+
+  /// The message's category, kept because the row itself is not read again.
+  final String? category;
+
+  final DwPushDeliveryAttempt? attempt;
 }
 
 final class _DeliveryOutcome {

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
@@ -31,9 +31,21 @@ final class DwPushWorker {
   final Random _random = Random.secure();
 
   /// Claims and processes one bounded batch using PostgreSQL `SKIP LOCKED`.
+  ///
+  /// [deadline] bounds the pass in wall-clock time. Without it a pass runs to
+  /// the end of its claimed batch however long that takes, and how long that is
+  /// belongs to the provider, not to us: `batchSize` deliveries at
+  /// `maxConcurrentDeliveries` in flight, each waiting out a round-trip, is
+  /// minutes when the provider is slow. A caller that drains in a loop and
+  /// stops after N seconds is measuring the wrong thing if it can only check
+  /// between passes — the pass it is inside of is the one that overran. Given a
+  /// deadline, the batch stops between concurrency chunks and hands the
+  /// deliveries it did not reach straight back to the queue instead of holding
+  /// them leased.
   Future<DwPushBatchResult> processBatch(
     Session session, {
     String workerName = 'default',
+    DateTime? deadline,
   }) async {
     if (await _runtime.isPaused(session, workerName)) {
       return const DwPushBatchResult.paused();
@@ -63,12 +75,21 @@ final class DwPushWorker {
       () => _runtime.markClaimed(session, workerName: workerName),
     );
 
+    // One read for the whole batch instead of one per delivery. A fan-out is
+    // thousands of deliveries of the *same* message, so the per-delivery
+    // `findById` was re-reading one row thousands of times; the row is written
+    // once at enqueue and never updated, so reading it outside the delivery's
+    // own transaction changes nothing it could have seen.
+    final messages = await _loadMessages(session, deliveries);
+
     final outcomes = <_DeliveryOutcome>[];
+    var processed = 0;
     for (
       var offset = 0;
       offset < deliveries.length;
       offset += _config.maxConcurrentDeliveries
     ) {
+      if (deadline != null && !_config.clock().isBefore(deadline)) break;
       final end = min(
         offset + _config.maxConcurrentDeliveries,
         deliveries.length,
@@ -77,9 +98,21 @@ final class DwPushWorker {
         await Future.wait(
           deliveries
               .sublist(offset, end)
-              .map((delivery) => _process(session, delivery, leaseId)),
+              .map(
+                (delivery) =>
+                    _process(session, delivery, leaseId, messages: messages),
+              ),
         ),
       );
+      processed = end;
+    }
+
+    // Whatever the deadline cut off is queue work again, not work in progress:
+    // left leased it would sit out `leaseDuration` before any worker could take
+    // it, which is the opposite of what a deadline is for.
+    final abandoned = deliveries.sublist(processed);
+    if (abandoned.isNotEmpty) {
+      await _releaseLeases(session, abandoned, leaseId);
     }
 
     await _recordMetrics(session, outcomes);
@@ -99,11 +132,54 @@ final class DwPushWorker {
     );
 
     return DwPushBatchResult(
-      claimed: deliveries.length,
+      claimed: processed,
       delivered: outcomes.where((outcome) => outcome.delivered).length,
       retried: outcomes.where((outcome) => outcome.retried).length,
       removed: outcomes.where((outcome) => outcome.removed).length,
       paused: false,
+    );
+  }
+
+  /// The messages the claimed batch refers to, by id.
+  Future<Map<int, DwPushMessage>> _loadMessages(
+    Session session,
+    List<DwPushDelivery> deliveries,
+  ) async {
+    final ids = deliveries.map((delivery) => delivery.messageId).toSet();
+    if (ids.isEmpty) return const {};
+    final rows = await DwPushMessage.db.find(
+      session,
+      where: (table) => table.id.inSet(ids),
+    );
+    return {for (final row in rows) row.id!: row};
+  }
+
+  /// Hands leases back for deliveries this pass will not process. Conditioned
+  /// on the lease id, so a delivery another worker has since claimed is left
+  /// alone.
+  Future<void> _releaseLeases(
+    Session session,
+    List<DwPushDelivery> deliveries,
+    String leaseId,
+  ) async {
+    final ids = deliveries
+        .map((delivery) => delivery.id)
+        .whereType<int>()
+        .toList();
+    if (ids.isEmpty) return;
+    await session.db.unsafeExecute(
+      '''
+UPDATE "dw_push_delivery"
+SET
+  "leaseId" = NULL,
+  "leaseExpiresAt" = NULL
+WHERE "id" = ANY(@deliveryIds)
+  AND "leaseId" = @leaseId
+''',
+      parameters: QueryParameters.named({
+        'deliveryIds': ids,
+        'leaseId': leaseId,
+      }),
     );
   }
 
@@ -337,8 +413,9 @@ ORDER BY classified."availableAt", classified."id"
   Future<_DeliveryOutcome> _process(
     Session session,
     DwPushDelivery claimed,
-    String leaseId,
-  ) async {
+    String leaseId, {
+    Map<int, DwPushMessage> messages = const {},
+  }) async {
     var sendStarted = false;
     try {
       final outcome = await session.db.transaction((transaction) async {
@@ -366,11 +443,13 @@ ORDER BY classified."availableAt", classified."id"
           return const _DeliveryOutcome.ignored();
         }
 
-        final message = await DwPushMessage.db.findById(
-          session,
-          delivery.messageId,
-          transaction: transaction,
-        );
+        final message =
+            messages[delivery.messageId] ??
+            await DwPushMessage.db.findById(
+              session,
+              delivery.messageId,
+              transaction: transaction,
+            );
         if (message == null) {
           await DwPushDelivery.db.deleteRow(
             session,

--- a/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
+++ b/packages/dartway_push/dartway_push_server/lib/src/push/dw_push_worker.dart
@@ -711,7 +711,12 @@ WHERE "id" = @deliveryId
           transaction: transaction,
         );
         final category = message?.category ?? '_missing_message';
-        final completedAttempts = delivery.attemptCount + (sendStarted ? 1 : 0);
+        // Строка уже учитывает эту попытку, если отправка началась: инкремент
+        // пишется и коммитится в первой фазе, до вызова провайдера. Раньше он
+        // жил в одной транзакции с вызовом и откатывался вместе с ним — отсюда
+        // и было «+1». Оставить его теперь значит считать каждую неудачную
+        // попытку дважды и вдвое сократить число ретраев.
+        final completedAttempts = delivery.attemptCount;
         final retryDelay = sendStarted
             ? _config.retryPolicy.delayAfterFailure(completedAttempts)
             : delivery.attemptCount == 0
@@ -739,7 +744,8 @@ WHERE "id" = @deliveryId
           retryDelay,
           runtimeError,
           transaction,
-          attemptCount: sendStarted ? completedAttempts : null,
+          // Ничего не переписываем: счётчик уже такой в строке.
+          attemptCount: null,
         );
         return _DeliveryOutcome(
           category: category,

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_push_server
 description: "Server side of the DartWay push module — a Serverpod module: a compact, reliable push delivery queue with worker, retries, dedup and built-in FCM/RuStore providers. Optional; add it only when an app needs push."
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dartway/dartway
 
 resolution: workspace

--- a/toolkit/skills/dartway-push-delivery/SKILL.md
+++ b/toolkit/skills/dartway-push-delivery/SKILL.md
@@ -265,6 +265,21 @@ await dwPush!.processBatch(session);
 await dwPush!.cleanup(session);
 ```
 
+**Draining in a loop with a time budget — pass the budget in.** A pass without a
+deadline runs to the end of its claimed batch however long the provider takes, so
+a loop that only checks its clock between passes overruns by whatever the pass
+inside it cost (a real case: a 20-second budget producing 55-77-second runs).
+With `deadline:` the batch stops between concurrency chunks and returns what it
+did not reach to the queue unleased, ready for the next pass:
+
+```dart
+final deadline = DateTime.now().add(const Duration(seconds: 20));
+while (DateTime.now().isBefore(deadline)) {
+  final result = await dwPush!.processBatch(session, deadline: deadline);
+  if (result.claimed == 0) break; // claimed counts what the pass processed
+}
+```
+
 Several instances may run: claim uses `FOR UPDATE SKIP LOCKED` + leases, takes at
 most one delivery per recipient per batch, and serialises with `pause` via
 runtime state. `attemptCount` is incremented only immediately before a real


### PR DESCRIPTION
Три правки из разбора продовой нагрузки клиентского приложения: 313 прогонов рассылки в сутки, 748 тысяч запросов, прогоны по 55–77 секунд при бюджете вызывающего в 20 секунд, и многосекундный хвост у запросов, к пушам отношения не имеющих.

**1. Дедлайн пачки.** `processBatch` принимает `deadline`. Драйнящий вызывающий мог проверить бюджет только между пачками, а переполняла его сама пачка. Теперь пачка останавливается между чанками и возвращает недообработанные доставки в очередь **без lease**. `DwPushBatchResult.claimed` считает обработанное.

**2. Сообщение — раз на пачку.** Рассылка это тысячи доставок одного сообщения, и каждая перечитывала его строку.

**3. Вызов провайдера вынесен из транзакции.** Доставка теперь три шага: короткая транзакция под локом получателя решает и коммитит всё, что нужно отправке; отправка идёт без коннекта; короткая транзакция пишет итог, перечитав строку и обусловив запись ею.

**Чем платим, осознанно** (записано в changelog и docs): пуш, уже отданный провайдеру, может долететь до устройства аккаунта, чьё удаление началось во время вызова — окно в один круг до провайдера; и отправка, пережившая `leaseDuration`, может быть перезахвачена другим воркером. Владелец системы это решение принял явно.

**Тесты.** В этом пакете нет суиты с базой (её отсутствие ревью отметило отдельно), поэтому поведение проверено интеграционными тестами потребителя на живой базе: 25 тестов, включая `deleteAccount atomically removes all push recipient data` и обе пуш-суиты. `dart test test/push` — 79/79, анализатор чист.