### PR TITLE
fix(cli): let deploy setup provision a cloud image

### DIFF
--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.10.1
+
+- **`dartway deploy setup` runs on a cloud image.** Its privileged steps — base packages, Docker,
+  the deployment user, the firewall — went out as plain SSH commands, so the session had to *be*
+  root. No cloud image is built that way: Yandex Cloud, AWS and GCP create an ordinary user with
+  passwordless sudo and refuse a root login, and provisioning met them with `Permission denied`
+  from `apt-get`, a message that names neither the cause nor the fix. Those steps now go through
+  `sudo -n` when the session is not root, and setup asks for that privilege once, up front, instead
+  of discovering it missing two steps in.
+
+- **The firewall is installed rather than skipped.** The step was guarded by
+  `if command -v ufw`, and an image without `ufw` — minimal Debian, several cloud images — passed
+  it with an "ok" and no firewall. A silently skipped firewall is indistinguishable from a
+  configured one, which is the worst of the available outcomes.
+
 ## 0.10.0
 
 - **`dartway update` — the one command that carries a project onto a newer framework.**

--- a/packages/dartway_cli/lib/src/commands/deploy_setup.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_setup.dart
@@ -104,11 +104,18 @@ Future<int> runSetup(Command<int> command, ArgResults results) async {
   if (!await step(
     'Root privileges',
     () async {
+      // The marker is what separates "connected, and the user has no root"
+      // from "never connected at all". Without it an unreachable host, a
+      // rejected key or a wrong --identity would all be reported as a
+      // privilege problem, and the real reason — which ssh did print — would
+      // be thrown away.
+      const denied = 'dw-no-root';
       final result = await ssh.run(
         'if [ "\$(id -u)" = 0 ]; then echo root; '
-        'elif sudo -n true 2>/dev/null; then echo sudo; else exit 1; fi',
+        'elif sudo -n true 2>/dev/null; then echo sudo; '
+        'else echo $denied; exit 1; fi',
       );
-      if (result.ok) {
+      if (result.ok || !result.stdout.contains(denied)) {
         return result;
       }
       return DwSshResult(
@@ -356,6 +363,10 @@ set -e
 # like a configured one.
 if ! command -v ufw >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
+  # The index is refreshed here rather than trusted: the only other
+  # `apt-get update` in this run sits behind "Docker is absent", so on a host
+  # that came with Docker there may have been none at all.
+  apt-get update -qq
   apt-get install -y -qq ufw
 fi
 if command -v ufw >/dev/null 2>&1; then

--- a/packages/dartway_cli/lib/src/commands/deploy_setup.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_setup.dart
@@ -97,11 +97,38 @@ Future<int> runSetup(Command<int> command, ArgResults results) async {
     return true;
   }
 
+  // Provisioning is root's work, and the session is not always root: cloud
+  // images create an ordinary user with passwordless sudo and refuse a root
+  // login over SSH. Ask once, here, rather than let `apt-get` answer with
+  // "Permission denied" two steps down and leave the reader guessing.
+  if (!await step(
+    'Root privileges',
+    () async {
+      final result = await ssh.run(
+        'if [ "\$(id -u)" = 0 ]; then echo root; '
+        'elif sudo -n true 2>/dev/null; then echo sudo; else exit 1; fi',
+      );
+      if (result.ok) {
+        return result;
+      }
+      return DwSshResult(
+        exitCode: result.exitCode,
+        stdout: '',
+        stderr:
+            '${ssh.target} is neither root nor allowed passwordless sudo. '
+            'Provisioning installs packages and creates the deployment user, '
+            'so it needs one of the two.',
+      );
+    },
+  )) {
+    return 1;
+  }
+
   // Base packages and Docker. Both are no-ops on a server that already has
   // them, which is the common case when setup is re-run for a template change.
   if (!await step(
     'Base packages and Docker',
-    () => ssh.run('''
+    () => ssh.runPrivileged('''
 set -e
 if ! command -v docker >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
@@ -117,7 +144,7 @@ systemctl enable --now docker >/dev/null 2>&1 || true
 
   if (!await step(
     'Deployment user',
-    () => ssh.run('''
+    () => ssh.runPrivileged('''
 set -e
 id -u '${target.deployUser}' >/dev/null 2>&1 || \\
   adduser --disabled-password --gecos "" '${target.deployUser}'
@@ -322,8 +349,15 @@ chmod 600 '${target.appDir}/.env'
 
   if (!await step(
     'Firewall',
-    () => ssh.run('''
+    () => ssh.runPrivileged('''
 set -e
+# Installed rather than skipped: Ubuntu images ship ufw, minimal Debian and
+# several cloud images do not, and a silently skipped firewall looks exactly
+# like a configured one.
+if ! command -v ufw >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get install -y -qq ufw
+fi
 if command -v ufw >/dev/null 2>&1; then
   ufw allow OpenSSH >/dev/null
   ufw allow 80/tcp >/dev/null

--- a/packages/dartway_cli/lib/src/deploy/ssh_runner.dart
+++ b/packages/dartway_cli/lib/src/deploy/ssh_runner.dart
@@ -91,6 +91,28 @@ class DwSshRunner {
     }
   }
 
+  /// Wraps [command] so it runs as root: unchanged when the session already
+  /// is root, through `sudo -n` when it is not.
+  ///
+  /// Cloud images are the reason this exists. Yandex Cloud, AWS and GCP all
+  /// create an ordinary user with passwordless sudo and refuse a root login
+  /// over SSH, so provisioning that insists on connecting as root cannot run
+  /// on any of them — and the failure surfaces as `Permission denied` from
+  /// `apt-get`, which names neither the cause nor the fix.
+  ///
+  /// `-n` keeps the promise the rest of this runner makes: nothing ever waits
+  /// for a password. A user without passwordless sudo fails immediately and
+  /// says so.
+  static String privilegedCommand(String command) {
+    final quoted = command.replaceAll("'", "'\\''");
+    return "if [ \"\$(id -u)\" = 0 ]; then sh -c '$quoted'; "
+        "else sudo -n sh -c '$quoted'; fi";
+  }
+
+  /// Runs [command] as root — see [privilegedCommand].
+  Future<DwSshResult> runPrivileged(String command) =>
+      run(privilegedCommand(command));
+
   /// Runs [command] as the deployment user via sudo, mirroring what the
   /// deployment itself does. Harmless when already connected as that user.
   Future<DwSshResult> runAs(String deployUser, String command) {

--- a/packages/dartway_cli/lib/src/toolkit_manifest.dart
+++ b/packages/dartway_cli/lib/src/toolkit_manifest.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as p;
 /// A copy of what `pubspec.yaml` says, because a compiled or globally activated
 /// executable has no reliable way back to its own pubspec. It is a checked
 /// copy: `cli_version_test.dart` compares the two and goes red when they part.
-const dartwayCliVersion = '0.10.0';
+const dartwayCliVersion = '0.10.1';
 
 /// Where an installed harness came from.
 ///

--- a/packages/dartway_cli/pubspec.yaml
+++ b/packages/dartway_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_cli
 description: "DartWay command-line tool: print the agent setup brief, check prerequisites, create projects from the canonical template, install the AI toolkit, run convention checks."
-version: 0.10.0
+version: 0.10.1
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_cli/test/deploy_ssh_runner_test.dart
+++ b/packages/dartway_cli/test/deploy_ssh_runner_test.dart
@@ -1,0 +1,38 @@
+import 'package:dartway_cli/src/deploy/ssh_runner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('privilegedCommand', () {
+    // The wrapper is one shell string with the payload inside single quotes,
+    // so a quote in the payload is the one thing that can break it — and it
+    // breaks silently: the shell runs a truncated command instead of failing.
+    test('escapes single quotes so the payload survives the wrapper', () {
+      final wrapped = DwSshRunner.privilegedCommand(
+        "adduser 'deploy-user' && echo 'done'",
+      );
+
+      expect(wrapped, contains(r"adduser '\''deploy-user'\''"));
+      expect(wrapped, contains(r"echo '\''done'\''"));
+      expect(wrapped, isNot(contains("adduser 'deploy-user'")));
+    });
+
+    // Both branches carry the payload: a session that is already root must not
+    // depend on sudo being installed, and a session that is not root must not
+    // wait for a password.
+    test('runs as is under root and through sudo -n otherwise', () {
+      final wrapped = DwSshRunner.privilegedCommand('apt-get update');
+
+      expect(wrapped, startsWith(r'if [ "$(id -u)" = 0 ]; then'));
+      expect(wrapped, contains("sh -c 'apt-get update'; else"));
+      expect(wrapped, contains("sudo -n sh -c 'apt-get update'; fi"));
+    });
+
+    test('keeps a multi-line script in one piece', () {
+      final wrapped = DwSshRunner.privilegedCommand(
+        'set -e\nufw --force enable',
+      );
+
+      expect(wrapped, contains("sh -c 'set -e\nufw --force enable'"));
+    });
+  });
+}

--- a/template/deploy/config.yaml.example
+++ b/template/deploy/config.yaml.example
@@ -11,8 +11,11 @@
 
 staging:
   # Where to connect and who to become. The first login provisions the machine
-  # (`dartway deploy setup`) and is usually root; everything afterwards runs as
-  # the deploy user, who owns the checkout and needs no privileges beyond it.
+  # (`dartway deploy setup`), which needs root — either by connecting as root
+  # or through passwordless sudo, which is what cloud images give their default
+  # user. Everything afterwards runs as the deploy user, who owns the checkout
+  # and needs no privileges beyond it; naming the same user in both lines is a
+  # normal arrangement on a cloud image, where root cannot log in at all.
   host: 203.0.113.10
   ssh_user: root
   deploy_user: your-project-admin


### PR DESCRIPTION
Closes #235 and #234, both hit while provisioning a Yandex Cloud machine for a project stand.

**Root.** The privileged steps of `dartway deploy setup` — base packages, Docker, the deployment user, the firewall — went out as plain SSH commands, so the session had to *be* root. No cloud image is built that way: Yandex Cloud, AWS and GCP create an ordinary user with passwordless sudo and refuse a root login. What the operator saw was `Permission denied` from `apt-get`, which names neither the cause nor the fix, and the `os:` field one would expect to warn about it is read into `DwDeployTarget.os` and used nowhere.

Those steps now go through `DwSshRunner.runPrivileged`: the command runs unchanged under root, and through `sudo -n` when the session is not root. `-n` keeps the promise the rest of the runner makes — nothing waits for a password, and a user without passwordless sudo fails at once instead of hanging. Setup asks for the privilege in its first step, so that answer arrives before two steps of work rather than in the middle of them.

**Firewall.** The step was guarded by `if command -v ufw`, and an image without `ufw` — minimal Debian, several cloud images — passed it with an "ok" and no firewall. It installs the package now: a silently skipped firewall is indistinguishable from a configured one.

**Checked on a real machine**, not only in tests: the wrapper was run over SSH against a Yandex Cloud Ubuntu 24.04 host as a non-root user and wrote to `/etc/` as root.

`deploy/config.yaml.example` no longer says root is what `ssh_user` "usually" is — it states the requirement (root or passwordless sudo) and notes that naming the same user in `ssh_user` and `deploy_user` is a normal arrangement on a cloud image.

Version moves to 0.10.1 (master and stable were level at 0.10.0), with the changelog entry and the version constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)