### PR TITLE
fix(template): the editor follows the SDK the project pins, instead of the one on PATH

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm\\versions\\3.44.0"
+  "dart.flutterSdkPath": ".fvm/flutter_sdk"
 }

--- a/docs/migrations/2026-09-05-vscode-flutter-sdk-path.md
+++ b/docs/migrations/2026-09-05-vscode-flutter-sdk-path.md
@@ -1,0 +1,47 @@
+---
+title: "The VS Code Flutter SDK path in your project points at a Windows path with a version in it"
+affects:
+  dartway_cli: "0.10.0"
+---
+
+## Who is affected
+
+Every project created by `dartway create` before 2026-09-05. The file is in your repository, so
+fixing the skeleton does not reach you — this is the only thing that does.
+
+Open `<project>_flutter/.vscode/settings.json` and look:
+
+```json
+{ "dart.flutterSdkPath": ".fvm\\versions\\3.44.0" }
+```
+
+Two things are wrong with that one line.
+
+**It is a Windows path.** On macOS and Linux there is no directory named `.fvm\versions\3.44.0` —
+the separator is part of the file name. The Dart extension does not complain about a path it
+cannot resolve; it quietly falls back to whatever Flutter is on your `PATH`, which is precisely the
+SDK fvm exists to stop you from using. Your editor then analyses against one SDK while your builds
+use another, and nothing anywhere says so.
+
+**The version is baked in.** `.fvmrc` is the file that names the SDK. This is a second copy of that
+number in a file nothing regenerates, so it goes stale the moment `.fvmrc` moves — and stale in the
+way that produces a "works on my machine".
+
+## What to change
+
+```json
+{ "dart.flutterSdkPath": ".fvm/flutter_sdk" }
+```
+
+`.fvm/flutter_sdk` is the symlink fvm maintains for exactly this: no separator problem, no version
+to keep in step. fvm itself warns about the other form — *"SDK Path points to project directory,
+but does not use the flutter_sdk symlink. Using `fvm use` will break the project."*
+
+If the project has several Flutter packages, each has its own `.vscode/settings.json`.
+
+## How to check
+
+Reload the window and open any Dart file. The status bar names the SDK the analyzer is using: it
+should be the version in `.fvmrc`, not the one from `PATH`. `.fvm/flutter_sdk` appears after
+`fvm use` has run in that package at least once — the directory is git-ignored, which is why the
+setting can be committed while the link is local.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -67,6 +67,12 @@ cannot be parsed at all.
 **Versions rather than commits**, because the CLI reads the monorepo from a shallow clone and has
 no history to diff — and because a version is what a project actually moves.
 
+**A change to `template/` alone is keyed to `dartway_cli`.** The skeleton has no version of its
+own, and a project keeps its copy of what it was created from — so a fix to `template/` reaches
+nobody, and the note is the whole delivery. `dartway_cli` is the right key because the template
+declares it as a dev dependency, which puts it in the lock of every project `dartway create`
+produces; name the version being released with the fix.
+
 **File name: `YYYY-MM-DD-slug.md`.** The notes are listed in file-name order, which is the order
 they are applied in by a project that has fallen several releases behind. Two notes landing on one
 day are ordered by their slug — so when one has to come after another, the slugs have to say so.

--- a/example/dartway_example_flutter/.vscode/settings.json
+++ b/example/dartway_example_flutter/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm\\versions\\3.44.0"
+  "dart.flutterSdkPath": ".fvm/flutter_sdk"
 }

--- a/template/dartway_starter_flutter/.vscode/settings.json
+++ b/template/dartway_starter_flutter/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm\\versions\\3.44.0"
+  "dart.flutterSdkPath": ".fvm/flutter_sdk"
 }


### PR DESCRIPTION
Closes #232.

`template/dartway_starter_flutter/.vscode/settings.json` (and the same file in `example/`) pointed `dart.flutterSdkPath` at `.fvm\\versions\\3.44.0`. Every project `dartway create` has produced carries that line.

**It is a Windows path.** On macOS and Linux the separator is part of the file name, so the directory does not exist. The Dart extension does not complain about a path it cannot resolve — it falls back to whatever Flutter is on `PATH`, which is precisely the SDK fvm exists to stop you from using. The editor then analyses against one version while the build uses another, and nothing anywhere says so.

**The version was baked in**, a second copy of what `.fvmrc` already states, in a file nothing regenerates. `.fvm/flutter_sdk` is the symlink fvm maintains for exactly this; fvm itself warns about the other form — *"SDK Path points to project directory, but does not use the flutter_sdk symlink. Using `fvm use` will break the project."*

Found while counting where the Flutter version literal lives in this repository: ten places, and this was the only one also wrong.

## Why it carries a migration note

The fix reaches no project that already exists — the file is in its own repository — so the note is the whole delivery. It is keyed to `dartway_cli`, and that is now written down in `docs/migrations/README.md` as the convention for template-only changes: the skeleton has no version of its own, and `dartway_cli` is in the lock of every project the template produced, because the template declares it as a dev dependency. Verified against the two live projects: both are shown the note.

## Base

Opened against `feat/project-update-cycle` (#231) rather than `master`, because that branch is what introduces `docs/migrations/`. The rule this repository just gained says the note ships in the same pull request as the change, and honouring it here means basing on the branch that makes notes exist. Retarget to `master` once #231 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)