### PR TITLE
fix(core): a refused session restore is an answer, not a dead app

### DIFF
--- a/docs/2-core/error-reporting.md
+++ b/docs/2-core/error-reporting.md
@@ -126,6 +126,31 @@ An app can throw one itself for a rule of its own — `throw const DwRefusal('Th
 file is larger than 10 MB')` — and get the same treatment. Write the message for
 a user: it reaches the screen unedited.
 
+## No session is a third answer
+
+A stored key the server does not accept — expired, revoked, the account deleted,
+the app pointed at another backend — is neither a rule saying no nor something
+breaking. It means the person is signed out, which is a state the app already
+knows how to render.
+
+The server has always named the case (`DwApiResponse.notAuthenticated`); the
+response carries it as `isNotAuthenticated`, and `dw.repo` raises a
+**`DwNotAuthenticated`** for it. `DwSessionService` acts on it at startup: the
+stored key goes, and the app starts unauthenticated instead of failing to start
+at all. Before the type existed the refusal arrived as a sentence inside a
+generic exception, propagated out of `initDwCore` — which apps await before any
+UI is built — and the app opened to nothing at all, on every launch, until it
+was reinstalled.
+
+A custom policy sorts it out the same way it sorts out a refusal:
+
+```dart
+onErrorReport: (report) {
+  if (report.error is DwNotAuthenticated) return; // the session simply ended
+  mySentry.capture(report.error, report.stackTrace);
+},
+```
+
 Everything else is unchanged, and deliberately so: a `DatabaseException`, an
 exception the server's guard caught, or a call the server has no config for
 still arrive as ordinary exceptions and are still reported.

--- a/docs/migrations/2026-09-09-app-error-screen-builder.md
+++ b/docs/migrations/2026-09-09-app-error-screen-builder.md
@@ -1,0 +1,30 @@
+---
+title: The startup error screen is built from the error
+affects:
+  dartway_flutter: "0.9.0"
+---
+
+## Who is affected
+
+A project that passes its own `errorScreen` to `DwAppLoadingOptions` — in the `DwAppRunner` of its
+app file. A project that uses the default screen has nothing to change.
+
+## What to change
+
+`DwAppLoadingOptions.errorScreen` (a widget) is now `errorScreenBuilder` (a function of the error
+that failed the start):
+
+    - DwAppLoadingOptions.withNativeSplash(errorScreen: const MyStartupError())
+    + DwAppLoadingOptions.withNativeSplash(
+    +   errorScreenBuilder: (error, stackTrace) => MyStartupError(error: error),
+    + )
+
+Ignoring both arguments is a valid answer — `(_, _) => const MyStartupError()` — but the error is
+worth putting on the screen. The person looking at a failed start is usually the one who will be
+asked what happened, and "please contact administrator" with nothing else is not something they
+can report.
+
+## How to check
+
+`dart analyze` in the Flutter package: `errorScreen` no longer exists, so a missed call site is a
+compile error rather than something that surfaces on a launch nobody watched.

--- a/example/dartway_example_client/pubspec.yaml
+++ b/example/dartway_example_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.12.0
+  dartway_serverpod_core_client: ^0.13.0
   # The client half of the optional push module. Required because the generated
   # protocol imports it — the server consumes the module, so its `Caller` shows
   # up in this package's `client.dart`. Drop both together if an app does not

--- a/example/dartway_example_flutter/pubspec.lock
+++ b/example/dartway_example_flutter/pubspec.lock
@@ -277,7 +277,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -305,21 +305,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_shared_preferences:
     dependency: "direct main"
     description:

--- a/example/dartway_example_flutter/pubspec.yaml
+++ b/example/dartway_example_flutter/pubspec.yaml
@@ -38,14 +38,14 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.8.0
+  dartway_flutter: ^0.9.0
   # Where the signed-in session is kept: the core asks the plugins for whoever
   # claimed the DwKeyValueStorePlugin role, and without one there is nowhere
   # to put the auth key.
   dartway_shared_preferences: ^0.5.0
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.12.0
+  dartway_serverpod_core_flutter: ^0.13.0
   dartway_studio_bridge: ^0.9.0
 
   dartway_studio_binding: ^0.1.0

--- a/example/dartway_example_server/pubspec.lock
+++ b/example/dartway_example_server/pubspec.lock
@@ -134,14 +134,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   ffi:
     dependency: transitive
     description:

--- a/example/dartway_example_server/pubspec.yaml
+++ b/example/dartway_example_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.12.0
+  dartway_serverpod_core_server: ^0.13.0
   # Optional push delivery module. An app that does not need push simply omits
   # this dependency and gets none of the dw_push_* tables.
   dartway_push_server: ^0.4.0

