### PR TITLE
feat(auth): implement changeIdentifier, so an account can acquire its second identifier

### DIFF
--- a/docs/4-server/auth-identity.md
+++ b/docs/4-server/auth-identity.md
@@ -161,11 +161,63 @@ so if the query searches `email` but a phone registration wrote only `phone`,
 the account exists and cannot be found. **Write and read the same set of
 columns.**
 
+## Acquiring the second identifier
+
 **Being able to sign in by two values is not the same as having two values.** A
 person who registered by phone has an empty `email` column until something puts
-one there, and until then the email door is shut for them specifically. Adding a
-second identifier to an existing account is a flow of its own — a code sent to
-the new address and verified before the column is written — and the framework
-does not implement it yet: `DwAuthRequestType.addAuthProvider` and
-`changeIdentifier` are declared in the enum and answer with
-`UnimplementedError`.
+one there, and until then the email door is shut for them specifically.
+
+`DwAuthRequestType.changeIdentifier` is that something, and it is the sign-in
+flow run backwards. A **signed-in** caller names a new phone number or address;
+DartWay sends a code to it and verifies it exactly as it would a sign-in; the
+app then writes it wherever it keeps it:
+
+```dart
+DwAuthConfig(
+  // ...
+  attachVerifiedIdentifier:
+      (session, {required userProfile, required verifiedRequest}) =>
+          UserProfile.db.updateRow(
+            session,
+            verifiedRequest.authProvider == DwAuthProvider.email
+                ? userProfile.copyWith(email: verifiedRequest.userIdentifier)
+                : userProfile.copyWith(phone: verifiedRequest.userIdentifier),
+          ),
+);
+```
+
+Return the profile as it now stands: it travels back to the caller, so the
+screen that asked shows the new value without a second read.
+
+**The two inversions are the whole of it**, and both are the opposite of a
+sign-in:
+
+- **the identifier must be free.** Finding an account is the failure here
+  (`userAlreadyExists`), not the happy path. Two people cannot hold one address,
+  because the sign-in lookup would then resolve them arbitrarily;
+- **the account is read from the session, never from the request.** `userId`
+  arrives on a model the client sends. Taken at its word, it would let anyone
+  write their address onto anyone's profile — so it is overwritten with the
+  caller's own id before anything else looks at it.
+
+**Unset, the flow is refused before a code is sent**, not after. An identifier
+verified and then dropped on the floor is the worst of the three outcomes: the
+person watched the code arrive, typed it, was told nothing went wrong, and their
+address did not change.
+
+What DartWay checks before calling you: the caller is signed in, the identifier
+is normalized, nobody else holds it, and the code came back correct. What it
+cannot check is whether *your* rules allow this person that identifier — a
+corporate domain, a blocked number, a plan that permits one channel. That check
+belongs in the callback, before the write.
+
+And one trap worth naming twice: **writing a column the sign-in query does not
+search** leaves the owner a door they cannot come back through. The pair has to
+agree.
+
+### Still not implemented
+
+`addAuthProvider` and `removeAuthProvider` remain `UnimplementedError`. They are
+a different subject — linking and unlinking an **external** credential (Apple,
+Google, Telegram), where there is no code to send and the provider's token is
+the proof.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## 0.12.1
 
+- **A signed-in person can move their phone number or email onto their own account, with the same
+  code they would sign in with.**
+
+  `DwAuthRequestType.changeIdentifier` was declared in the enum and answered `UnimplementedError`,
+  so the second half of the feature above was missing: an account could be *reached* by two
+  identifiers, and there was no way to *acquire* the second one. A person who registered by phone
+  kept an empty email column forever, and the email door stayed shut for them specifically.
+
+  The request now runs the sign-in flow backwards. The identifier must be **free** — held by
+  nobody, `userAlreadyExists` otherwise — and the account it lands on is read from the session, not
+  from the request, so a client naming somebody else's profile id changes its own and nothing more.
+  `DwAuthConfig.attachVerifiedIdentifier` writes it where the app keeps it and answers with the
+  updated profile, which travels back to the caller so the screen that asked redraws without a
+  second read.
+
+  Unset, a `changeIdentifier` request is refused **before a code is sent** rather than after: an
+  identifier verified and then dropped is the worst of the three outcomes — the person watched the
+  code arrive, typed it, was told nothing went wrong, and their address did not change.
+
 - **An account can be reached by more than one identifier.**
 
   `DwCore` found the profile by matching one column, `userIdentifier`, exactly — and required that

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_config.dart
@@ -87,8 +87,53 @@ class DwAuthConfig<UserProfileClass extends TableRow> {
     this.passwordHasher = const DwBcryptPasswordHasher(),
     this.legacyPasswordVerifiers = const [],
     this.findUserProfileByIdentifier,
+    this.attachVerifiedIdentifier,
     required this.normalizeIdentifier,
   });
