### PR TITLE
fix(monorepo): refresh the lock #205 left a minor behind

### DIFF
--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: "../../packages/dartway_push/dartway_push_server"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   dartway_serverpod_core_server:
     dependency: "direct main"
     description:


### PR DESCRIPTION
One line. #205 moved `dartway_push_server` to `0.4.0` and updated the caret in `example/dartway_example_server/pubspec.yaml`, but not the `pubspec.lock` beside it, which still recorded `0.3.0` for the path-overridden package.

## Why it matters, given that nothing fails

An overridden package's constraint is not checked at all, and the version a lock records for one is a copy written by whichever `pub get` ran last. So nothing breaks at runtime and nothing goes red. What it does is **dirty the working tree**: the next resolve in any tree rewrites the file, and `git status` comes back modified where nobody touched anything.

`CLAUDE.md` makes a clean tree carry a meaning — it is the first rule of Claude's git protocol, dirty means another session is working here. That is #192, closed four days ago, and this is the same entry class arriving again. I met it exactly that way: `git worktree remove` refused after an unrelated merge, because the tree had dirtied itself.

## Found the way it was meant to be found

`tool/lock_check.dart` (#193) exists for this and names it:

```
$ dart run tool/lock_check.dart
example/dartway_example_server/pubspec.lock: dartway_push_server locked 0.3.0, package declares 0.4.0
1 stale entry. Fix: `flutter pub get` in each tree above and commit the lockfile.
$ echo $?
1
```

and after the refresh:

```
✓ every lockfile agrees with the packages it locks
```

It is wired into `framework-finish` Step 4. #205 did not reach it — the check is days old and the habit of running it is not established yet, which is worth saying plainly rather than treating this as an oversight by whoever wrote that PR: a check nobody has the habit of running is only half a check, and the other half is the run.

`tool/checks.sh` green.