### PR TITLE
fix(core): restore the protocol patch #211 erased, and say it in English

### DIFF
--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/protocol.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/protocol/protocol.dart
@@ -76,6 +76,15 @@ class Protocol extends _i1.SerializationManager {
   ]) {
     t ??= T;
 
+    if (data is Map<String, dynamic>) {
+      final manualDeserialization = _i21.DwApiResponse.manualDeserialization<T>(
+        data,
+      );
+      if (manualDeserialization != null) {
+        return manualDeserialization;
+      }
+    }
+
     final dataClassName = getClassNameFromObjectJson(data);
     if (dataClassName != null && dataClassName != getClassNameForType(t)) {
       try {

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## 0.12.0
 
-- **`dw_auth_request` получил индекс по `(userIdentifier, createdAt)`.**
+- **`dw_auth_request` is indexed on `(userIdentifier, createdAt)`.**
 
-  Каждый запрос кода читает историю отправок этого же идентификатора — rate limit по построению
-  спрашивает «сколько раз мы слали ему за окно». Без индекса это последовательный перебор всей
-  таблицы на каждый вход: на боевом проекте 126 тысяч строк, 12 мс на запрос, и цифра растёт
-  вместе с таблицей, которая по природе своей только копится.
+  Every code request reads that identifier's own send history — rate limiting asks, by
+  construction, "how many times have we sent to them in the window". Without an index the answer
+  is a sequential scan of the whole table on every sign-in: 126 thousand rows and 12 ms per
+  request on a production app, and the number grows with a table that only ever accumulates.
 
-  Приложению индекс приезжает обычным путём — `serverpod generate` и `create-migration` в самом
-  приложении подхватят его из определения модуля.
+  An app inherits the index the ordinary way: its own `serverpod generate` and
+  `create-migration` pick it up from the module definition.
 
 - **`DwSaveConfig.resolveExistingRowForInsert` — a create onto a taken natural key becomes an
   update of that row.**

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/models/auth/auth_request/dw_auth_request.spy.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/models/auth/auth_request/dw_auth_request.spy.yaml
@@ -21,10 +21,11 @@ fields:
   extraData: Map<String, String>?
 
 indexes:
-  # Каждый запрос кода читает историю отправок этого же идентификатора —
-  # rate limit по построению спрашивает «сколько раз мы слали ему за окно».
-  # Без индекса это последовательный перебор всей таблицы на каждый вход:
-  # на боевом проекте 126 тысяч строк и 12 мс на запрос, и цифра растёт
-  # вместе с таблицей, которая по природе своей только копится.
+  # Every code request reads this identifier's own send history — rate
+  # limiting asks, by construction, "how many times have we sent to them in
+  # the window". Without an index that answer is a sequential scan of the
+  # whole table on every sign-in: 126 thousand rows and 12 ms per request on
+  # a production app, and the number grows with a table that only ever
+  # accumulates.
   dw_auth_request_identifier_created_idx:
     fields: userIdentifier, createdAt


### PR DESCRIPTION
Ревью PR #211 нашло блокирующее — уже после мержа.

`serverpod generate` стирает ручную вставку `manualDeserialization` в `Protocol.deserialize`, и CLAUDE.md этого репозитория называет ловушку по имени. #211 регенерировал протокол ради индекса в базе и наступил ровно в неё: код компилируется, а на рантайме **каждый** CRUD-ответ перестаёт разбираться — проверка генератора идёт против сырого типа `DwApiResponse` и не срабатывает ни для одной конкретной инстанциации, которая реально ездит по проводу.

Здесь патч восстановлен дословно по CLAUDE.md, с актуальным алиасом импорта (`_i21`).

**Потребители:** тег из #211 (`stable-2026-09-02.3`) сломан, `.4` — с патчем; в проде ни одно приложение на `.3` не выкатывалось, клиентский проект переведён на `.4`.

Второе замечание того же ревью: комментарий к индексу и запись в changelog были по-русски в артефактах, которые читает посторонний на GitHub, — переписаны на английский.