### PR TITLE
feat(auth): let an app answer the profile lookup, so one account can have two identifiers

### DIFF
--- a/docs/4-server/auth-identity.md
+++ b/docs/4-server/auth-identity.md
@@ -116,3 +116,56 @@ after.
 A new project has none of this to worry about: declare the rule in
 `DwAuthConfig` on day one and the question never arises. `dartway create` ships
 `template/` with it already declared.
+
+## When one account has two identifiers
+
+Everything above assumes one account is reached by one string. Some products are
+not shaped that way: sign in by phone **or** by email, with both belonging to
+the same person. Matching a single column cannot express that, and the failure
+is the one this page opened with, arriving by a different road — the second
+channel matches nothing, so it registers a second account.
+
+`DwAuthConfig.findUserProfileByIdentifier` hands the lookup to the app:
+
+```dart
+DwAuthConfig(
+  passwords: passwords,
+  normalizeIdentifier: DwIdentifierForm.folded,
+  findUserProfileByIdentifier: (session, identifier, {transaction}) =>
+      UserProfile.db.findFirstRow(
+        session,
+        where: (t) => t.phone.equals(identifier) | t.email.equals(identifier),
+        transaction: transaction,
+      ),
+);
+```
+
+The identifier arrives already normalized, so the rule is still stated once —
+do not apply it again inside the query. With this set, the `userIdentifier`
+column is never read and is no longer required to exist: an app answering the
+question itself has no use for a column nothing consults.
+
+**What you take on with it.** The framework can no longer see the shape of the
+lookup, so three things stop being its problem and become yours, and none of
+them raises an error when it is wrong:
+
+| What | What it costs to skip |
+|---|---|
+| a unique index on **every** column the query searches | two accounts claim one address, and `findFirstRow` resolves to whichever row the database hands back first |
+| the query reaches the account by every value that can **create** one | a channel written at registration but missing from the query is a door in with no way back — the person registers again on their second visit |
+| the query carries its own `include:` | relations the app expects loaded arrive null; the core applies its own include only to the lookup it performs itself |
+
+The second row is the one that bites, because it looks like it works. A
+registration writes the identifier into whichever column matches the provider —
+so if the query searches `email` but a phone registration wrote only `phone`,
+the account exists and cannot be found. **Write and read the same set of
+columns.**
+
+**Being able to sign in by two values is not the same as having two values.** A
+person who registered by phone has an empty `email` column until something puts
+one there, and until then the email door is shut for them specifically. Adding a
+second identifier to an existing account is a flow of its own — a code sent to
+the new address and verified before the column is written — and the framework
+does not implement it yet: `DwAuthRequestType.addAuthProvider` and
+`changeIdentifier` are declared in the enum and answer with
+`UnimplementedError`.

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -305,21 +305,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_shared_preferences:
     dependency: "direct main"
     description:

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -134,14 +134,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   ffi:
     dependency: transitive
     description:

