### PR TITLE
docs(toolkit): the law list is what dartway check fails on, and the labels stop ranking findings

### DIFF
--- a/docs/5-tooling/conventions-checker.md
+++ b/docs/5-tooling/conventions-checker.md
@@ -104,6 +104,14 @@ Then findings by feature (the first six of each), then a count per check, then t
 errors. **Only errors fail the run.** Warnings and infos print and pass — a check that blocks a
 commit over a 210-line file is a check people disable.
 
+**That set carries a second meaning outside this command.** The harness installed by
+`dartway setup-ai` draws its law/default line on it: the checks that fail are the framework's law,
+which a project does not override, and everything else — warnings included — is a default it may
+replace with its own rule. A warning is a warning precisely because the check cannot tell one
+legitimate state from another (`crudConfigMissing`, `generatedCodeUnformatted` below), and that is
+not something a project can be forbidden to decide for itself. So changing a check's level here
+moves it in or out of the law; `toolkit_law_list_test.dart` fails when the two stop agreeing.
+
 ## The checks
 
 | Check | Level | What it means |

--- a/packages/dartway_cli/lib/src/checker/dw_check_type.dart
+++ b/packages/dartway_cli/lib/src/checker/dw_check_type.dart
@@ -168,6 +168,16 @@ enum DwCheckType {
   /// good enough signal to raise the question, not to fail a build on.
   crudRuleUntested;
 
+  /// Which severity a check carries, and the answer is read elsewhere.
+  ///
+  /// The `error` set is published as the law list in `toolkit/CLAUDE.md` — the
+  /// rules a project on this framework may not override, as against the
+  /// defaults it may. That is deliberately derived rather than sorted by hand:
+  /// a check that declines to fail because it has a second legitimate reading
+  /// is not something a project can be forbidden to decide for itself.
+  ///
+  /// So moving a check across this boundary moves it in or out of the law, and
+  /// `toolkit_law_list_test.dart` holds the two together.
   DwCheckSeverity get severity => switch (this) {
     DwCheckType.fileLong => DwCheckSeverity.info,
     DwCheckType.uiKitContainsText ||

--- a/packages/dartway_cli/test/toolkit_law_list_test.dart
+++ b/packages/dartway_cli/test/toolkit_law_list_test.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/checker/dw_check_type.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// The law list `toolkit/CLAUDE.md` publishes is the checker's `error` set.
+///
+/// The harness draws its one hard line there — a law is not a project's to
+/// override, a default is — and it draws it by naming checks. The naming is a
+/// copy: the checks themselves live in [DwCheckType.severity], one `switch`
+/// statement away, and nothing makes the two agree.
+///
+/// Both directions of the drift are silent and both are worse than a missing
+/// list. A check promoted to `error` and never added here is a law nobody was
+/// told about, enforced by a red build against a rule the project could not
+/// read. A check softened to a warning and left in the table is the opposite:
+/// the harness forbids a project to decide something the framework has already
+/// stopped holding it to — which is the exact failure the section was written
+/// to end.
+void main() {
+  final toolkit = () {
+    var dir = Directory.current.absolute;
+    while (true) {
+      final candidate = Directory(p.join(dir.path, 'toolkit', 'skills'));
+      if (candidate.existsSync()) {
+        return Directory(p.join(dir.path, 'toolkit'));
+      }
+      final up = dir.parent;
+      if (up.path == dir.path) {
+        throw StateError('no toolkit/ above ${Directory.current.path}');
+      }
+      dir = up;
+    }
+  }();
+
+  final claudeMd = File(p.join(toolkit.path, 'CLAUDE.md')).readAsLinesSync();
+
+  /// The rows of the table headed "Checks that fail", as one string.
+  String lawTable() {
+    final header = claudeMd.indexWhere(
+      (line) => line.startsWith('|') && line.contains('Checks that fail'),
+    );
+    if (header < 0) {
+      throw StateError('no law table in toolkit/CLAUDE.md');
+    }
+    // Past the header and its `|---|---|` separator, up to the blank line.
+    final rows = claudeMd
+        .skip(header + 2)
+        .takeWhile((line) => line.startsWith('|'));
+    return rows.join('\n');
+  }
+
+  test('the law table names every failing check, and only those', () {
+    final failing = DwCheckType.values
+        .where((check) => check.severity == DwCheckSeverity.error)
+        .map((check) => check.name)
+        .toSet();
+
+    final named = RegExp(
+      // Digits included: `l10nNotWired` is a check name.
+      r'`([a-z][A-Za-z0-9]+)`',
+    ).allMatches(lawTable()).map((match) => match.group(1)!).toSet();
+
+    expect(
+      named.difference(failing),
+      isEmpty,
+      reason:
+          'named as law in toolkit/CLAUDE.md, but the checker does not fail '
+          'on it — a project is being forbidden to decide something the '
+          'framework only warns about',
+    );
+    expect(
+      failing.difference(named),
+      isEmpty,
+      reason:
+          'the checker fails on it and toolkit/CLAUDE.md does not name it — '
+          'a law a project first meets as a red build',
+    );
+  });
+
+  test('the counts stated around the table are the counts', () {
+    // Spelled out in the prose, so they are read rather than skimmed past.
+    // Reword the sentences freely; the numbers in them have to stay true.
+    const words = {
+      1: 'one',
+      2: 'two',
+      3: 'three',
+      4: 'four',
+      5: 'five',
+      6: 'six',
+      7: 'seven',
+      8: 'eight',
+      9: 'nine',
+      10: 'ten',
+      11: 'eleven',
+      12: 'twelve',
+      13: 'thirteen',
+      14: 'fourteen',
+      15: 'fifteen',
+    };
+
+    int countOf(DwCheckSeverity severity) =>
+        DwCheckType.values.where((check) => check.severity == severity).length;
+
+    final section = claudeMd
+        .skipWhile(
+          (line) => !line.contains('The law list is therefore derived'),
+        )
+        .takeWhile((line) => !line.startsWith('## '))
+        .join('\n')
+        .toLowerCase();
+
+    for (final severity in [DwCheckSeverity.error, DwCheckSeverity.warning]) {
+      final word = words[countOf(severity)];
+      expect(
+        // Whole word only: "written" carries a "ten" that means nothing.
+        word != null && RegExp('\\b$word\\b').hasMatch(section),
+        isTrue,
+        reason:
+            'toolkit/CLAUDE.md does not say "$word" anywhere around the law '
+            'table, and that is how many checks are ${severity.name}',
+      );
+    }
+  });
+}

--- a/toolkit/CLAUDE.md
+++ b/toolkit/CLAUDE.md
@@ -59,7 +59,22 @@ Two consequences worth stating, because both are easy to get wrong:
 - **`.claude/CLAUDE.md` is managed and overwritten on update.** A project's own rule written into it disappears at the next `dartway setup-ai`. The root `CLAUDE.md` is the project's and is never touched by the installer — that is why the override lives there.
 - **An override is a decision, not a preference, so it carries its reason.** "We do it differently" ages into nobody remembering whether it was considered. The ADR case above is the model: what was tried, what it cost, what replaced it.
 
-**How the boundary stays honest over time: law is what `dartway check` can enforce.** Anything the checker cannot see is broken silently, which is exactly the state the removed commit rule documented — so promote a rule to law and you owe it a check. Today the checker reaches Law 3 in detail (the zone → group → feature tree, `invalidFeatureStructure`, `notAFeature`, `barrelFile`, `forbiddenFeatureImport`) and half of Law 6 (`featureSpecMissing`); Laws 2, 4 and 5 it does not reach at all. That gap is real and is not resolved by this section — it is named here so the next person has the fact rather than the slogan.
+**How the boundary stays honest over time: law is what `dartway check` *fails* on.** Anything the checker cannot see is broken silently, which is exactly the state the removed commit rule documented — so promote a rule to law and you owe it a check. But "what the checker can check" is one word too wide, and the checker itself says which word. It has **three** severities, not two, and several checks are warnings **precisely because they have a second legitimate reading**: `crudConfigMissing` cannot tell a model no client can reach from a table the server owns alone, and `generatedCodeUnformatted` cannot tell a skipped step from an SDK newer than the one that formatted the file. A check that deliberately declines to fail is not a rule a project is forbidden to decide for itself. So the `error` severity is law; a warning is a strong default, and the one `info` is a nudge.
+
+**The law list is therefore derived rather than sorted** — it is `DwCheckType.severity` in `dartway_cli`, one `switch` statement, and reading it off is the whole method. Twelve checks fail today:
+
+| What it holds | Checks that fail |
+|---|---|
+| The feature boundary (Law 3) | `invalidFeatureStructure`, `notAFeature`, `barrelFile`, `forbiddenFeatureImport` |
+| The UI kit boundary | `uiKitPartMissing`, `forbiddenUiUsage`, `forbiddenUiKitImport` |
+| The widget's contract with its parent | `widgetSizesItself` |
+| The declared top-level layout | `invalidTopLevelLayout` |
+| What ships broken with nothing to notice | `assetPathMissing`, `l10nNotWired` |
+| CRUD reachability (Law 1) | `crudConfigUnregistered` |
+
+Ten further checks are warnings and one is a nudge; those are defaults, however firmly the prose around them is written. **That is the point of deriving the list: anything it does not name is a default by construction** — no rule in this file or in the skills becomes law by being phrased definitely, and promoting one costs a failing check rather than a sentence.
+
+**The gap this leaves is real, and is named rather than smoothed over.** Laws 2, 4 and 5 — domain-first, the escalation order, the naming — have no failing check at all, and Law 6 has only a warning (`featureSpecMissing`). They are declared as law and are not yet held as one. The debt is now a missing row in the table above rather than a slogan.
 
 ## Code generation: two sanctioned generators, and no `build_runner`
 
@@ -259,10 +274,17 @@ next until the field means nothing.
 | `impact:workaround` | It was worked around, and the code carries the marker to prove it. The cost is known and dated: the day the fix lands upstream, that code starts duplicating the framework |
 | `impact:friction` | It works, but the API pushes you to write the wrong thing, or the documentation says something untrue. Nobody was blocked and there was nothing to work around |
 
-**`silent` — it breaks with no error attached.** Orthogonal to impact, and it is the label that
-moves a decision: a `friction` that quietly corrupts data outranks a `blocks` that crashes on the
-first run, because the loud one gets fixed the day it appears. It is visible; the other one is
-found by eye, months later, if at all.
+**`silent` — it breaks with no error attached.** Orthogonal to impact: a finding carries it
+alongside any one of the three above. Nothing announced the defect — no exception, no red test, no
+line in a log — so it was found by eye, months later, if at all, and the label is the only thing
+that says so. A defect that crashes on the first run needs no label to be noticed.
+
+**None of this ranks your finding against anyone else's.** The labels record what happened to this
+project, and that is the whole of a reporter's job; which issue is picked up first is decided where
+the queue lives, once. This file used to state an order of its own, and the two had quietly
+disagreed — the same finding coming out ahead under one rule and behind under the other, with
+nobody placed to read both. It is the same line as "Law and default" above: saying what a thing
+means is this file's business, deciding it on everyone else's behalf is not.
 
 **A gap another project has already filed gets a comment, not a second issue** (rule 3 above): your
 impact in one line, and the label rises to the worst voice on the issue if yours is worse. That is


### PR DESCRIPTION
Closes #198. `Refs #167` — its second and third points; the first is deliberately left, and is now cheaper than it was.

## The law list stops being a claim

#207 stated the precedence and named the tier. It also stated the boundary that keeps the tier honest, in #167's words: **law is what `dartway check` can enforce**. That is one word too wide, and the checker says which word.

`DwCheckType` has **three** severities, not two, and several checks are warnings **precisely because they have a second legitimate reading** — their own doc comments say so. `crudConfigMissing` cannot tell a model no client can reach from a table the server owns alone. `generatedCodeUnformatted` cannot tell a skipped step from an SDK newer than the one that formatted the file. A check that deliberately declines to fail is not a rule a project may be forbidden to decide for itself.

So the boundary is the `error` severity, and the consequence is the point: **the law list is derived, not sorted.** It is read off one `switch` statement. Twelve checks fail today, ten are warnings and one is a nudge, and anything the list does not name is a default by construction — no rule in the harness becomes law by being phrased definitely.

| What it holds | Checks that fail |
|---|---|
| The feature boundary (Law 3) | `invalidFeatureStructure`, `notAFeature`, `barrelFile`, `forbiddenFeatureImport` |
| The UI kit boundary | `uiKitPartMissing`, `forbiddenUiUsage`, `forbiddenUiKitImport` |
| The widget's contract with its parent | `widgetSizesItself` |
| The declared top-level layout | `invalidTopLevelLayout` |
| What ships broken with nothing to notice | `assetPathMissing`, `l10nNotWired` |
| CRUD reachability (Law 1) | `crudConfigUnregistered` |

The gap #207 named stays named, and one correction lands with it: `featureSpecMissing` is a **warning**, so Law 6 is not half-held by it — it is a strong default. Laws 2, 4 and 5 still have no failing check. The debt is now a missing row in a table rather than a slogan.

**And the table is held, not maintained.** `toolkit_law_list_test.dart` compares it against `DwCheckType.severity` in both directions, because both drifts are silent and both are worse than having no list: a check promoted to `error` and never added is a law nobody was told about, met as a red build; a check softened to a warning and left in the table forbids a project to decide something the framework has already stopped holding it to — the exact failure the section was written to end. Verified by breaking it both ways before trusting it.

## The labels stop ranking findings — #198

`toolkit/CLAUDE.md` said a `silent friction` outranks a loud `blocks`. The queue that picks issues says `silent` raises whatever rung it sits on. The same finding therefore came out ahead under one rule and behind under the other, and nobody was placed to read both: the toolkit is read inside a project that has just hit a defect, the queue by whoever is choosing what to fix next.

This takes the issue's own option 1 — the toolkit keeps what each label **means** and stops stating an order. The argument that motivated the order is not lost, because it was never an ordering claim: a silent defect is found by eye months later, if at all, and that is now stated as why the label exists rather than as a rank. A defect that crashes on the first run needs no label to be noticed.

It is the same line as law/default, and the text says so: **saying what a thing means is that file's business; deciding it on everyone else's behalf is not.** Worth noting that the queue's order does not live in this repository at all, which makes the toolkit's copy of it unreachable by anything here.

`docs/5-tooling/conventions-checker.md` gains the mirror: a check's level is no longer only about what fails a run.

## Scope, deliberately

Not done: marking every individual rule across `toolkit/CLAUDE.md` and the fourteen skills — #167's first point. It is the large half, and it now has something to be annotated against: with a derived list in place, the question per rule is "is it on the list" rather than "is this DartWay's or the project's", which is what made it open-ended. Nothing here settles it, and it should not ride along with a boundary definition.

Not done either: an install-time question. #167 warns against it and `--base-branch` is the standing demonstration — an answer given once goes stale.

## Checks

- `tool/checks.sh` — green.
- `framework-finish` — no drift. Not a public API change (a doc comment and a test), so no CHANGELOG entry, matching #207 for the same shape. `dartway_cli` is at `0.9.0` on master against `0.8.0` on stable: the pending release already carries a bump, so `version:` is untouched.
- `tool/self_check.dart` — the standing 16 unsatisfied carets against pub.dev (#143), untouched: that is closed by publishing, not by lowering a caret.