### PR TITLE
docs(toolkit): say which rules a project may override, and where it records that

### DIFF
--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -1,0 +1,15 @@
+# dartway_starter — the project's own rules
+
+**This file is yours.** `dartway setup-ai` never touches it. The managed methodology lives in `.claude/CLAUDE.md` and is overwritten on every update, so a rule of your own written there disappears at the next one.
+
+Read `.claude/CLAUDE.md` first: it carries DartWay's laws and its defaults, and the section "Law and default" says which of the two a project may override.
+
+## Conventions
+
+Nothing here yet, and the emptiness is the point — this is the stated place for the rules this project decides for itself, so that they sit where a reader is actually sent rather than in a README inside the folder they happen to be about.
+
+**What belongs here:** a DartWay **default** this project replaces, and the project's own conventions DartWay says nothing about — the tracker and how work is filed, the shape of a commit message where it differs, the language the project writes its own texts in, how decisions are recorded.
+
+**What does not:** a **law** — the numbered cross-stack rules in `.claude/CLAUDE.md`. Those are not a project's to override; a project that has to break one has outgrown the framework rather than configured it.
+
+**Write the reason beside the rule.** An override with no reason ages into nobody remembering whether it was a decision or a habit, and the next reader cannot tell whether it still holds. One or two sentences are enough: what was tried, what it cost, what replaced it.

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Read `.claude/CLAUDE.md` first: it carries DartWay's laws and its defaults, and the section "Law and default" says which of the two a project may override.
 
-## Conventions
+## Project conventions
 
 Nothing here yet, and the emptiness is the point — this is the stated place for the rules this project decides for itself, so that they sit where a reader is actually sent rather than in a README inside the folder they happen to be about.
 

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -42,6 +42,25 @@ A fourth one, `*_shared` — pure Dart for code that has to behave identically o
 5. **Naming.** Classes — at least 2 words (`UserProfile`, not `User`). Variables are fully descriptive and match the type (`userProfile`, `userProfileId`). Fields relating to a user always carry the word Profile: `userProfileId`, `authorProfileId`, `updatedByProfileId`. Forbidden: `id`/`data`/`info`/`obj`/`temp`/`val`/`item`/`x`.
 6. **Done = audit + a description next to the code.** A feature is not finished until `dartway-finish` has been run: an audit of the diff against the cleanliness contract, and a reconciliation of the feature's description with the new behavior. **The description lives in the code, not in a separate doc:** a screen's behavior — in the `DwFeatureSpec` of the feature widget, the server-side agreements — in the doc comments above the CRUD config. We do not keep separate "a doc per feature" files: a description far from the code drifts from it on the very first edit, and it drifts silently — the code compiles while the doc lies. Verified on a production project: a feature's doc described an API that had not been in the code for a year, and the agent wrote non-working code from it.
 
+## Law and default — and which one a project may override
+
+Two kinds of rule live in this file and, until this section existed, read exactly alike: the same prose, the same voice, the same apparent weight. So an agent obeyed them alike — including where the rule was never DartWay's to make. A commit format demanded a ticket number, a project had no tracker, and the agent stopped mid-task on a question that had no answer. The rule was removed; the shape that produced it is what this section is for.
+
+**Law is what makes it DartWay.** The six numbered rules above: traffic through CRUD rather than arbitrary endpoints, domain-first models, a feature as a folder with exactly one public file, the escalation order for logic, the naming, a description that lives next to the code. Break one and the thing you are building stops being a DartWay project — a second architecture grows inside the first, confidently and fast. **A project does not override a law.**
+
+**Default is what DartWay proposes because something has to be proposed.** Everything else here and in the skills: how a commit message is shaped, the base branch, how a decision is recorded, the language a project writes its own texts in. These are opinions, and good ones, but they are this framework's habits rather than its architecture. **A project may replace a default with its own rule.**
+
+**Precedence, once, so nobody has to guess:** a default yields to the project's own root `CLAUDE.md`; a law does not. Where the two are silent, this file stands.
+
+**A project records its override in its own root `CLAUDE.md`, under "Project conventions", with the reason.** Not in a README inside the folder the rule is about — that is where an override goes to die. It has happened: a project decided from experience that an ADR should be revised in place rather than superseded, wrote the cancellation and its reasoning into `docs/adr/README.md`, and it was correct — but nothing points a reader there, so an agent working from this file alone kept opening new ADR numbers against the project's own decided practice. The rule that is in force has to live where the reader is sent.
+
+Two consequences worth stating, because both are easy to get wrong:
+
+- **`.claude/CLAUDE.md` is managed and overwritten on update.** A project's own rule written into it disappears at the next `dartway setup-ai`. The root `CLAUDE.md` is the project's and is never touched by the installer — that is why the override lives there.
+- **An override is a decision, not a preference, so it carries its reason.** "We do it differently" ages into nobody remembering whether it was considered. The ADR case above is the model: what was tried, what it cost, what replaced it.
+
+**How the boundary stays honest over time: law is what `dartway check` can enforce.** Anything the checker cannot see is broken silently, which is exactly the state the removed commit rule documented — so promote a rule to law and you owe it a check. Today the checker reaches Law 3 in detail (the zone → group → feature tree, `invalidFeatureStructure`, `notAFeature`, `barrelFile`, `forbiddenFeatureImport`) and half of Law 6 (`featureSpecMissing`); Laws 2, 4 and 5 it does not reach at all. That gap is real and is not resolved by this section — it is named here so the next person has the fact rather than the slogan.
+
 ## Code generation: two sanctioned generators, and no `build_runner`
 
 The project has exactly two: **`serverpod generate`** (models and the client package) and **`flutter gen-l10n`** (the typed `AppLocalizations` from `lib/l10n/*.arb`). Both are unavoidable — the first because the wire is generated, the second because the localization law in the Flutter section is not obeyable without it — and both share the same three properties.