--- a/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
+++ b/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
@@ -196,21 +196,21 @@ packages:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_flutter:
     dependency: "direct overridden"
     description:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dbus:
     dependency: transitive
     description:

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.1
+
+- Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in
+  `dartway_serverpod_core_server` — an app may now answer the profile lookup itself, so an account
+  can be signed into by more than one identifier.
+
 ## 0.12.0
 
 **`dwUpload` changed shape.** `getUploadDescription` takes a folder, an extension and an optional

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.12.0
+version: 0.12.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.1
+
+- Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in
+  `dartway_serverpod_core_server` — an app may now answer the profile lookup itself, so an account
+  can be signed into by more than one identifier.
+
 ## 0.12.0
 
 - **`DwFileUploadHandler` no longer names the object — the server does.** Naming it here was the

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.12.0
+version: 0.12.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.12.1
+
+- **An account can be reached by more than one identifier.**
+
+  `DwCore` found the profile by matching one column, `userIdentifier`, exactly — and required that
+  column to exist. That is the right shape while an account has exactly one login value, and it
+  cannot express the case where it has two: a person who registered with their phone number and
+  came back with their email address was not found, and the flow did to them what it does to any
+  unknown identifier — it registered them again, silently, into a second empty account.
+
+  `DwAuthConfig.findUserProfileByIdentifier` takes the lookup over when an app sets it. The
+  identifier arrives already through `normalizeIdentifier`, so the app's rule is still stated
+  once, and the `userIdentifier` column stops being required — an app that answers the question
+  itself has no use for a column nothing reads.
+
+  ```dart
+  findUserProfileByIdentifier: (session, identifier, {transaction}) =>
+      UserProfile.db.findFirstRow(
+        session,
+        where: (t) => t.phone.equals(identifier) | t.email.equals(identifier),
+        transaction: transaction,
+      ),
+  ```
+
+  Nothing changes for an app that does not set it, the boot-time check for the column included.
+  Three obligations come with taking it over and none of them is checked: a unique index on every
+  column searched, a query that reaches the account by every value that can create one, and the
+  `include:` the app's own relations need. See `docs/4-server/auth-identity.md`.
+
 ## 0.12.0
 
 - **Uploads: the server names the object, and confirms only the reservation it issued.**

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
@@ -86,8 +86,48 @@ class DwAuthConfig<UserProfileClass extends TableRow> {
     this.authRequestRateLimitWindow = const Duration(minutes: 10),
     this.passwordHasher = const DwBcryptPasswordHasher(),
     this.legacyPasswordVerifiers = const [],
+    this.findUserProfileByIdentifier,
     required this.normalizeIdentifier,
   });