+
+  /// How this app records an identifier the owner has just proved is theirs.
+  ///
+  /// Answers `DwAuthRequestType.changeIdentifier`: a **signed-in** caller names
+  /// a new phone number or email address, DartWay sends a code to it and
+  /// verifies it exactly as it would a sign-in, and then hands it here to be
+  /// written. Where it goes is the app's business — the framework does not know
+  /// which column holds a phone and which an address, and there may be one of
+  /// each:
+  ///
+  /// ```dart
+  /// attachVerifiedIdentifier: (session, {required userProfile, required verifiedRequest}) =>
+  ///     UserProfile.db.updateRow(
+  ///       session,
+  ///       verifiedRequest.authProvider == DwAuthProvider.email
+  ///           ? userProfile.copyWith(email: verifiedRequest.userIdentifier)
+  ///           : userProfile.copyWith(phone: verifiedRequest.userIdentifier),
+  ///     ),
+  /// ```
+  ///
+  /// Return the profile as it now stands: the core sends it back to the caller,
+  /// so the screen that asked shows the new value without a second read.
+  ///
+  /// **Leaving it unset closes the flow rather than opening it half-way** — a
+  /// `changeIdentifier` request is refused. An identifier verified and then
+  /// dropped on the floor is the worse failure of the two: the person watched
+  /// a code arrive, typed it, was told nothing went wrong, and their address
+  /// did not change.
+  ///
+  /// What DartWay guarantees before calling this, so the app does not repeat
+  /// it: the caller is signed in, the identifier is normalized, it belongs to
+  /// nobody else (otherwise the request fails with
+  /// [DwAuthFailReason.userAlreadyExists]), and the code sent to it came back
+  /// correct. What it does **not** know is whether the app's own rules allow
+  /// this person that identifier — that check belongs here, before the write.
+  ///
+  /// Writing a column the sign-in query does not search leaves the owner a door
+  /// they cannot come back through; see [findUserProfileByIdentifier].
+  final Future<UserProfileClass> Function(
+    Session session, {
+    required UserProfileClass userProfile,
+    required DwAuthRequest verifiedRequest,
+  })?
+  attachVerifiedIdentifier;
 
   /// How this app finds the account an identifier belongs to.
   ///

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_request_extension.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_request_extension.dart
@@ -229,7 +229,8 @@ extension DwAuthRequestVerification on DwAuthRequest {
           verifiedRequest: this,
         );
 