--- a/packages/dartway_flutter/CHANGELOG.md
+++ b/packages/dartway_flutter/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.9.0
+
+- **A start that fails says so, and says what failed.** An initializer that threw was reported and
+  then the app was expected to render an error screen — but the reporting ran first and
+  unguarded, so a handler that threw in turn (DwCore's own alerting, talking to the server the
+  start could not reach) left the failure flag unset. The app stayed on the loading screen, which
+  under a native splash is a `SizedBox.shrink()`: nothing at all, on every launch, until the app
+  was reinstalled. Reporting is now attempted inside its own guard and cannot decide whether the
+  app gets a first frame.
+
+- **`DwAppLoadingOptions.errorScreen` becomes `errorScreenBuilder`.** The screen is built from the
+  error that failed the start, and the default one puts that text on it. A start can fail for
+  reasons only the failure names, and the person looking at the screen is usually the one who will
+  be asked what happened. **Breaking:** see `docs/migrations/2026-09-09-app-error-screen-builder.md`.
+
+- **`DwNotAuthenticated`** — the answer "there is no session", as a type. Raised by
+  `DwRepository.processApiResponse` for a response the server marked `isNotAuthenticated`, and
+  sorted out by an app's `onErrorReport` with one type check, the way `DwRefusal` already is.
+
 ## 0.8.0
 
 - **`DwKeyValueStorePlugin` — the role the framework asks for when it needs to keep a small value.**

--- a/packages/dartway_flutter/example/pubspec.lock
+++ b/packages/dartway_flutter/example/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/dartway_flutter/lib/dartway_flutter.dart
+++ b/packages/dartway_flutter/lib/dartway_flutter.dart
@@ -51,6 +51,7 @@ export 'src/ui/confirmation/dw_ui_confirmation.dart';
 export 'src/diagnostics/error_reporting/dw_error_report.dart';
 // The one error that is an answer rather than an incident — see DwRefusal.
 export 'src/diagnostics/error_reporting/dw_refusal.dart';
+export 'src/diagnostics/error_reporting/dw_not_authenticated.dart';
 
 // diagnostics/dw_feature: mark a widget as a product feature and discover the
 // mounted ones at runtime — feature catalogs, error context, Studio passports.

