### PR TITLE
fix(cli): the deployment issues its own TLS certificate

### DIFF
--- a/docs/5-tooling/cli.md
+++ b/docs/5-tooling/cli.md
@@ -483,11 +483,23 @@ Addresses, fully qualified names, `localhost`, nginx variables and aliases the f
 its own `upstream` block are not services and are not reported — a check that flagged them would be
 switched off within a week.
 
-`run` updates the checkout, writes the bridge, rebuilds, applies migrations, checks the upstreams and
-restarts, then polls every public URL. The bridge is written **after** the checkout update: it judges the revision this
+`run` updates the checkout, writes the bridge, rebuilds, applies migrations, checks the upstreams,
+issues the TLS certificate and restarts, then polls every public URL. The bridge is written **after** the checkout update: it judges the revision this
 deploy is applying, and a deploy that itself introduces the override must not be refused on a tree
 that does not have it yet. It does not render `docker-compose.yml` or `nginx.conf` — a deploy that re-renders
 infrastructure on every push turns a routine change into an infrastructure one.
+
+**The certificate is issued by the deploy, and it is the only place that can.** `setup` writes a
+one-day self-signed file so that Nginx starts, and the compose stack runs `certbot renew` — which
+renews lineages certbot already manages and knows nothing about a file openssl wrote. For a long
+time that left nobody issuing anything: a stand built exactly by the book served an expired
+self-signed certificate, and the smoke test failed on every endpoint while pointing at container
+logs that had nothing to say. The step sits after `up`, because the ACME challenge is answered by
+the Nginx this deploy has just started, and before the restart, which is what makes Nginx read what
+arrived. It asks one question — does certbot manage this lineage — and does nothing when the answer
+is yes, so a routine deploy does not spend a rate-limited issuance every time. One certificate
+covers every served name, because the rendered Nginx names a single certificate in all four of its
+`server` blocks.
 
 **The migration step prints what the container said, and fails on it.** It used to print its title
 and nothing else, because a step's output was shown only when its exit code was non-zero — and this

--- a/packages/dartway_cli/CHANGELOG.md
+++ b/packages/dartway_cli/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.10.1
 
+- **The deployment issues its TLS certificate.** `setup` wrote a one-day self-signed certificate so
+  that Nginx could start, and the compose stack ran `certbot renew`, which renews lineages certbot
+  already manages and knew nothing about that file — so nothing ever ran `certonly` and the real
+  certificate was never requested. A stand built exactly by the book served an expired self-signed
+  certificate, and the smoke test failed on all four endpoints with advice pointing at container
+  logs that had nothing to say. `deploy run` now issues it between starting the stack and restarting
+  the proxy, one certificate covering every served name, and does nothing when certbot already
+  manages the lineage.
+
 - **`dartway deploy setup` runs on a cloud image.** Its privileged steps — base packages, Docker,
   the deployment user, the firewall — went out as plain SSH commands, so the session had to *be*
   root. No cloud image is built that way: Yandex Cloud, AWS and GCP create an ordinary user with

--- a/packages/dartway_cli/lib/src/commands/deploy_setup.dart
+++ b/packages/dartway_cli/lib/src/commands/deploy_setup.dart
@@ -383,7 +383,8 @@ fi
 
   // Nginx will not start without a certificate file, and certbot cannot issue
   // one until Nginx answers the challenge. A one-day self-signed certificate
