### PR TITLE
fix(core): a maybeModel that answered null hears about the row once it exists

### DIFF
--- a/docs/3-flutter/data-layer.md
+++ b/docs/3-flutter/data-layer.md
@@ -47,6 +47,13 @@ Pick by whether absence is a normal state of your screen. A profile screen opene
 because a missing profile is a bug you want reported. "Has this booking been reviewed yet?":
 `maybeModel`, because `null` is the answer, not a failure.
 
+**`null` is an answer about now, not a promise that the row will never exist.** A `maybeModel` that
+resolved to `null` takes the first row that later arrives and passes its filter (or has its `id`) —
+so "save, then read the provider" works for a model you just created, exactly as it does for a
+list. Until #242 it did not: an empty single-model read stopped listening the moment it answered,
+the screen stayed on a legitimate-looking empty state, and a `if (model == null) return;` behind it
+skipped its work with nothing anywhere saying so.
+
 One consequence catches people out. `model` is a **derived** provider — a throwing view over
 `maybeModel`, not its own fetch. So `ref.refresh(dw.repo.model<T>(...).future)` only recomputes the
 wrapper and returns the same cached value; to force a fresh fetch, refresh the provider that

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.13.0
 
+- **A `maybeModel` that answered `null` hears about the row once it exists.** Its update listener
+  returned on an empty state, so a single-model read that had once resolved to `null` was deaf to
+  every update after it: a feature saved a model, read the provider back and was told the row did
+  not exist. A list state has always taken new rows through its filter; the single-model state now
+  does the same, with the filter it already carries (an `id:` read folds into one). Projects that
+  threaded `saveModel`'s return value around or invalidated the provider to work around it can drop
+  that.
+
 - **A refused session restore no longer kills the app.** A stored key the server does not accept —
   expired, revoked, a deleted account, a different backend — came back as
   `Exception('Authentication required (getOne for UserProfile)')`, and `DwSessionService` had no

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/states/dw_single_model_state.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/lib/src/repository/states/dw_single_model_state.dart
@@ -83,7 +83,29 @@ class DwSingleModelState<Model extends SerializableModel>
 
   void _updatesListener(List<DwModelWrapper> wrappedModelUpdates) async {
     return await future.then((currentState) async {
-      if (currentState == null) return;
+      if (currentState == null) {
+        // An empty answer is an answer about *now*, not a promise that the
+        // row will never exist. This used to return here, so a state that had
+        // once resolved to null was deaf to every update after it: a feature
+        // saved the model, read the provider back and was told the row did
+        // not exist — a legitimate-looking empty screen, and a
+        // `if (model == null) return;` that quietly skipped the work behind
+        // it. A list state has always taken new rows through the same filter;
+        // this is the single-model half of that promise.
+        final arrived = wrappedModelUpdates.firstWhereOrNull(
+          (e) =>
+              !e.isDeleted &&
+              config.backendFilter.filterUpdate(e.jsonSerialization),
+        );
+        if (arrived != null) {
+          debugPrint(
+            "Filling empty singleState ${DwRepository.typeName<Model>()} "
+            "with id ${arrived.modelId}",
+          );
+          state = AsyncValue.data(arrived.model as Model);
+        }
+        return;
+      }
 
       final currentId = (currentState as dynamic).id;
       final match = wrappedModelUpdates.firstWhereOrNull(

--- a/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_single_model_state_test.dart
+++ b/packages/dartway_serverpod_core/dartway_serverpod_core_flutter/test/dw_single_model_state_test.dart
@@ -1,0 +1,175 @@
+import 'package:dartway_serverpod_core_flutter/dartway_serverpod_core_flutter.dart';
+import 'package:dartway_serverpod_core_flutter/src/repository/dw_repository.dart';
+import 'package:dartway_serverpod_core_flutter/testing.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A single-model read that answered "no such row" has to hear about the row
+/// once it exists. It used to stop listening the moment it resolved to null:
+/// a feature saved a model, read the provider back and was told the row did
+/// not exist, with nothing anywhere saying so (#242).
+void main() {
+  late DwRecordingServerTransport transport;
+
+  setUpAll(() {
+    // A manager that can read the model back, not only name it: updates reach
+    // a live state the way the wire delivers them — through
+    // `DwModelWrapper.fromJson`, which is what carries a `modelId`.
+    transport = DwRecordingServerTransport(
+      serializationManager: _OwnedProtocol(),
+    );
+    DwCore<ServerpodClientShared, _OwnedModel>(
+      config: const DwConfig(),
+      transport: transport,
+      dwAlerts: DwAlerts.init(logErrors: false, logFunction: (_) {}),
+      getUserId: (_) => null,
+    );
+    DwRepository.setupRepository(defaultModel: const _OwnedModel(id: 0));
+  });
+
+  setUp(() {
+    transport.reset();
+    // The server has no row yet — the state every case starts from.
+    transport.answerGetOne = (_) async =>
+        const DwApiResponse<DwModelWrapper>(isOk: true, value: null);
+  });
+
+  final ownerSeven = DwBackendFilter<int>.value(
+    type: DwBackendFilterType.equals,
+    fieldName: 'ownerId',
+    fieldValue: 7,
+  );
+
+  Future<
+    (
+      ProviderContainer,
+      AsyncNotifierProvider<DwSingleModelState<_OwnedModel>, _OwnedModel?>,
+    )
+  >
+  emptyRead({int? id, DwBackendFilter? filter}) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = const DwRepo().maybeModel<_OwnedModel>(
+      id: id,
+      filter: filter,
+    );
+    // Keep it alive the way a watching widget would.
+    container.listen(provider, (_, _) {});
+    expect(await container.read(provider.future), isNull);
+    return (container, provider);
+  }
+
+  Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+  test('a created row that passes the filter fills the empty read', () async {
+    final (container, provider) = await emptyRead(filter: ownerSeven);
+
+    DwRepository.updateListeningStates(
+      wrappedModelUpdates: [_arrived(const _OwnedModel(id: 1, ownerId: 7))],
+    );
+    await settle();
+
+    expect(
+      container.read(provider).value,
+      const _OwnedModel(id: 1, ownerId: 7),
+    );
+  });
+
+  test('a row that does not pass the filter leaves it empty', () async {
+    final (container, provider) = await emptyRead(filter: ownerSeven);
+
+    DwRepository.updateListeningStates(
+      wrappedModelUpdates: [_arrived(const _OwnedModel(id: 2, ownerId: 8))],
+    );
+    await settle();
+
+    expect(container.read(provider).value, isNull);
+  });
+
+  test('a read by id is filled by the row with that id', () async {
+    // `id:` folds into an `id equals` filter, so the one rule covers both.
+    final (container, provider) = await emptyRead(id: 42);
+
+    DwRepository.updateListeningStates(
+      wrappedModelUpdates: [
+        _arrived(const _OwnedModel(id: 41, ownerId: 7)),
+        _arrived(const _OwnedModel(id: 42, ownerId: 7)),
+      ],
+    );
+    await settle();
+
+    expect(container.read(provider).value?.id, 42);
+  });
+
+  test('a row already there is still replaced by its update', () async {
+    transport.answerGetOne = (_) async => DwApiResponse<DwModelWrapper>(
+      isOk: true,
+      value: DwModelWrapper.wrap(model: const _OwnedModel(id: 5, ownerId: 7)),
+    );
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final provider = const DwRepo().maybeModel<_OwnedModel>(filter: ownerSeven);
+    container.listen(provider, (_, _) {});
+    expect((await container.read(provider.future))?.id, 5);
+
+    DwRepository.updateListeningStates(
+      wrappedModelUpdates: [
+        _arrived(const _OwnedModel(id: 5, ownerId: 7, note: 'edited')),
+      ],
+    );
+    await settle();
+
+    expect(container.read(provider).value?.note, 'edited');
+  });
+}
+
+/// An update as the wire delivers it.
+DwModelWrapper _arrived(_OwnedModel model) => DwModelWrapper.fromJson({
+  'className': 'OwnedModel',
+  'data': model.toJson(),
+  'isDeleted': false,
+});
+
+class _OwnedProtocol extends SerializationManager {
+  @override
+  String? getClassNameForObject(Object? data) =>
+      data is _OwnedModel ? 'OwnedModel' : super.getClassNameForObject(data);
+
+  @override
+  dynamic deserializeByClassName(Map<String, dynamic> data) {
+    if (data['className'] == 'OwnedModel') {
+      final json = data['data'] as Map<String, dynamic>;
+      return _OwnedModel(
+        id: json['id'] as int,
+        ownerId: json['ownerId'] as int,
+        note: json['note'] as String?,
+      );
+    }
+    return super.deserializeByClassName(data);
+  }
+}
+
+class _OwnedModel implements SerializableModel {
+  const _OwnedModel({required this.id, this.ownerId = 0, this.note});
+
+  final int id;
+  final int ownerId;
+  final String? note;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'ownerId': ownerId,
+    if (note != null) 'note': note,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is _OwnedModel &&
+      other.id == id &&
+      other.ownerId == ownerId &&
+      other.note == note;
+
+  @override
+  int get hashCode => Object.hash(id, ownerId, note);
+}

--- a/toolkit/skills/dartway-data-layer/SKILL.md
+++ b/toolkit/skills/dartway-data-layer/SKILL.md
@@ -44,7 +44,7 @@ await dw.repo.saveModel(updatedCourse);                                      // 
 await dw.repo.deleteModel(post);
 ```
 
-**Reads are the `dw.repo.model/maybeModel/modelList` providers under the native `ref`; writes are the `dw.repo.saveModel/deleteModel` methods.** No `ref.watchModel` and no `DwRepository.` — the single data access point is `dw.repo`. `model` throws a `StateError` if the model is missing; `maybeModel` returns `null`. A forced fetch is `ref.refresh(dw.repo.maybeModel(...).future)` (the fetching provider). **Create and Update are one `saveModel`** (the CRUD law).
+**Reads are the `dw.repo.model/maybeModel/modelList` providers under the native `ref`; writes are the `dw.repo.saveModel/deleteModel` methods.** No `ref.watchModel` and no `DwRepository.` — the single data access point is `dw.repo`. `model` throws a `StateError` if the model is missing; `maybeModel` returns `null` — and a `maybeModel` that answered `null` picks up a row created afterwards that passes its filter, so save-then-read works for a new model without invalidating anything or threading the returned instance around by hand. A forced fetch is `ref.refresh(dw.repo.maybeModel(...).future)` (the fetching provider). **Create and Update are one `saveModel`** (the CRUD law).
 
 **What you hand to `saveModel` is a `copyWith`, not a rebuilt model.** `saveModel(SessionBooking(id: booking.id, …))` compiles today and silently resets tomorrow's field to its default — `default=` and nullable make those constructor arguments optional. See `dartway-clean-code` §1.10; `model_rebuild_by_constructor` (`dartway_lints`, warning) flags it in the editor.
 


### PR DESCRIPTION
Fixes #242.

**What happened.** A feature created a model and read it back the way the data layer prescribes:

```dart
await ref.read(dw.repo.maybeModel<T>(filter: owner).future); // null
await dw.repo.saveModel(T(...));                             // created on the server
await ref.read(dw.repo.maybeModel<T>(filter: owner).future); // still null
```

The row reached the database; the provider kept its `null`. Nothing announced it — a legitimate-looking empty screen, and an `if (model == null) return;` that quietly skipped the work behind it.

**Root — one line.** `DwSingleModelState._updatesListener` began with `if (currentState == null) return;`. It matched updates only by the id of a model it already held, so a state that had once answered "no such row" was deaf to every update after it.

**Fix.** A list state has always taken new rows through its filter (`backendFilter.filterUpdate`). The single-model state carries the same filter — an `id:` read folds into an `id equals` one in `DwSingleModelStateConfig` — and now uses it the same way: an empty state takes the first non-deleted update that passes. This is the promise `dartway-data-layer` already makes (reads are providers, writes are `saveModel`, no manual syncing), kept for one model and not only for lists.

**Not taken:** the documentation-only answer ("after creating, use what `saveModel` returns"). It would state the trap instead of removing it.

**Tests** — `dw_single_model_state_test.dart`: a created row passing the filter fills an empty read; one that does not leaves it empty; a read by `id` is filled by that id and not its neighbour; a row already held is still replaced by its update. Updates are delivered in wire form through `DwModelWrapper.fromJson`, because that is what carries a `modelId` — `DwModelWrapper.wrap` does not, and a fixture built with it silently tests a different path. **Run against the old listener, exactly the two filling cases fail.**

**Sync law.** `docs/3-flutter/data-layer.md` and `toolkit/skills/dartway-data-layer` now say it; CHANGELOG under the pending `0.13.0` (master is ahead of `stable`, so no version move). No migration note: nothing asks a project to change — a project that worked around this by threading the returned instance or invalidating the provider may simply drop that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)