@@ -112,6 +131,8 @@ An ADR records **the alternatives that were rejected, and why**. That is the one
 **Never write "how it works now".** That is the part that rots, and it rots silently, because the code changes under it without an error. A real ADR described a `--dart-define` as the source of an app's URL while the README on the very same commit said that mechanism was gone.
 
 **An ADR is never edited — it is superseded by a new one**, and the old one gets `superseded by NNNN` in its status. Editing destroys the only thing it is for: what was known at the moment of the choice. A record you may rewrite is not a record.
+
+**This is a default, and a project may replace it** — see "Law and default" above. What must not be destroyed is *what was known at the moment of the choice*; a new number preserves that, and so does a change log at the end of one long-lived file, which is what one project moved to after several documents about a single model started contradicting each other. Either mechanism is fine, the property is not. If the project has decided otherwise, its decision belongs in its root `CLAUDE.md` with the reason — **check there before opening a number**, because a cancellation recorded only inside `docs/adr/` is one nobody is sent to read.
 
 **Planning reads them.** `dartway-plan` looks in `docs/adr/` before proposing an approach, so a decision whose alternatives were already weighed is not re-argued from scratch — and a plan that itself makes such a choice proposes a new ADR as one of its steps.
 


### PR DESCRIPTION
Closes #141. `Refs #167` — the precedence half of it; the marking half is deliberately left, with a reason.

## The shape

The toolkit has one tier. A rule about commit formatting sits in the same prose, in the same voice, as *"a feature is a folder with exactly one public file"*. Both read as equally mandatory, so an agent obeys both equally — including where the rule was never DartWay's to make. #69 was one instance: `/commit` demanded a ticket number, a project had no tracker, and the agent stopped mid-task on a question that had no answer. The rule was removed. The shape was not.

And nothing stated precedence. `dartway setup-ai` installs the methodology into `.claude/`; a project's own conventions live in its root `CLAUDE.md`; which wins was never written. The agent guesses, and guesses in favour of whichever spoke more definitely.

## What the section says

- **Law** — the six numbered cross-stack rules. Break one and the thing being built stops being a DartWay project: a second architecture grows inside the first, confidently and fast. Not a project's to override.
- **Default** — everything else here and in the skills: the commit shape, the base branch, how a decision is recorded, the language a project writes its own texts in. Good opinions, but this framework's habits rather than its architecture. A project may replace one.
- **Precedence, once:** a default yields to the project's root `CLAUDE.md`; a law does not.
- **Where an override is recorded:** the project's root `CLAUDE.md`, under "Conventions", **with the reason** — not in a README inside the folder the rule is about, which is where an override goes to die.

## #141, which is the paid-for instance

A project decided from experience that an ADR should be revised in place rather than superseded — several documents about one model had started contradicting each other — and wrote the cancellation with its reasoning into `docs/adr/README.md`. The reasoning was sound. But the methodology sends a reader to `CLAUDE.md` and nothing sends them there, so an agent working from the methodology alone kept opening new numbers against the project's own decided practice. The issue's author came within one step of doing exactly that.

The ADR rule is now marked as the default it always was, and says what must not be destroyed (*what was known at the moment of the choice*) rather than which mechanism preserves it — a new number does, and so does a change log at the end of one long-lived file. It also tells the reader to check the project's root `CLAUDE.md` **before opening a number**.

## `template/` gains a root `CLAUDE.md`

There was no such place at all. The only `CLAUDE.md` a new project received was `.claude/CLAUDE.md`, which is managed and overwritten on every update — so a project rule written there disappears at the next `dartway setup-ai`. The template now ships the file with its section stated and empty, which is #167's third point.

**Both halves verified by running them, not by reading the installer:**

```
$ dartway create lawdemo --local-repo <this branch> --no-git
$ head -1 lawdemo/CLAUDE.md
# lawdemo — the project's own rules          # the template's rename applied
$ grep -c "Law and default" lawdemo/.claude/CLAUDE.md
2
```

and then, with a line of my own appended to the project's root file:

```
$ dartway setup-ai --local-repo <this branch>
Done: .claude/CLAUDE.md, skills and commands installed.
root CLAUDE.md before=67e2b52b… after=67e2b52b…   # UNTOUCHED
```

The claim written into that file — *"`dartway setup-ai` never touches it"* — is therefore a checked statement rather than a description of what the installer looks like it does.

## What this deliberately does not do

Mark every rule in the toolkit as law or default — #167's first item, and the one it calls "most of the value".

The boundary that would make such marking honest is #167's own: **law is what `dartway check` can enforce**, because anything the checker cannot see is broken silently. That test does not hold against the six laws today. Checked against `DwCheckType`: the checker reaches **Law 3** in detail (`invalidFeatureStructure`, `notAFeature`, `barrelFile`, `forbiddenFeatureImport`, the zone → group → feature tree) and **half of Law 6** (`featureSpecMissing`); it does not reach **Laws 2, 4 or 5** at all.

Sorting fourteen skills against a test that fails on the list it starts from would be an assertion with no acceptance behind it — and #167 itself says any further mechanism without a stated precedence is "scaffolding over an undefined relation". Precedence first, marking when the checker can hold it. The gap is written into the section rather than left as a slogan.

`tool/checks.sh` green; `tool/self_check.dart` green.