-  // breaks the circle; the real one replaces it on the first deploy.
+  // breaks the circle; the `certificate` step of `deploy run` replaces it with
+  // the real one, once the stack it needs is up.
   final certName = serverpod.apiServer.publicHost;
   if (!await step(
     'TLS bootstrap certificate',

--- a/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
+++ b/packages/dartway_cli/lib/src/deploy/deploy_runner.dart
@@ -159,6 +159,81 @@ class DwDeployRunner {
     );
   }
 
+  /// The certificate name every `server` block in the rendered nginx points
+  /// at, and the lineage certbot has to manage.
+  String? get _certName => serverpod.apiServer.publicHost;
+
+  /// Every domain that certificate has to cover.
+  ///
+  /// One certificate for four names: the rendered nginx names a single
+  /// `__CERTNAME__` in all of its `server` blocks, so a certificate listing
+  /// only the API host leaves three of them serving a name it does not carry.
+  List<String> get certificateDomains => {
+    for (final endpoint in serverpod.endpoints)
+      if (endpoint.publicHost != null) endpoint.publicHost!,
+    target.webAppDomain,
+  }.toList();
+
+  /// Asks Let's Encrypt for the real certificate, once.
+  ///
+  /// `deploy setup` writes a one-day self-signed certificate so that nginx can
+  /// start at all, and the compose stack runs `certbot renew` — which renews
+  /// lineages certbot already manages and knows nothing about that file. So
+  /// nothing ever issued anything: the stand served an expired self-signed
+  /// certificate, the smoke test failed on all four endpoints, and its advice
+  /// pointed at container logs that had nothing to say.
+  ///
+  /// Runs after the stack is up, because the ACME challenge is answered by the
+  /// nginx this deploy has just started, and before the proxy restart, which is
+  /// what makes nginx read the new certificate.
+  ///
+  /// The step asks one question — does certbot manage this lineage — and does
+  /// nothing when the answer is yes. That is what keeps a routine deploy from
+  /// spending a rate-limited issuance on every run.
+  Future<DwSshResult> issueCertificate() {
+    final certName = _certName;
+    if (certName == null) {
+      return Future.value(
+        const DwSshResult(
+          exitCode: 1,
+          stdout: '',
+          stderr:
+              'The Serverpod config gives apiServer no publicHost, so there is '
+              'no name to put on a certificate — and the rendered nginx points '
+              'at /etc/letsencrypt/live//fullchain.pem, which cannot exist. '
+              'Set apiServer.publicHost and render the server again with '
+              'dartway deploy setup.',
+        ),
+      );
+    }
+    final domains = certificateDomains.map((domain) => "-d '$domain'").join(' ');
+    return ssh.runAs(target.deployUser, '''
+set -e
+cd '$_appDir'
+${DwComposeFiles.selectFiles}
+# A renewal config is what certbot writes for a lineage it manages, and the
+# self-signed bootstrap certificate has none. `-s` rather than `-f`: a failed
+# attempt leaves that file behind empty, and certbot then issues under
+# `$certName-0001`, a path nginx never names — so the retry reports success and
+# changes nothing.
+if ${DwComposeFiles.invoke} run --rm -T --entrypoint sh certbot -c \\
+  "test -s /etc/letsencrypt/renewal/$certName.conf" </dev/null; then
+  exit 0
+fi
+${DwComposeFiles.invoke} run --rm -T --entrypoint sh certbot -c "
+  set -e
+  # certonly refuses to write into an existing live directory, and that
+  # directory is exactly what the bootstrap step created.
+  rm -rf /etc/letsencrypt/live/$certName \\
+         /etc/letsencrypt/archive/$certName \\
+         /etc/letsencrypt/renewal/$certName.conf
+  certbot certonly --webroot -w /var/www/certbot \\
+    --cert-name '$certName' $domains \\
+    --email '${target.sslEmail}' --agree-tos --no-eff-email -n
+" </dev/null
+''');
+  }
+
   Future<DwSshResult> up() =>
       ssh.runAs(target.deployUser, _compose('up -d --remove-orphans'));
 
@@ -210,6 +285,14 @@ class DwDeployRunner {
       title: 'Check nginx upstreams against the applied stack',
       run: checkUpstreams,
       verdict: upstreamVerdict,
+    ),
+    // After `up`, because the ACME challenge is answered by the nginx this
+    // deploy has just started, and before the restart, which is what makes
+    // nginx read what was issued.
+    DwDeployStep(
+      id: 'certificate',
+      title: 'Issue the TLS certificate',
+      run: issueCertificate,
     ),
     DwDeployStep(
       id: 'restart-proxy',

--- a/packages/dartway_cli/test/deploy_certificate_test.dart
+++ b/packages/dartway_cli/test/deploy_certificate_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:dartway_cli/src/deploy/deploy_runner.dart';
+import 'package:dartway_cli/src/deploy/deploy_target.dart';
+import 'package:dartway_cli/src/deploy/serverpod_config.dart';
+import 'package:dartway_cli/src/deploy/ssh_runner.dart';
+import 'package:test/test.dart';
+
+/// An SSH runner that records what it was asked to run and answers nothing.
+class _RecordingSsh extends DwSshRunner {
+  _RecordingSsh()
+    : super(host: '203.0.113.10', user: 'root', identityFile: null);
+
+  final List<String> issued = [];
+
+  @override
+  Future<DwSshResult> run(String command) async {
+    issued.add(command);
+    return const DwSshResult(exitCode: 0, stdout: '', stderr: '');
+  }
+
+  @override
+  Future<DwSshResult> runAs(String deployUser, String command) => run(command);
+}
+
+DwDeployTarget _target() => DwDeployTarget(
+  environment: 'staging',
+  host: '203.0.113.10',
+  sshUser: 'root',
+  deployUser: 'deployer',
+  os: 'ubuntu',
+  repo: 'git@github.com:acme/shop.git',
+  branch: 'master',
+  sslEmail: 'ops@example.com',
+  webAppDomain: 'app.example.com',
+  requiredSecretFiles: const [],
+);
+
+DwServerpodConfig _serverpod({String? apiPublicHost = 'api.example.com'}) =>
+    DwServerpodConfig(
+      environment: 'staging',
+      relativePath: 'shop_server/config/staging.yaml',
+      apiServer: DwServerEndpoint(
+        name: 'apiServer',
+        port: 8080,
+        publicHost: apiPublicHost,
+        publicPort: 443,
+        publicScheme: 'https',
+      ),
+      insightsServer: DwServerEndpoint(
+        name: 'insightsServer',
+        port: 8081,
+        publicHost: 'insights.example.com',
+        publicPort: 443,
+        publicScheme: 'https',
+      ),
+      webServer: DwServerEndpoint(
+        name: 'webServer',
+        port: 8082,
+        publicHost: 'srv.example.com',
+        publicPort: 443,
+        publicScheme: 'https',
+      ),
+      databaseHost: 'postgres',
+      databasePort: 5432,
+      databaseName: 'shop',
+      databaseUser: 'shop',
+      redisEnabled: false,
+      redisHost: null,
+    );
+
+DwDeployRunner _runner(
+  _RecordingSsh ssh, {
+  String? apiPublicHost = 'api.example.com',
+}) =>
+    DwDeployRunner(
+      ssh: ssh,
+      target: _target(),
+      serverpod: _serverpod(apiPublicHost: apiPublicHost),
+      stdout: stdout,
+    );
+
+void main() {
+  group('the deployment issues its own certificate', () {
+    test('the step runs after the stack is up and before nginx restarts', () {
+      final ids = _runner(
+        _RecordingSsh(),
+      ).steps(skipGitUpdate: false).map((step) => step.id).toList();
+
+      expect(ids, contains('certificate'));
+      expect(ids.indexOf('certificate'), greaterThan(ids.indexOf('up')));
+      expect(
+        ids.indexOf('certificate'),
+        lessThan(ids.indexOf('restart-proxy')),
+      );
+    });
+
+    test('it asks for one certificate covering every served name', () async {
+      final ssh = _RecordingSsh();
+      await _runner(ssh).issueCertificate();
+
+      final command = ssh.issued.single;
+      expect(command, contains('certbot certonly --webroot'));
+      expect(command, contains("--cert-name 'api.example.com'"));
+      for (final domain in [
+        'api.example.com',
+        'insights.example.com',
+        'srv.example.com',
+        'app.example.com',
+      ]) {
+        expect(command, contains("-d '$domain'"));
+      }
+      expect(command, contains("--email 'ops@example.com'"));
+    });
+
+    test('a lineage certbot already manages is left alone', () async {
+      final ssh = _RecordingSsh();
+      await _runner(ssh).issueCertificate();
+
+      // Non-empty, not merely present: a failed attempt leaves the renewal
+      // config behind empty, and certbot then issues under `<name>-0001`,
+      // which nginx never names.
+      expect(
+        ssh.issued.single,
+        contains('test -s /etc/letsencrypt/renewal/api.example.com.conf'),
+      );
+    });
+
+    test('the bootstrap certificate is cleared out of the way first', () async {
+      final ssh = _RecordingSsh();
+      await _runner(ssh).issueCertificate();
+
+      // certonly refuses to write into a live directory that exists, and the
+      // self-signed bootstrap certificate is written into exactly that one.
+      expect(
+        ssh.issued.single,
+        contains('rm -rf /etc/letsencrypt/live/api.example.com'),
+      );
+    });
+
+    test('a config with no public API host fails and issues nothing', () async {
+      final ssh = _RecordingSsh();
+      final result = await _runner(ssh, apiPublicHost: null).issueCertificate();
+
+      expect(result.ok, isFalse);
+      expect(result.stderr, contains('publicHost'));
+      expect(ssh.issued, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #238.

**Root.** `deploy setup` writes a one-day self-signed certificate so Nginx can start at all, and the rendered compose runs `certbot renew` in a loop. `renew` only renews lineages certbot already manages, and a file openssl wrote is not one — there is no `renewal/<name>.conf`, so it finds nothing to do and exits happily, forever. No code path anywhere ran `certonly`: a grep across `packages/` and `template/` came back empty.

A stand provisioned exactly by the book therefore served an expired self-signed certificate. The smoke test was right and its advice was wrong — four failing endpoints, and a pointer at container logs where nothing had failed.

**The fix.** `deploy run` gains a `certificate` step between `up` and `restart-proxy`. Both neighbours are load-bearing: the ACME challenge is answered by the Nginx this deploy has just started, and the restart is what makes Nginx read what arrived. One certificate covers every served name, because the rendered Nginx points all four `server` blocks at a single `__CERTNAME__` — one certificate per domain would leave three of them serving a name it does not carry.

Two details that cost an afternoon by hand:

1. `certonly` refuses to write into an existing `live/<name>` directory — which is exactly what the bootstrap step creates, so it is removed in the same command that issues the replacement;
2. a failed attempt leaves a **zero-byte** `renewal/<name>.conf` behind, after which certbot issues under `<name>-0001`, a path Nginx never names. The guard therefore asks `test -s` rather than `test -f`, and the stale file is cleaned up with the rest.

**What it deliberately does not do.** It asks one question — does certbot manage this lineage — and does nothing when the answer is yes, so a routine deploy does not spend a rate-limited issuance on every run. It does not inspect an existing certificate, compare its names, or repair what an older stand was left with: under a zero major we fix the shape going forward (root `CLAUDE.md`, "Zero major", #252).

**Tests.** `test/deploy_certificate_test.dart` — the step's place in the order, the four names under one `--cert-name`, the non-empty-renewal guard, the live-directory cleanup, and a config with no `apiServer.publicHost` failing with a message that names it instead of issuing against an empty name (the renderer writes `live//fullchain.pem` in that case today).

Docs and CHANGELOG updated; `docs/5-tooling/cli.md` claimed "the first `run` replaces it", which was not true until this PR. No migration note: nothing asks a project to change its own code. Version stays at `0.10.1` — master is already ahead of stable, so the pending release carries the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)