+
+  /// How this app finds the account an identifier belongs to.
+  ///
+  /// Unset, the core matches the profile table's `userIdentifier` column
+  /// exactly, and that column is required — one account, one login value.
+  /// That is the right shape until an account can be reached by more than one
+  /// value, and then it stops being expressible: a person who registered by
+  /// phone and signs in with their email is not found, and registers again.
+  ///
+  /// Set, this function is the whole lookup. The core stops requiring the
+  /// `userIdentifier` column, because an app that answers this question itself
+  /// has no use for a column it never reads:
+  ///
+  /// ```dart
+  /// findUserProfileByIdentifier: (session, identifier, {transaction}) =>
+  ///     UserProfile.db.findFirstRow(
+  ///       session,
+  ///       where: (t) => t.phone.equals(identifier) | t.email.equals(identifier),
+  ///       transaction: transaction,
+  ///     ),
+  /// ```
+  ///
+  /// [identifier] arrives already through [normalizeIdentifier] — the rule is
+  /// the app's own, and applying it here too would apply it twice.
+  ///
+  /// **Three obligations come with taking this over, and nothing checks any of
+  /// them.** The columns searched need a unique index each, or two accounts
+  /// claim one address and the lookup resolves to whichever row the database
+  /// returns first. The account has to be reachable by every value that can
+  /// create one: a channel written on registration but absent from this query
+  /// is a door in with no way back. And the query carries its own `include:`
+  /// where the profile has relations the app expects loaded — the core applies
+  /// its own only to the lookup it performs itself.
+  final Future<UserProfileClass?> Function(
+    Session session,
+    String identifier, {
+    Transaction? transaction,
+  })?
+  findUserProfileByIdentifier;
 
   /// Brings a user identifier to the single form this app stores it in.
   ///

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
@@ -41,7 +41,12 @@ class DwCore<UserProfileClass extends TableRow> {
   final List<DwChannelConfig> _channelConfiguration = [];
 
   late final ColumnInt _userInfoIdColumn;
-  late final ColumnString _userIdentifierColumn;
+
+  /// The `userIdentifier` column, when the app leaves the lookup to the core.
+  /// Null when [DwAuthConfig.findUserProfileByIdentifier] answers instead — an
+  /// app that finds an account by its own columns is not asked for a column it
+  /// never reads.
+  late final ColumnString? _userIdentifierColumn;
 
   final Include? _userProfileInclude;
   final Future<UserProfileClass> Function(
@@ -118,14 +123,19 @@ class DwCore<UserProfileClass extends TableRow> {
             )
             as ColumnInt;
 
-    _userIdentifierColumn =
-        userProfileTable.columns.firstWhereOrThrow(
-              (column) =>
-                  column is ColumnString &&
-                  column.columnName == DwCoreConst.userIdentifierColumnName,
-              'User profile table must have a String ${DwCoreConst.userIdentifierColumnName} column',
-            )
-            as ColumnString;
+    // Required only while the core does the looking up. The check stays a boot
+    // failure rather than a first-sign-in failure: a missing column is a fact
+    // about the schema, and the schema is known here.
+    _userIdentifierColumn = auth?.config.findUserProfileByIdentifier != null
+        ? null
+        : userProfileTable.columns.firstWhereOrThrow(
+                (column) =>
+                    column is ColumnString &&
+                    column.columnName == DwCoreConst.userIdentifierColumnName,
+                'User profile table must have a String ${DwCoreConst.userIdentifierColumnName} column, '
+                'or DwAuthConfig.findUserProfileByIdentifier must say how to find an account',
+              )
+              as ColumnString;
 
     _crudConfiguration[DwCoreConst.dartwayInternalApi] = Map.fromEntries(
       [
@@ -246,6 +256,10 @@ class DwCore<UserProfileClass extends TableRow> {
   /// rule. Without a rule configured this is an exact match, as it always was.
   ///
   /// [transaction] carries the same meaning as on [getUserProfile].
+  /// An app that can be signed into by more than one value — a phone *or* an
+  /// email on one account — answers this itself through
+  /// [DwAuthConfig.findUserProfileByIdentifier]; then that function is the
+  /// lookup and the `userIdentifier` column is not consulted at all.
   Future<UserProfileClass?> getUserProfileByIdentifier(
     Session session,
     String identifier, {
@@ -253,11 +267,16 @@ class DwCore<UserProfileClass extends TableRow> {
   }) async {
     final normalized = normalizeAuthIdentifier(identifier);
 
-    final profile = await session.db.findFirstRow<UserProfileClass>(
-      where: _userIdentifierColumn.equals(normalized),
-      include: _userProfileInclude,
-      transaction: transaction,
-    );
+    final findByApp = auth?.config.findUserProfileByIdentifier;
+    final identifierColumn = _userIdentifierColumn;
+
+    final profile = findByApp != null
+        ? await findByApp(session, normalized, transaction: transaction)
+        : await session.db.findFirstRow<UserProfileClass>(
+            where: identifierColumn!.equals(normalized),
+            include: _userProfileInclude,
+            transaction: transaction,
+          );
 
     if (profile == null) {
       session.log('Warning: User profile not found for identifier $normalized');

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.12.0
+version: 0.12.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/identifier_resolver_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/identifier_resolver_test.dart
@@ -1,0 +1,163 @@
+// `findFirstRow` is internal to Serverpod; the double below has to implement it
+// to prove the core does *not* call it once the app answers the lookup itself.
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+/// The address as a human typed it.
+const _asTyped = ' Ivan@Acme.COM ';
+
+/// The one form the app decided to store it in.
+const _stored = 'ivan@acme.com';
+
+class TestUserProfile implements TableRow<int?> {
+  @override
+  int? get id => 1;
+
+  @override
+  Table<int?> get table => _tableWithoutIdentifier;
+
+  @override
+  Map<String, dynamic> toJson() => const {};
+}
+
+/// A profile table that carries **no** `userIdentifier` column — the shape an
+/// app takes once an account can be reached by more than one value.
+class TableWithoutIdentifier extends Table<int?> {
+  TableWithoutIdentifier(String name) : super(tableName: name) {
+    phone = ColumnString('phone', this);
+    email = ColumnString('email', this);
+  }
+
+  late final ColumnString phone;
+  late final ColumnString email;
+
+  @override
+  List<Column> get columns => [id, phone, email];
+}
+
+final _tableWithoutIdentifier = TableWithoutIdentifier('test_user_profile');
+
+/// Fails the test if the core reaches for the database at all: with a resolver
+/// configured, the lookup is the app's and the core has nothing to query.
+class ForbiddenDatabase implements Database {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw StateError(
+    'The core queried the database: ${invocation.memberName}',
+  );
+}
+
+class RecordingSession implements Session {
+  @override
+  Database get db => ForbiddenDatabase();
+
+  @override
+  void log(
+    String message, {
+    LogLevel? level,
+    dynamic exception,
+    StackTrace? stackTrace,
+  }) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('Unexpected session call: ${invocation.memberName}');
+}
+
+void main() {
+  // `DwCore.init` resolves class names through `Serverpod.instance`. Nothing
+  // here is started; no socket and no database is touched.
+  Serverpod(
+    ['--mode', 'test', '--role', 'monolith'],
+    Protocol(),
+    Endpoints(),
+    config: ServerpodConfig.defaultConfig(),
+  );
+
+  final askedFor = <String>[];
+  final profile = TestUserProfile();
+
+  final dw = DwCore.init<TestUserProfile>(
+    userProfileTable: _tableWithoutIdentifier,
+    crudConfigurations: [],
+    dtoConfigurations: [],
+    channelConfigurations: [],
+    userProfileConstructor: (session, {required registrationRequest}) async =>
+        throw UnimplementedError(),
+    dwAlerts: DwAlerts.init(logFunction: (_) {}),
+    dwAuthConfig: DwAuthConfig<TestUserProfile>(
+      passwords: const {},
+      normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+      // One account, two ways in — the case the `userIdentifier` column cannot
+      // express, and the reason this seam exists.
+      findUserProfileByIdentifier: (session, identifier, {transaction}) async {
+        askedFor.add(identifier);
+        return identifier == _stored || identifier == '79991235544'
+            ? profile
+            : null;
+      },
+    ),
+  );
+
+  group('with the lookup answered by the app', () {
+    setUp(askedFor.clear);
+
+    test('the core boots without a userIdentifier column', () {
+      // The assertion is that `DwCore.init` above returned at all: it used to
+      // throw here, and a table with no such column is exactly what an app
+      // holding phone and email separately has.
+      expect(dw.userProfileTable.columns.map((column) => column.columnName), [
+        'id',
+        'phone',
+        'email',
+      ]);
+    });
+
+    test('the resolver answers, and the core queries nothing itself', () async {
+      final found = await dw.getUserProfileByIdentifier(
+        RecordingSession(),
+        _asTyped,
+      );
+
+      expect(found, same(profile));
+    });
+
+    test(
+      'the resolver is handed the normalized form, not what was typed',
+      () async {
+        await dw.getUserProfileByIdentifier(RecordingSession(), _asTyped);
+
+        // The app states the rule once, in `normalizeIdentifier`; applying it a
+        // second time inside the resolver is how the two copies start to differ.
+        expect(askedFor.single, _stored);
+      },
+    );
+
+    test('either value reaches the same account', () async {
+      final byEmail = await dw.getUserProfileByIdentifier(
+        RecordingSession(),
+        _asTyped,
+      );
+      final byPhone = await dw.getUserProfileByIdentifier(
+        RecordingSession(),
+        '79991235544',
+      );
+
+      expect(byPhone, same(byEmail));
+    });
+
+    test(
+      'an identifier nobody holds is still a registration, not an error',
+      () async {
+        final found = await dw.getUserProfileByIdentifier(
+          RecordingSession(),
+          'nobody@acme.com',
+        );
+
+        expect(found, isNull);
+      },
+    );
+  });
+}

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.1
+
+- Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in
+  `dartway_serverpod_core_server` — an app may now answer the profile lookup itself, so an account
+  can be signed into by more than one identifier.
+
 ## 0.12.0
 
 No changes of its own. The four `dartway_serverpod_core_*` packages move in lockstep — one version

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.12.0
+version: 0.12.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -291,21 +291,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_shared_preferences:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_server/pubspec.lock
+++ b/template/dartway_starter_server/pubspec.lock
@@ -127,14 +127,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.12.1"
   dartway_starter_shared:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## The gap

`DwCore.getUserProfileByIdentifier` matched one column exactly — `userIdentifier` —
and `DwCore.init` required that column to exist. Right while an account has one
login value; unable to express two.

The failure is the one `docs/4-server/auth-identity.md` already opens with,
arriving by a different road. A person registers with their phone number, comes
back and signs in with their email, and the lookup honestly reports that nothing
carries that identifier. An identifier matching nothing is not an error in this
flow — it is a **registration**. They get a second, empty account, and nobody
raises anything, because every step did what it was asked.

## The change

`DwAuthConfig.findUserProfileByIdentifier`, optional:

```dart
findUserProfileByIdentifier: (session, identifier, {transaction}) =>
    UserProfile.db.findFirstRow(
      session,
      where: (t) => t.phone.equals(identifier) | t.email.equals(identifier),
      transaction: transaction,
    ),
```

Set, it is the whole lookup and the `userIdentifier` column is neither read nor
required — an app answering the question itself has no use for a column nothing
consults. The identifier arrives already through `normalizeIdentifier`, so the
app's rule stays stated once instead of being copied into the query.

**Unset, nothing changes**, including the boot-time check for the column.

## What moves to the app, and is not checked

| What | What it costs to skip |
|---|---|
| a unique index on every column searched | two accounts claim one address; `findFirstRow` returns whichever row the database hands back first |
| a query reaching the account by every value that can **create** one | a channel written at registration but missing from the query is a door in with no way back |
| the query's own `include:` | relations arrive null; the core applies its own include only to the lookup it performs itself |

The middle one is the one that bites, because it looks like it works — a
registration writes the column matching the provider, so a query searching
`email` cannot find an account a phone registration created. All three are on
the field's doc comment and in the doc page.

## Mirrors

- `docs/4-server/auth-identity.md` — new section "When one account has two
  identifiers", with the worked example and the obligations table.
- `example/` and `template/` — compile unchanged, and deliberately do **not**
  demonstrate the capability: both sign in by one channel, and giving the
  skeleton a second one to show a feature off is domain it is not allowed to
  carry. The doc page carries the worked example instead.
- `toolkit/skills/` — untouched: no skill teaches the profile lookup (checked by
  grep for `getUserProfileByIdentifier` and `normalizeIdentifier`).
- `docs/2-core/access-and-roles.md` names the method in a list of three readers;
  nothing there contradicts the change.
- CHANGELOG in all four core packages; version `0.12.0` → `0.12.1` in lockstep.
  Additive and non-breaking, so a patch — and `^0.12.0` still admits it, which
  is why no caret moved. `tool/caret_check.dart` and `tool/lock_check.dart` both
  green.
- `dartway_studio_bridge` untouched — no Studio-side follow-up.

## Not done here

**Attaching a second identifier to an existing account.**
`DwAuthRequestType.addAuthProvider` and `changeIdentifier` are declared in the
enum and answer `UnimplementedError`; `onVerified` handles only `login`,
`register` and `changePassword`. So being *able* to sign in by two values is not
the same as *having* two: a person who registered by phone keeps an empty email
column until something fills it, and the framework offers no flow that does.
Named explicitly at the end of the doc section rather than left to be discovered.

`tool/checks.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)