--- a/packages/dartway_flutter/lib/src/bootstrap/dw_app_runner.dart
+++ b/packages/dartway_flutter/lib/src/bootstrap/dw_app_runner.dart
@@ -25,7 +25,9 @@ import 'widgets/dw_app_bootstrapper.dart';
 /// `init()` inside `appInitializers`.
 class DwAppRunner {
   /// Optional initialization steps, run in order before the app renders. Each
-  /// is awaited; an initializer that throws surfaces on the error screen.
+  /// is awaited; an initializer that throws surfaces on the error screen,
+  /// which is built from the error itself
+  /// ([DwAppLoadingOptions.errorScreenBuilder]).
   final List<FutureOr<void> Function()>? appInitializers;
 
   /// Loading/error screen configuration.
@@ -111,7 +113,7 @@ class DwAppRunner {
           appInitializers: initializers,
           useNativeSplash: appLoadingOptions.useNativeSplash,
           onError: effectiveOnError,
-          errorScreen: appLoadingOptions.errorScreen,
+          errorScreenBuilder: appLoadingOptions.errorScreenBuilder,
           loadingScreen: appLoadingOptions.loadingScreen,
           child: child,
         ),

--- a/packages/dartway_flutter/lib/src/bootstrap/logic/dw_app_loading_options.dart
+++ b/packages/dartway_flutter/lib/src/bootstrap/logic/dw_app_loading_options.dart
@@ -1,26 +1,64 @@
 import 'package:flutter/material.dart';
 
+/// What the app shows while it is starting, and what it shows when it cannot.
 class DwAppLoadingOptions {
-  static const defaultErrorScreen = Center(
-    child: Directionality(
-      textDirection: TextDirection.ltr,
-      child: Center(
-        child: Text('App initialization failed, please, contact administrator'),
-      ),
-    ),
-  );
+  /// The screen a failed start lands on: the message, and the failure itself.
+  ///
+  /// The error text is on the screen deliberately. A start can fail for
+  /// reasons only the failure names — a missing configuration, an unreachable
+  /// server, a plugin that threw — and the person looking at the screen is
+  /// usually the one who will be asked what happened. "Please contact
+  /// administrator" with nothing else turns a reportable fault into "the app
+  /// is broken".
+  static Widget defaultErrorScreen(Object error, StackTrace stackTrace) =>
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ColoredBox(
+          color: const Color(0xFF1C1C1E),
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text(
+                    'The app could not start',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: Color(0xFFFFFFFF),
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    '$error',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Color(0xFFBDBDBD),
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
 
   const DwAppLoadingOptions.withoutNativeSplash({
     this.loadingScreen = const Center(child: CircularProgressIndicator()),
-    this.errorScreen = defaultErrorScreen,
+    this.errorScreenBuilder = defaultErrorScreen,
   }) : useNativeSplash = false;
 
   const DwAppLoadingOptions.withNativeSplash({
-    this.errorScreen = defaultErrorScreen,
+    this.errorScreenBuilder = defaultErrorScreen,
   }) : loadingScreen = const SizedBox.shrink(),
        useNativeSplash = true;
 
-  final Widget errorScreen;
+  /// Builds the screen for a start that failed, from the error that failed it.
+  final Widget Function(Object error, StackTrace stackTrace) errorScreenBuilder;
+
   final Widget loadingScreen;
   final bool useNativeSplash;
 }

--- a/packages/dartway_flutter/lib/src/bootstrap/widgets/dw_app_bootstrapper.dart
+++ b/packages/dartway_flutter/lib/src/bootstrap/widgets/dw_app_bootstrapper.dart
@@ -9,7 +9,7 @@ class DwAppBootstrapper extends ConsumerStatefulWidget {
   final bool useNativeSplash;
 
   final void Function(Object error, StackTrace stackTrace) onError;
-  final Widget errorScreen;
+  final Widget Function(Object error, StackTrace stackTrace) errorScreenBuilder;
   final Widget loadingScreen;
   final Widget child;
 
@@ -18,7 +18,7 @@ class DwAppBootstrapper extends ConsumerStatefulWidget {
     required this.appInitializers,
     required this.useNativeSplash,
     required this.onError,
-    required this.errorScreen,
+    required this.errorScreenBuilder,
     required this.loadingScreen,
     required this.child,
   });
@@ -29,7 +29,7 @@ class DwAppBootstrapper extends ConsumerStatefulWidget {
 
 class _DwAppBootstrapperState extends ConsumerState<DwAppBootstrapper> {
   bool _initialized = false;
-  bool _failed = false;
+  (Object, StackTrace)? _failure;
 
   @override
   void initState() {
@@ -50,9 +50,20 @@ class _DwAppBootstrapperState extends ConsumerState<DwAppBootstrapper> {
         setState(() => _initialized = true);
       }
     } catch (error, stack) {
-      widget.onError(error, stack);
+      // Reporting is attempted, and it is not allowed to decide whether the
+      // app gets a first frame. The handler runs against a core that has just
+      // failed to initialize — DwCore's own alerting talks to the server the
+      // start could not reach — and a throw in here used to leave `_failed`
+      // unset, so the app sat on the loading screen, which under a native
+      // splash is a `SizedBox.shrink()`: nothing at all, for good.
+      try {
+        widget.onError(error, stack);
+      } catch (reportingError, reportingStack) {
+        debugPrint('[DwAppBootstrapper] the error report itself failed: '
+            '$reportingError\n$reportingStack');
+      }
       if (mounted) {
-        setState(() => _failed = true);
+        setState(() => _failure = (error, stack));
       }
     } finally {
       if (widget.useNativeSplash) {
@@ -63,7 +74,10 @@ class _DwAppBootstrapperState extends ConsumerState<DwAppBootstrapper> {
 
   @override
   Widget build(BuildContext context) {
-    if (_failed) return widget.errorScreen;
+    final failure = _failure;
+    if (failure != null) {
+      return widget.errorScreenBuilder(failure.$1, failure.$2);
+    }
     if (!_initialized) return widget.loadingScreen;
 
     return widget.child;

--- a/packages/dartway_flutter/lib/src/diagnostics/error_reporting/dw_not_authenticated.dart
+++ b/packages/dartway_flutter/lib/src/diagnostics/error_reporting/dw_not_authenticated.dart
@@ -1,0 +1,34 @@
+/// There is no session: the server was asked with a stored key and answered
+/// that it does not know it.
+///
+/// Thrown where a failure would otherwise be, and it is not one. A key stops
+/// being accepted whenever it expires, is revoked, the account is deleted, the
+/// password changes or the app is pointed at another backend — all ordinary,
+/// and all of them mean the same thing: *this person is not signed in*. That
+/// is a state every app already knows how to render.
+///
+/// It used to arrive as `Exception('Authentication required (getOne for
+/// UserProfile)')`, which a client can do nothing with but match on text. The
+/// server has always had a name for the case — `DwApiResponse.notAuthenticated`
+/// — and this type is that name surviving the trip: `isNotAuthenticated` on the
+/// response, raised here by `DwRepository.processApiResponse`.
+///
+/// What acts on it:
+///
+/// - `DwSessionService` drops the stored key on startup and starts signed out,
+///   instead of failing the launch and leaving the app with no first frame;
+/// - an app's own `DwConfig.onErrorReport` can sort it out by type, the same
+///   way it sorts out a `DwRefusal`, rather than alerting on a person whose
+///   session simply ended.
+///
+/// [message] is the server's own account of where it happened — a diagnostic,
+/// not a line for the screen. What the user should see is the sign-in screen.
+class DwNotAuthenticated implements Exception {
+  const DwNotAuthenticated(this.message);
+
+  /// The server's description of the refused call, for logs and reports.
+  final String message;
+
+  @override
+  String toString() => 'DwNotAuthenticated: $message';
+}

--- a/packages/dartway_flutter/pubspec.yaml
+++ b/packages/dartway_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_flutter
 description: "The Flutter skeleton of a DartWay app: bootstrap runner, guarded UI actions, the AsyncValue rendering contract, notifications and error reporting. Riverpod-native."
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_flutter/test/dw_app_bootstrapper_test.dart
+++ b/packages/dartway_flutter/test/dw_app_bootstrapper_test.dart
@@ -1,0 +1,80 @@
+import 'package:dartway_flutter/src/bootstrap/logic/dw_app_loading_options.dart';
+import 'package:dartway_flutter/src/bootstrap/widgets/dw_app_bootstrapper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _bootstrapper({
+  required List<Future<void> Function()> initializers,
+  void Function(Object, StackTrace)? onError,
+  Widget Function(Object, StackTrace)? errorScreenBuilder,
+}) => MediaQuery(
+  data: const MediaQueryData(),
+  child: DwAppBootstrapper(
+    appInitializers: initializers,
+    useNativeSplash: false,
+    onError: onError ?? (_, _) {},
+    errorScreenBuilder:
+        errorScreenBuilder ?? DwAppLoadingOptions.defaultErrorScreen,
+    loadingScreen: const SizedBox.shrink(),
+    child: const Text('the app', textDirection: TextDirection.ltr),
+  ),
+);
+
+void main() {
+  testWidgets('a start that succeeds renders the app', (tester) async {
+    await tester.pumpWidget(_bootstrapper(initializers: [() async {}]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('the app'), findsOneWidget);
+  });
+
+  testWidgets('a failed start says so, and says what failed', (tester) async {
+    await tester.pumpWidget(
+      _bootstrapper(
+        initializers: [() async => throw Exception('no database')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('the app'), findsNothing);
+    expect(find.text('The app could not start'), findsOneWidget);
+    // The failure itself is on the screen: without it the person looking at it
+    // has nothing to report but "the app is broken".
+    expect(find.textContaining('no database'), findsOneWidget);
+  });
+
+  testWidgets('a reporter that throws does not eat the screen', (
+    tester,
+  ) async {
+    // The handler runs against a core that has just failed to start, and its
+    // out-of-the-box alerting talks to the server the start could not reach.
+    // A throw in there used to leave the app on the loading screen — under a
+    // native splash a `SizedBox.shrink()`, which is nothing at all, for good.
+    await tester.pumpWidget(
+      _bootstrapper(
+        initializers: [() async => throw Exception('no database')],
+        onError: (_, _) => throw StateError('the reporter is broken too'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('The app could not start'), findsOneWidget);
+  });
+
+  testWidgets('the error screen is built from the error', (tester) async {
+    Object? seen;
+    await tester.pumpWidget(
+      _bootstrapper(
+        initializers: [() async => throw Exception('no database')],
+        errorScreenBuilder: (error, _) {
+          seen = error;
+          return const Text('mine', textDirection: TextDirection.ltr);
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('mine'), findsOneWidget);
+    expect(seen.toString(), contains('no database'));
+  });
+}

--- a/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
+++ b/packages/dartway_offline/dartway_offline_flutter/example/pubspec.lock
@@ -175,7 +175,7 @@ packages:
       path: "../../../dartway_flutter"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_offline_flutter:
     dependency: "direct main"
     description:
@@ -196,21 +196,21 @@ packages:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_flutter:
     dependency: "direct overridden"
     description:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../../dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dbus:
     dependency: transitive
     description:

--- a/packages/dartway_offline/dartway_offline_flutter/pubspec.yaml
+++ b/packages/dartway_offline/dartway_offline_flutter/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.8.0
+  dartway_flutter: ^0.9.0
   dartway_offline_shared: ^0.1.0
-  dartway_serverpod_core_flutter: ^0.12.0
+  dartway_serverpod_core_flutter: ^0.13.0
   drift: ^2.31.0
   drift_flutter: ^0.2.8
   background_downloader: ^9.5.7

--- a/packages/dartway_push/dartway_push_client/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_client/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   # wrapper types. Inside the workspace this resolved without being declared,
   # which is exactly the kind of dependency that only fails once the package is
   # published and somebody else resolves it.
-  dartway_serverpod_core_client: ^0.12.0
+  dartway_serverpod_core_client: ^0.13.0

--- a/packages/dartway_push/dartway_push_flutter/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_flutter/pubspec.yaml
@@ -16,12 +16,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.8.0
+  dartway_flutter: ^0.9.0
   # The device registration request, and the CRUD action that carries it. The
   # app half talks to the server half through the generated protocol, not
   # through an endpoint of its own.
   dartway_push_client: ^0.2.0
-  dartway_serverpod_core_flutter: ^0.12.0
+  dartway_serverpod_core_flutter: ^0.13.0
   flutter_riverpod: ^3.0.0
 
 dev_dependencies:

--- a/packages/dartway_push/dartway_push_server/pubspec.yaml
+++ b/packages/dartway_push/dartway_push_server/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   serverpod: ^3.4.11
 
-  dartway_serverpod_core_server: ^0.12.0
+  dartway_serverpod_core_server: ^0.13.0
   collection: ^1.19.1
   crypto: ^3.0.6
   googleapis_auth: ^2.3.3

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.0
+
+- The response carries `isNotAuthenticated`, so "there is no session" survives the trip to the
+  client as a fact rather than as a sentence inside a generic exception. The four
+  `dartway_serverpod_core_*` packages move in lockstep.
+
 ## 0.12.1
 
 - Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_api_response.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/lib/src/domain/api/dw_api_response.dart
@@ -34,6 +34,7 @@ class DwApiResponse<T> implements SerializableModel {
     this.error,
     this.updatedModels,
     this.isRefusal = false,
+    this.isNotAuthenticated = false,
   });
 
   /// A rule on the server said no, and [message] is what it said.
@@ -46,7 +47,8 @@ class DwApiResponse<T> implements SerializableModel {
       error = message,
       warning = null,
       updatedModels = null,
-      isRefusal = true;
+      isRefusal = true,
+      isNotAuthenticated = false;
 
   const DwApiResponse.notConfigured()
     : isOk = false,
@@ -54,7 +56,8 @@ class DwApiResponse<T> implements SerializableModel {
       error = 'This action is not supported by the server',
       warning = null,
       updatedModels = null,
-      isRefusal = false;
+      isRefusal = false,
+      isNotAuthenticated = false;
 
   const DwApiResponse.forbidden()
     : isOk = false,
@@ -62,7 +65,8 @@ class DwApiResponse<T> implements SerializableModel {
       error = 'Not enough permissions',
       warning = null,
       updatedModels = null,
-      isRefusal = true;
+      isRefusal = true,
+      isNotAuthenticated = false;
 
   /// The caller is not signed in and the config did not opt into anonymous
   /// access. Distinct from [DwApiResponse.forbidden]: there the caller is
@@ -74,7 +78,8 @@ class DwApiResponse<T> implements SerializableModel {
       error = 'Authentication required${source != null ? ' ($source)' : ''}',
       warning = null,
       updatedModels = null,
-      isRefusal = false;
+      isRefusal = false,
+      isNotAuthenticated = true;
 
   final bool isOk;
   final T? value;
@@ -92,6 +97,22 @@ class DwApiResponse<T> implements SerializableModel {
   /// **False when the key is absent**, which is how a server older than the
   /// flag reads: every error stays an incident, exactly as before.
   final bool isRefusal;
+
+  /// Whether [error] means "there is no session", rather than a rule saying no
+  /// or something breaking.
+  ///
+  /// The twin of [isRefusal], and it exists for the same reason: the case has
+  /// a name on the server — [DwApiResponse.notAuthenticated] — and lost it on
+  /// the way to the client, arriving as a sentence inside a generic
+  /// `Exception`. A client cannot act on a sentence. It can act on this: an
+  /// expired key, a revoked one, a deleted account and a different backend all
+  /// mean the person is signed out, which is a state the app knows how to
+  /// render.
+  ///
+  /// `DwRepository.processApiResponse` raises a `DwNotAuthenticated` for it,
+  /// and `DwSessionService` drops the stored key and starts signed out instead
+  /// of failing the launch.
+  final bool isNotAuthenticated;
 
   static K? manualDeserialization<K>(Map<String, dynamic> jsonSerialization) {
     if (K == DwApiResponse<List<int>>) {
@@ -133,6 +154,8 @@ class DwApiResponse<T> implements SerializableModel {
                 )
                 .toList(),
       isRefusal: jsonSerialization['isRefusal'] as bool? ?? false,
+      isNotAuthenticated:
+          jsonSerialization['isNotAuthenticated'] as bool? ?? false,
     );
   }
 
@@ -144,6 +167,7 @@ class DwApiResponse<T> implements SerializableModel {
       if (warning != null) 'warning': warning,
       if (error != null) 'error': error,
       if (isRefusal) 'isRefusal': true,
+      if (isNotAuthenticated) 'isNotAuthenticated': true,
       if (updatedModels != null)
         'updatedModels': updatedModels?.toJson(valueToJson: (v) => v.toJson()),
     };

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_client
 description: "Generated Serverpod client of the DartWay core module: protocol models and endpoint callers consumed by dartway_serverpod_core_flutter. Not edited by hand."
-version: 0.12.1
+version: 0.13.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.13.0
+
+- **A refused session restore no longer kills the app.** A stored key the server does not accept —
+  expired, revoked, a deleted account, a different backend — came back as
+  `Exception('Authentication required (getOne for UserProfile)')`, and `DwSessionService` had no
+  way to tell it from a bug, so it propagated out of `initDwCore`. Apps await that before any UI
+  exists: the app started to a black screen, every launch, and only a reinstall recovered it. The
+  server has always had a name for the case (`DwApiResponse.notAuthenticated`); the response now
+  carries it as `isNotAuthenticated`, `processApiResponse` raises a `DwNotAuthenticated`, and the
+  session service drops the stored key and starts signed out — the state the app already knows how
+  to render.
+
 ## 0.12.1
 
 - Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/app/session/service/dw_session_service.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/app/session/service/dw_session_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dartway_flutter/dartway_flutter.dart';
 import 'package:dartway_serverpod_core_client/dartway_serverpod_core_client.dart';
 import 'package:flutter/foundation.dart';
 
@@ -112,6 +113,16 @@ class DwSessionService<UserProfileClass extends SerializableModel> {
 
       await keyManager.storeUserProfile(profile);
       _setCurrentUser(profile, id);
+    } on DwNotAuthenticated catch (error) {
+      // The server refused the stored key, which is an answer and not a
+      // failure: expired, revoked, a deleted account, another backend. Every
+      // one of them means the person is signed out — the state the app knows
+      // how to render — and this used to leave `initDwCore` by exception,
+      // before any UI existed, so the app started to nothing at all and only a
+      // reinstall recovered it.
+      debugPrint('[DwSessionService] the stored session is gone: $error');
+      await invalidateSession();
+      return;
     } catch (error) {
       // A connection-level failure is not an answer: with a cached profile we
       // start from it and keep working offline — fresh data arrives once

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repository.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/dw_repository.dart
@@ -838,6 +838,14 @@ class DwRepository {
     // was written in, and the app's error policy can sort it out by type
     // instead of by matching the text.
     if (response.error != null) {
+      // "No session" is the third answer, and it is neither of the other two:
+      // a key the server does not know is not a rule saying no, and not a bug
+      // either. It reaches the caller as a type so that a session can be
+      // dropped and a sign-in screen shown, instead of a launch failing on a
+      // sentence.
+      if (response.isNotAuthenticated) {
+        throw DwNotAuthenticated(response.error!);
+      }
       throw response.isRefusal
           ? DwRefusal(response.error!)
           : Exception(response.error);

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_flutter
 description: "Flutter side of the DartWay core: a typed realtime data layer over the Serverpod module, session management, connection-aware error handling and context-rich alerting."
-version: 0.12.1
+version: 0.13.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -24,9 +24,9 @@ dependencies:
 
   serverpod_client: ^3.4.11
 
-  dartway_flutter: ^0.8.0
-  dartway_serverpod_core_client: ^0.12.0
-  dartway_serverpod_core_shared: ^0.12.0
+  dartway_flutter: ^0.9.0
+  dartway_serverpod_core_client: ^0.13.0
+  dartway_serverpod_core_shared: ^0.13.0
   collection: ^1.19.1
   crypto: ^3.0.6
   flutter_riverpod: ^3.0.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_refusal_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_refusal_test.dart
@@ -97,6 +97,50 @@ void main() {
       );
     });
 
+    test('a refused session is answered with DwNotAuthenticated', () {
+      expect(
+        () => DwRepository.processApiResponse<bool>(
+          const DwApiResponse<bool>.notAuthenticated(source: 'getOne'),
+          updateListeners: false,
+        ),
+        throwsA(
+          isA<DwNotAuthenticated>().having(
+            (e) => e.message,
+            'message',
+            'Authentication required (getOne)',
+          ),
+        ),
+      );
+    });
+
+    test('no session is neither a refusal nor a failure', () {
+      // The three answers are distinct on purpose: a rule saying no reaches
+      // the user as text, a bug is an incident, and a key the server does not
+      // know means the person is signed out.
+      const response = DwApiResponse<bool>.notAuthenticated(source: 'getAll');
+
+      expect(response.isRefusal, isFalse);
+      expect(response.isNotAuthenticated, isTrue);
+      expect(
+        () => DwRepository.processApiResponse<bool>(
+          response,
+          updateListeners: false,
+        ),
+        throwsA(isNot(isA<DwRefusal>())),
+      );
+    });
+
+    test('the flag survives the wire', () {
+      final wire = const DwApiResponse<bool>.notAuthenticated(
+        source: 'getOne',
+      ).toJson();
+      final back = DwApiResponse<bool>.fromJson(wire);
+
+      expect(wire['isNotAuthenticated'], isTrue);
+      expect(back.isNotAuthenticated, isTrue);
+      expect(back.isRefusal, isFalse);
+    });
+
     test('an older server, which marks nothing, still reports failures', () {
       // The flag absent from the JSON is what a server built before it looks
       // like: every error stays an incident, exactly as it did.

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_session_service_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_session_service_test.dart
@@ -59,6 +59,29 @@ void main() {
     expect(signedIn, [null]);
   });
 
+  test('starts signed out when the server refuses the stored key', () async {
+    // The other half of "no session", and the one that used to be fatal: the
+    // server answers with a refusal rather than an empty value — an expired or
+    // revoked key, a deleted account, another backend. It left initialize() by
+    // exception, and since apps await it before any UI exists the app started
+    // to nothing at all, on every launch, until it was reinstalled.
+    final keyManager = _FakeKeyManager((1, _FakeProfile(1)));
+    final signedIn = <int?>[];
+    final service = _buildService(
+      keyManager: keyManager,
+      fetchUserProfile: (_) async =>
+          throw const DwNotAuthenticated('Authentication required (getOne)'),
+      onUserChanged: (_, id) => signedIn.add(id),
+    );
+
+    await service.initialize();
+
+    expect(service.currentUserProfile, isNull);
+    expect(service.currentUserId, isNull);
+    expect(keyManager.removeCalls, 1);
+    expect(signedIn, [null]);
+  });
+
   test('drops a stored key that resolves to no user id', () async {
     final keyManager = _FakeKeyManager((null, null));
     var fetched = false;

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.0
+
+- Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in
+  `dartway_serverpod_core_client` and `dartway_serverpod_core_flutter` — a refused session restore
+  is an answer now, not a failed launch.
+
 ## 0.12.1
 
 - **A signed-in person can move their phone number or email onto their own account, with the same

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_server
 description: "Server side of the DartWay core, a Serverpod module: model-driven CRUD with realtime, declarative access and validation configs, phone auth, cloud storage and Telegram alerts."
-version: 0.12.1
+version: 0.13.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues
@@ -16,7 +16,7 @@ dependencies:
   # For @visibleForTesting on the two web-route helpers a test drives directly.
   meta: ^1.16.0
 
-  dartway_serverpod_core_shared: ^0.12.0
+  dartway_serverpod_core_shared: ^0.13.0
   collection: ^1.19.1
   crypto: ^3.0.6
   http: ^1.5.0

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.0
+
+- Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in
+  `dartway_serverpod_core_client` and `dartway_serverpod_core_flutter` — a refused session restore
+  is an answer now, not a failed launch.
+
 ## 0.12.1
 
 - Version only: the four `dartway_serverpod_core_*` packages move in lockstep. The change is in

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartway_serverpod_core_shared
 description: "Pure-Dart shared layer of the DartWay core: alert formatting, Telegram alerts, configuration keys and cross-stack utilities used by both the server and the Flutter app."
-version: 0.12.1
+version: 0.13.0
 repository: https://github.com/dartway/dartway
 homepage: https://dartway.dev
 issue_tracker: https://github.com/dartway/dartway/issues

--- a/packages/dartway_shared_preferences/pubspec.yaml
+++ b/packages/dartway_shared_preferences/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.8.0
+  dartway_flutter: ^0.9.0
   flutter_riverpod: ^3.0.0
   shared_preferences: ^2.3.0
   # For InMemorySharedPreferencesStore — the fallback when the platform has no

--- a/packages/dartway_studio_binding/pubspec.yaml
+++ b/packages/dartway_studio_binding/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
   # The passports the binding reports come from mounted DwFeature widgets.
-  dartway_flutter: ^0.8.0
+  dartway_flutter: ^0.9.0
   # The screen identity Studio binds to is the route's declared name, which is
   # a DwRouter concept — the reason this is a package of its own rather than a
   # corner of core_flutter, where the dependency would reach apps that never
@@ -25,7 +25,7 @@ dependencies:
   dartway_router: ^1.1.1
   # The persona switch runs the core's own OTP flow, so the binding sits above
   # the core rather than inside it.
-  dartway_serverpod_core_flutter: ^0.12.0
+  dartway_serverpod_core_flutter: ^0.13.0
   # The wire. Both this package and Studio depend on it; its version means the
   # protocol, which is why host-side changes do not belong there.
   dartway_studio_bridge: ^0.9.0

--- a/packages/dartway_telegram/pubspec.yaml
+++ b/packages/dartway_telegram/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  dartway_flutter: ^0.8.0
+  dartway_flutter: ^0.9.0
   telegram_web_app: ^0.3.3
 
 dev_dependencies:

--- a/template/dartway_starter_client/pubspec.yaml
+++ b/template/dartway_starter_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   serverpod_client: 3.4.11
 
-  dartway_serverpod_core_client: ^0.12.0
+  dartway_serverpod_core_client: ^0.13.0
 # Inside the monorepo — a local build. `dartway create` removes this block.
 dependency_overrides:
   dartway_serverpod_core_client:

--- a/template/dartway_starter_flutter/pubspec.lock
+++ b/template/dartway_starter_flutter/pubspec.lock
@@ -270,7 +270,7 @@ packages:
       path: "../../packages/dartway_flutter"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.9.0"
   dartway_lints:
     dependency: "direct dev"
     description:
@@ -291,21 +291,21 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_client"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_flutter:
     dependency: "direct main"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_flutter"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_shared_preferences:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_flutter/pubspec.yaml
+++ b/template/dartway_starter_flutter/pubspec.yaml
@@ -42,14 +42,14 @@ dependencies:
   # packages belong to the app, not to the framework.
   device_frame: ^1.4.0
 
-  dartway_flutter: ^0.8.0
+  dartway_flutter: ^0.9.0
   # Where the signed-in session is kept: the core asks the plugins for whoever
   # claimed the DwKeyValueStorePlugin role, and without one there is nowhere
   # to put the auth key.
   dartway_shared_preferences: ^0.5.0
   dartway_router: ^1.1.1
 
-  dartway_serverpod_core_flutter: ^0.12.0
+  dartway_serverpod_core_flutter: ^0.13.0
   dartway_studio_bridge: ^0.9.0
 
   dartway_studio_binding: ^0.1.0

--- a/template/dartway_starter_server/pubspec.lock
+++ b/template/dartway_starter_server/pubspec.lock
@@ -127,14 +127,14 @@ packages:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_server"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_serverpod_core_shared:
     dependency: "direct overridden"
     description:
       path: "../../packages/dartway_serverpod_core/dartway_serverpod_core_shared"
       relative: true
     source: path
-    version: "0.12.1"
+    version: "0.13.0"
   dartway_starter_shared:
     dependency: "direct main"
     description:

--- a/template/dartway_starter_server/pubspec.yaml
+++ b/template/dartway_starter_server/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   serverpod: 3.4.11
 
-  dartway_serverpod_core_server: ^0.12.0
+  dartway_serverpod_core_server: ^0.13.0
   http: ^1.5.0
 
   # Rules that must hold identically here and in the app. A path dependency,

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -365,6 +365,8 @@ dw.action(
 **What this means for your code:** write nothing. Do not catch `DwRefusal` to re-show it, do not
 add an `onErrorNotification` for the refusal case, and if the app has a custom
 `DwConfig.onErrorReport`, filter refusals there by type — `if (report.error is DwRefusal) return;` —
+and the same for `DwNotAuthenticated`, which is the answer "there is no session" rather than a bug:
+the framework has already dropped the stored key and the app is signed out —
 never by matching the message text.
 
 A rule of your own that lives on the client throws the same type:


### PR DESCRIPTION
Closes #243 — both halves of it, the session and the black screen.

**Root.** A stored auth key stops being accepted whenever it expires, is revoked, the account is deleted, the password changes, or the app is pointed at another backend. All ordinary; all meaning *this person is not signed in*. The server has always named the case (`DwApiResponse.notAuthenticated`) and the name did not survive the trip to the client: the response arrived as `Exception('Authentication required (getOne for UserProfile)')`, a sentence a client can only match on. `DwSessionService._doInitialize` already handles the other half correctly — the server answering with *no profile* drops the session — but a refusal was indistinguishable from a bug, so it propagated out of `initDwCore`, which apps await inside `DwAppRunner(appInitializers: [...])` **before any UI is built**. Black screen, every launch, recovered only by reinstalling.

**The fix, half one.** `isNotAuthenticated` sits next to `isRefusal` on `DwApiResponse`, `processApiResponse` raises a `DwNotAuthenticated`, and the session service drops the stored key and starts signed out. Three answers, three types: a rule saying no reaches the user as text, a bug is an incident, and a key the server does not know signs somebody out. This is the shape #137 asks for, applied to the one case that is fatal today — a code, not a sentence.

**The fix, half two — the surface, which was the worse half.** `DwAppBootstrapper` reported a failed initializer *before* rendering anything, and unguarded: a reporting handler that threw in turn left the failure flag unset and the app sat on the loading screen, which under a native splash is a `SizedBox.shrink()` — nothing at all. DwCore's out-of-the-box alerting talks to the server the start could not reach, which is precisely when it throws. Reporting now runs inside its own guard and cannot decide whether the app gets a first frame.

`DwAppLoadingOptions.errorScreen` (a widget) becomes `errorScreenBuilder` (a function of the error), and the default screen puts the error text on it. A start fails for reasons only the failure names, and the person looking at the screen is usually the one who will be asked what happened — "please contact administrator" alone turns a reportable fault into "the app is broken". One way to do it rather than two, per `docs/DESIGN.md`.

**Tests.** `dw_session_service_test.dart` — a refused key starts the app signed out instead of throwing. `dw_refusal_test.dart` — the typed answer, its distinctness from a refusal and from a failure, and the flag surviving the wire. `dw_app_bootstrapper_test.dart` (new) — the failure screen names what failed, a reporter that throws does not eat the screen, and the builder receives the real error.

**Sync law.** `docs/2-core/error-reporting.md` gains the third answer next to the refusal section; `toolkit/skills/dartway-data-layer` teaches the type check; CHANGELOGs on all five packages; migration note `docs/migrations/2026-09-09-app-error-screen-builder.md` for the one breaking rename. **Versions:** master and `stable` were level, so this moves `dartway_flutter` to `0.9.0` and the four `dartway_serverpod_core_*` to `0.13.0` in lockstep — carets in `example/`, `template/` and the seven sibling packages raised with them, lockfiles refreshed, `tool/self_check.dart` green.

Nothing here recognises or repairs an older client: under a zero major the shape moves forward (root `CLAUDE.md`, "Zero major").

🤖 Generated with [Claude Code](https://claude.com/claude-code)