-        if (updatedProfile == null) {
+        final wrapped = DwModelWrapper.wrap(updatedProfile);
+        if (wrapped == null) {
           // Either the app never said where a verified identifier goes, or the
           // account disappeared mid-flow. Both leave the person having proved
           // an address that was then not written, so the request says so
@@ -238,7 +239,7 @@ extension DwAuthRequestVerification on DwAuthRequest {
           return [];
         }
 
-        return [DwModelWrapper(object: updatedProfile as SerializableModel)];
+        return [wrapped];
 
       case DwAuthRequestType.register:
         userId = await dw.createUserProfile(session, registrationRequest: this);

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_request_extension.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/business/auth/dw_auth_request_extension.dart
@@ -75,13 +75,41 @@ extension DwAuthRequestVerification on DwAuthRequest {
       return;
     }
 
-    // TODO: add alternative logic for registration requests
-    if (requestType != DwAuthRequestType.register && userProfile == null) {
+    // Two request types claim an identifier that must be free rather than
+    // present: a registration, and a signed-in person moving their phone or
+    // address onto their own account. For both, finding a profile is the
+    // failure and finding none is the happy path — the mirror image of a
+    // sign-in.
+    final claimsFreeIdentifier =
+        requestType == DwAuthRequestType.register ||
+        requestType == DwAuthRequestType.changeIdentifier;
+
+    if (!claimsFreeIdentifier && userProfile == null) {
       return setFailed(session, DwAuthFailReason.userNotFound);
     }
 
-    if (requestType == DwAuthRequestType.register && userProfile != null) {
+    if (claimsFreeIdentifier && userProfile != null) {
       return setFailed(session, DwAuthFailReason.userAlreadyExists);
+    }
+
+    if (requestType == DwAuthRequestType.changeIdentifier) {
+      // Refused here rather than after the code has been sent: an app that
+      // never said where a verified identifier goes cannot finish this flow,
+      // and finding that out at the end costs the person an SMS and the belief
+      // that their address changed.
+      if (!dw.canAttachVerifiedIdentifier) {
+        return setFailed(session, DwAuthFailReason.userNotFound);
+      }
+
+      // The account being changed is the caller's own, and it is read from the
+      // session rather than from the request: `userId` arrives on a model the
+      // client sends, so taking it at its word would let anyone write an
+      // identifier onto anyone's profile.
+      final callerProfileId = session.signedInUserProfileId;
+      if (callerProfileId == null) {
+        return setFailed(session, DwAuthFailReason.userNotFound);
+      }
+      userId = callerProfileId;
     }
 
     if (password != null) {
@@ -191,6 +219,27 @@ extension DwAuthRequestVerification on DwAuthRequest {
         );
 
         return [];
+      case DwAuthRequestType.changeIdentifier:
+        // Nobody is being signed in here — the caller already is. What travels
+        // back is the profile carrying its new value, so the screen that asked
+        // redraws without a second read.
+        final updatedProfile = await dw.attachVerifiedIdentifier(
+          session,
+          userId: userId!,
+          verifiedRequest: this,
+        );
+
+        if (updatedProfile == null) {
+          // Either the app never said where a verified identifier goes, or the
+          // account disappeared mid-flow. Both leave the person having proved
+          // an address that was then not written, so the request says so
+          // instead of reporting success.
+          setFailed(session, DwAuthFailReason.userNotFound);
+          return [];
+        }
+
+        return [DwModelWrapper(object: updatedProfile as SerializableModel)];
+
       case DwAuthRequestType.register:
         userId = await dw.createUserProfile(session, registrationRequest: this);
 

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/lib/src/core/dw_core.dart
@@ -309,6 +309,49 @@ class DwCore<UserProfileClass extends TableRow> {
     return getUserProfile(session, userId, transaction: transaction);
   }
 
+  /// Whether this app has said where a verified identifier goes — that is,
+  /// whether `DwAuthRequestType.changeIdentifier` can complete at all.
+  ///
+  /// A getter rather than a read of the field at the call site, and the
+  /// difference is not style. `dw` is the raw `DwCore`, so a caller reading
+  /// [DwAuthConfig.attachVerifiedIdentifier] through it reads a function that
+  /// takes `dynamic` where the real one takes the app's profile type — and a
+  /// function is contravariant in its parameters, so that read throws at
+  /// runtime rather than failing to compile. Inside this class the type
+  /// argument is the real one and the read is sound.
+  bool get canAttachVerifiedIdentifier =>
+      auth?.config.attachVerifiedIdentifier != null;
+
+  /// Writes an identifier its owner has just verified onto their profile, and
+  /// answers with the profile as it now stands.
+  ///
+  /// The app decides where the value goes — see
+  /// [DwAuthConfig.attachVerifiedIdentifier]. Returns `null` when no app has
+  /// said how, which the caller treats as a refusal: an identifier verified and
+  /// then not written is the worst of the three outcomes.
+  Future<UserProfileClass?> attachVerifiedIdentifier(
+    Session session, {
+    required int userId,
+    required DwAuthRequest verifiedRequest,
+    Transaction? transaction,
+  }) async {
+    final attach = auth?.config.attachVerifiedIdentifier;
+    if (attach == null) return null;
+
+    final profile = await getUserProfile(
+      session,
+      userId,
+      transaction: transaction,
+    );
+    if (profile == null) return null;
+
+    return attach(
+      session,
+      userProfile: profile,
+      verifiedRequest: verifiedRequest,
+    );
+  }
+
   Future<int> createUserProfile(
     Session session, {
     required DwAuthRequest registrationRequest,

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/verified_identifier_change_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/test/auth/verified_identifier_change_test.dart
@@ -1,0 +1,230 @@
+// The doubles below stand in for Serverpod's database and session, both of
+// which are internal to it.
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:dartway_serverpod_core_server/dartway_serverpod_core_server.dart';
+import 'package:dartway_serverpod_core_server/src/business/auth/dw_auth_request_extension.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+/// The person doing the changing.
+const _callerProfileId = 42;
+
+/// The address they are moving onto their account.
+const _newAddress = 'ivan@acme.com';
+
+class TestUserProfile implements TableRow<int?> {
+  TestUserProfile({required this.id, this.email});
+
+  @override
+  final int? id;
+
+  final String? email;
+
+  @override
+  Table<int?> get table => _userProfileTable;
+
+  @override
+  Map<String, dynamic> toJson() => {'id': id, 'email': email};
+}
+
+class TestTable extends Table<int?> {
+  TestTable(String name) : super(tableName: name) {
+    email = ColumnString('email', this);
+  }
+
+  late final ColumnString email;
+
+  @override
+  List<Column> get columns => [id, email];
+}
+
+final _userProfileTable = TestTable('test_user_profile');
+
+/// Answers the one read the flow makes — the caller's own row — and refuses
+/// everything else, so a test that starts touching the database says so.
+class ProfileDatabase implements Database {
+  ProfileDatabase(this.storedProfile);
+
+  final TestUserProfile? storedProfile;
+
+  @override
+  Future<T?> findFirstRow<T extends TableRow>({
+    Expression? where,
+    int? offset,
+    Column? orderBy,
+    List<Order>? orderByList,
+    bool orderDescending = false,
+    Transaction? transaction,
+    Include? include,
+    LockMode? lockMode,
+    LockBehavior? lockBehavior,
+  }) async => storedProfile as T?;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('Unexpected database call: ${invocation.memberName}');
+}
+
+class TestSession implements Session {
+  TestSession({required this.callerProfileId, TestUserProfile? storedProfile})
+    : database = ProfileDatabase(
+        storedProfile ?? TestUserProfile(id: callerProfileId),
+      );
+
+  TestSession.anonymous()
+    : callerProfileId = null,
+      database = ProfileDatabase(null);
+
+  final int? callerProfileId;
+  final ProfileDatabase database;
+
+  @override
+  Database get db => database;
+
+  @override
+  AuthenticationInfo? get authenticated {
+    final id = callerProfileId;
+    if (id == null) return null;
+    return AuthenticationInfo('$id', const <Scope>{}, authId: 'test');
+  }
+
+  @override
+  void log(
+    String message, {
+    LogLevel? level,
+    dynamic exception,
+    StackTrace? stackTrace,
+  }) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('Unexpected session call: ${invocation.memberName}');
+}
+
+DwAuthRequest _changeRequest(String identifier) => DwAuthRequest(
+  requestType: DwAuthRequestType.changeIdentifier,
+  userIdentifier: identifier,
+  authProvider: DwAuthProvider.email,
+);
+
+void main() {
+  Serverpod(
+    ['--mode', 'test', '--role', 'monolith'],
+    Protocol(),
+    Endpoints(),
+    config: ServerpodConfig.defaultConfig(),
+  );
+
+  final written = <String>[];
+
+  DwCore.init<TestUserProfile>(
+    userProfileTable: _userProfileTable,
+    crudConfigurations: [],
+    dtoConfigurations: [],
+    channelConfigurations: [],
+    userProfileConstructor: (session, {required registrationRequest}) async =>
+        throw UnimplementedError(),
+    dwAlerts: DwAlerts.init(logFunction: (_) {}),
+    dwAuthConfig: DwAuthConfig<TestUserProfile>(
+      passwords: const {},
+      normalizeIdentifier: (identifier) => identifier.trim().toLowerCase(),
+      // The shape this flow exists for: an account reachable by its own
+      // columns, so there is no `userIdentifier` column to boot against.
+      // These tests hand `tryVerify` the lookup's answer directly, so what
+      // this returns never matters — that it is set does.
+      findUserProfileByIdentifier: (session, identifier, {transaction}) async =>
+          null,
+      attachVerifiedIdentifier:
+          (session, {required userProfile, required verifiedRequest}) async {
+            written.add(verifiedRequest.userIdentifier);
+            return TestUserProfile(
+              id: userProfile.id,
+              email: verifiedRequest.userIdentifier,
+            );
+          },
+    ),
+  );
+
+  group('changing an identifier', () {
+    setUp(written.clear);
+
+    test('a free address on a signed-in account waits for its code', () async {
+      final request = _changeRequest(_newAddress);
+
+      await request.tryVerify(
+        TestSession(callerProfileId: _callerProfileId),
+        // Nobody holds this address — the happy path, and the mirror image of
+        // a sign-in, where finding nobody is the failure.
+        userProfile: null,
+      );
+
+      expect(request.status, DwAuthRequestStatus.pendingVerification);
+    });
+
+    test(
+      'the account changed is the caller, not what the request claims',
+      () async {
+        final request = _changeRequest(_newAddress)
+          // What a hostile client would send: somebody else's profile id.
+          ..userId = 7;
+
+        await request.tryVerify(
+          TestSession(callerProfileId: _callerProfileId),
+          userProfile: null,
+        );
+
+        expect(request.userId, _callerProfileId);
+      },
+    );
+
+    test('an address somebody already holds is refused', () async {
+      final request = _changeRequest(_newAddress);
+
+      await request.tryVerify(
+        TestSession(callerProfileId: _callerProfileId),
+        // Another account carries it. Registering a second owner for one
+        // address is exactly what the sign-in lookup would then resolve
+        // arbitrarily.
+        userProfile: TestUserProfile(id: 7, email: _newAddress),
+      );
+
+      expect(request.status, DwAuthRequestStatus.failed);
+      expect(request.failReason, DwAuthFailReason.userAlreadyExists);
+    });
+
+    test(
+      'a caller with no session is refused before any code is sent',
+      () async {
+        final request = _changeRequest(_newAddress);
+
+        await request.tryVerify(TestSession.anonymous(), userProfile: null);
+
+        expect(request.status, DwAuthRequestStatus.failed);
+        expect(request.failReason, DwAuthFailReason.userNotFound);
+      },
+    );
+
+    test(
+      'a verified request writes the identifier and answers with the profile',
+      () async {
+        final request = _changeRequest(_newAddress)..userId = _callerProfileId;
+
+        final result = await request.onVerified(
+          TestSession(callerProfileId: _callerProfileId),
+          // The lookup found nobody — that is what made this address claimable.
+          userProfile: null,
+        );
+
+        expect(written.single, _newAddress);
+        expect(result.single.object, isA<TestUserProfile>());
+        expect((result.single.object as TestUserProfile).email, _newAddress);
+        expect(
+          (result.single.object as TestUserProfile).id,
+          _callerProfileId,
+          reason: 'the profile handed back is the caller’s own',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Follows #227, which let an account be **reached** by more than one identifier and
left no way to **acquire** the second one. `DwAuthRequestType.changeIdentifier`
was declared in the enum and answered `UnimplementedError`, so a person who
registered by phone kept an empty email column forever.

## The flow

The sign-in flow, run backwards. A signed-in caller names a new phone number or
address, DartWay sends a code to it and verifies it exactly as it would a
sign-in, and the app writes it where it keeps it:

```dart
attachVerifiedIdentifier:
    (session, {required userProfile, required verifiedRequest}) =>
        UserProfile.db.updateRow(
          session,
          verifiedRequest.authProvider == DwAuthProvider.email
              ? userProfile.copyWith(email: verifiedRequest.userIdentifier)
              : userProfile.copyWith(phone: verifiedRequest.userIdentifier),
        ),
```

The returned profile travels back to the caller, so the screen that asked
redraws without a second read.

## The two inversions, which is where the security is

| | Sign-in | `changeIdentifier` |
|---|---|---|
| identifier already held | the happy path | **the failure** — `userAlreadyExists` |
| whose account | the one the identifier resolves to | **the session's**, never the request's |

The second one is the sharp edge: `userId` arrives on a model the client sends.
Taken at its word it would let anyone write their address onto anyone's profile,
so it is overwritten with the caller's own id before anything reads it. There is
a test that sends somebody else's id and asserts it was ignored.

**Unset, the request is refused before a code is sent**, not after — an
identifier verified and then dropped on the floor is the worst of the three
outcomes.

## A typing trap worth naming

The callback takes the app's profile type, and a function is contravariant in
its parameters, so reading that field through the raw `dw` singleton throws at
runtime rather than failing to compile — `DwAuthConfig<dynamic>` declares a
parameter the real function will not accept. The null check therefore lives on
`DwCore` as `canAttachVerifiedIdentifier`, where the type argument is the real
one. `findUserProfileByIdentifier` does not have this problem because its
generic appears only in the return type.

## Mirrors

- `docs/4-server/auth-identity.md` — new section "Acquiring the second
  identifier", plus an explicit note that `addAuthProvider` and
  `removeAuthProvider` stay unimplemented and are a different subject (linking
  an external credential, where there is no code to send).
- CHANGELOG under `0.12.1` — master is already ahead of `stable`, so the pending
  release carries the entry rather than opening a new version.
- `example/` and `template/` compile unchanged; neither sets the callback, and
  the flow is refused cleanly when it is unset. Neither gains a screen for it —
  the skeleton carries no domain, and a profile screen that changes an address
  is domain.
- `toolkit/skills/` untouched: no skill teaches the auth request types.
- Five tests: the free-address path, the hostile `userId`, the taken address,
  the anonymous caller, and the write-and-answer.

`tool/checks.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)